### PR TITLE
fix: modify check empty parameters

### DIFF
--- a/bin/otomi
+++ b/bin/otomi
@@ -306,7 +306,7 @@ function execute() {
       check_sops_file
       check_kube_context=0
       evaluate_secrets
-      if [ -n "$@" ]; then
+      if [ "$@" != '' ]; then
         for f in $@; do
           echo "Encrypting $f"
           drun helm secrets enc ./env/$f >/dev/null
@@ -349,7 +349,7 @@ function execute() {
       drun bin/test.sh
       ;;
     validate-templates)
-      if [ -n "$@" ]; then
+      if [ "$@" != '' ]; then
         validate_cluster_env
       fi
       check_kube_context=0

--- a/bin/otomi
+++ b/bin/otomi
@@ -283,7 +283,7 @@ function execute() {
       check_sops_file
       check_kube_context=0
       evaluate_secrets
-      if [ -n "$@" ]; then
+      if [ "$@" != '' ]; then
         for f in $@; do
           echo "Decrypting $f"
           drun helm secrets dec ./env/$f >/dev/null


### PR DESCRIPTION
Relating to #228. This modification will execute `otomi decrypt` without parameters as `drun bin/crypt.sh decrypt` which will decrypt all files in `otomi-values`. 