### PR TITLE
refactor: change otomi-stack-tasks docker image for jobs charts

### DIFF
--- a/values/jobs/certs-aws.gotmpl
+++ b/values/jobs/certs-aws.gotmpl
@@ -2,7 +2,7 @@
 {{- $c := $v.charts -}}
 {{- $cm := $c | get "cert-manager" -}}
 {{- $vars := tpl (readFile "../../helmfile.d/snippets/domains.gotmpl") $v | fromYaml -}}
-{{- $otomiTasksImage := printf "eu.gcr.io/otomi-cloud/otomi-stack-tasks:%s" "v0.1.0" -}}
+{{- $otomiTasksImage :=  "eu.gcr.io/otomi-cloud/otomi-stack-tasks:v0.1.0" -}}
 
 tasks:
   certs-aws:

--- a/values/jobs/harbor.gotmpl
+++ b/values/jobs/harbor.gotmpl
@@ -8,7 +8,7 @@
 {{- $realm := $k | get "realm" "master" }}
 {{- $keycloakIssuer := printf "https://keycloak.%s/realms/%s" $v.cluster.domain $realm }}
 {{- $hasHarbor := $h | get "enabled" false -}}
-{{- $otomiTasksImage := printf "eu.gcr.io/otomi-cloud/otomi-stack-tasks:%s" "v0.1.0" -}}
+{{- $otomiTasksImage :=  "eu.gcr.io/otomi-cloud/otomi-stack-tasks:v0.1.0" -}}
 
 {{- $teams := keys $v.teamConfig.teams }}
 {{- $teamNames := list -}}

--- a/values/jobs/keycloak.gotmpl
+++ b/values/jobs/keycloak.gotmpl
@@ -12,7 +12,7 @@
 {{- $cm := $c | get "cert-manager" -}}
 {{- $k := $c | get "keycloak" dict }}
 {{- $idp := $v.oidc.idp }}
-{{- $otomiTasksImage := printf "eu.gcr.io/otomi-cloud/otomi-stack-tasks:%s" "v0.1.0" -}}
+{{- $otomiTasksImage :=  "eu.gcr.io/otomi-cloud/otomi-stack-tasks:v0.1.0" -}}
 {{- $skipVerify := eq ($cm | get "stage") "staging" }}
 tasks:
   keycloak:


### PR DESCRIPTION
I refactored the jobs charts in the stack to use the new otomi-stack-tasks docker image. 
Please take a look if anything seems to be strange.
This needs to be merged after building the new tasks image and the values for each environment have been amended with new structure.