### PR TITLE
Use helm in tillerless mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,1 @@
 CLOUD=gce
-
-export HELM_TLS_ENABLE=true
-export HELM_TLS_CA_CERT=$PWD/.helm/ca.pem
-export HELM_TLS_CERT=$PWD/.helm/cert.pem
-export HELM_TLS_KEY=$PWD/.helm/key.pem

--- a/bin/aliases
+++ b/bin/aliases
@@ -42,11 +42,7 @@ else
     unalias h &> /dev/null
     unalias hf &> /dev/null
     function helm() {
-      drun helm --tls \
-        --tls-ca-cert $HELM_TLS_CA_CERT \
-        --tls-cert $HELM_TLS_CERT \
-        --tls-key $HELM_TLS_KEY \
-        $@
+      drun helm tiller run helm $@
     }
     alias h="helm"
     function hf() {


### PR DESCRIPTION
We are already using `helmfile` in tillerless mode.
Let's use `helm` itself in the same mode.