### PR TITLE
feat: update json schema

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1,5 +1,5 @@
 ---
-'$schema': 'http://json-schema.org/draft-07/schema'
+'$schema': 'http://json-schema.org/draft/2019-09/schema'
 type: object
 additionalProperties: false
 definitions:


### PR DESCRIPTION
Draft-07 is expired. [Here](http://json-schema.org/draft/2019-09/release-notes.html) are the release notes for 2019-09.

**Incompatible Changes**

1. By default, format is no longer an assertion. This has been done because the inconsistent implementation of format as an assertion has been an endless source of surprising problems for schema authors. The default behavior will now be predictable, if not ideal. There are several ways to turn on assertion functionality, as explained below. However, we recommend doing semantic validation in the application layer.
2. Plain name fragments are no longer defined with $id, but instead with the new keyword $anchor (which has a different syntax).
3. $id cannot contain a fragment anymore (except possibly an empty fragment, although that is discouraged).
4. In cases where multiple URIs could be used for the same schema, some are now discouraged. These are believed to have rarely been used, as the behavior involved was fairly confusing and not well explained until the updated version of draft-07 (draft-handrews-json-schema-01). If this doesn’t mean much to you, you are probably safe.

**Semi-incompatible Changes**

The old syntax for these keywords is not an error (and the default meta-schema still validates them), so implementations can therefore offer a compatibility mode. However, migrating to the new keywords is straightforward and should be preferred.

5. definitions is now $defs
6. dependencies has been split into dependentSchemas and dependentRequired

**Compatibility**
Compatible: 1, 2, 3, 4, 6
Incompatible: 5 (_but there is backward compatibility_)
