### PR TITLE
fix for missing route

### DIFF
--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -150,7 +150,7 @@ alertmanager:
           - url: "http://prometheus-msteams.monitoring.svc.cluster.local:2000/high_priority_channel"
             send_resolved: true
       {{- end }}
-      {{- if not $v.otomi.isRedkubesMonitored }}
+      {{- if $v.otomi.isRedkubesMonitored }}
       - name: critical-redkubes
         # sending criticals also to redkubes to be aware of customer issues
         slack_configs:


### PR DESCRIPTION
This PR fixes an issue with routes in Alertmanager, the route get configured when {{- if $v.otomi.isRedkubesMonitored }} the receiver wasn't.
