### PR TITLE
improvement: exit on unset variables

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-. bin/common.sh
-set -e
+set -eu
 
 ENV_DIR=${ENV_DIR:-./env}
+. bin/common.sh
+
 . $ENV_DIR/.secrets
 
 skip_demo_files=$1
@@ -38,8 +39,8 @@ if [ "$skip_demo_files" != "1" ]; then
   cp -r $PWD/.demo/env $ENV_DIR/env
 fi
 cp -f $PWD/bin/hooks/pre-commit $ENV_DIR/.git/hooks/
-[ "$GCLOUD_SERVICE_KEY" != "" ] && echo $GCLOUD_SERVICE_KEY | jq '.' >$ENV_DIR/gcp-key.json
-if [ "$OTOMI_PULLSECRET" != "" ]; then
+[ "${GCLOUD_SERVICE_KEY-}" != "" ] && echo $GCLOUD_SERVICE_KEY | jq '.' >$ENV_DIR/gcp-key.json
+if [ "${OTOMI_PULLSECRET-}" != "" ]; then
   echo "Copying Otomi Console setup"
   cp -rf $PWD/docker-compose $ENV_DIR/
   cp -f $PWD/core.yaml $ENV_DIR/


### PR DESCRIPTION
the common.sh requires that ENV_DIR is set before

The `set -u`: Treat unset variables and parameters other than the special parameters ‘@’ or ‘*’ as an error when performing parameter expansion. 

The `"${VARNAME-}"` is explicit way of accessing variables that might be unset, so set -u` does not take effect on them. 