### PR TITLE
Include `otomi bootstrap` in one of the Husky hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "format": "prettier --check \"**/*.{json,md,yml,yaml}\"",
     "format:fix": "prettier --write \"**/*.{json,md,yml,yaml}\"",
     "husky:lint-staged": "lint-staged",
-    "husky:pre-commit": "lint-staged && npm run spellcheck",
+    "husky:pre-commit": "lint-staged && npm run spellcheck && exec < /dev/tty && bin/otomi bootstrap",
     "lint": "bin/otomi validate-templates",
     "lint:all": "run-p spellcheck lint",
     "release": "standard-version",


### PR DESCRIPTION
I came up with this idea, it saves me some time when I have this process:
1. Edit values-schema.yaml
2. Run `otomi bootstrap`
3. Go through an otomi-values YAML file to check if the new meta schema works as intended.
4. Go back to 1.

More ideally, 
- `otomi bootstrap` wouldn't take so long (all I actually want is the new schema applied to one of the files in `otomi-values`). I think an easy solution would be to just use the root `values-schema.yaml` for validation. If I look at the `generate_loose_schema` function in `bin/bootstrap.sh`, all it does is remove "required", if someone could help me figure out why that's necessary, that would be great. If it's really necessary, that function could also be pulled into a separate file, if I'm not mistaken `bootstrap` is only supposed to run once when someone creates a new `otomi-values` repository?
- I've added it to pre-commit now, but it could be post-commit too. 