### PR TITLE
task: confirm current-context before applying cluster changes

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -3,6 +3,12 @@ shopt -s expand_aliases
 . bin/utils.sh
 set -e
 
+read -p "Current kubectl context: $(kubectl config current-context), are you sure to apply changes (Y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    exit 1
+fi
+
 # install some stuff that we never want to end up as charts
 hft -f helmfile.tpl/helmfile-init.yaml | k apply -f -
 # not ready yet:


### PR DESCRIPTION
Ask users if the current-context is as expected, in order to prevent users to apply changes to the wrong cluster.