### PR TITLE
Schema versioning proposal

### DIFF
--- a/schemas/values/0.11/values-schema.yaml
+++ b/schemas/values/0.11/values-schema.yaml
@@ -1,5 +1,6 @@
 ---
 $schema: 'http://json-schema.org/draft-07/schema'
+$id: '11'
 additionalProperties: false
 definitions:
   alerts:


### PR DESCRIPTION
Related to #259. 

Please say if this is simplistic, lacks features or for any other reason.

To me it seems obvious to use the diff between versions to migrate values. 

Furthermore, ["the "$id" keyword identifies a schema resource with its canonical URI." ](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.2.2) So there's already some room to identify the schema inside and outside of itself.