### PR TITLE
fix: downgrade keycloak replicas to one

### DIFF
--- a/values/keycloak/keycloak.gotmpl
+++ b/values/keycloak/keycloak.gotmpl
@@ -30,7 +30,7 @@ keycloak:
       cpu: 100m
       memory: 1Gi
     {{- end }}
-  replicas: 2
+  replicas: 1
 
 postgresql:
   postgresqlUsername: {{ $k | get "postgresql.postgresqlUsername" "keycloak" }}


### PR DESCRIPTION
The replica supposed to run the Keycloak in HA mode but does not work out of the box, thus needs to be downgraded to have stack fully operational.