### PR TITLE
Requirements setting #164: Kiali Operator

### DIFF
--- a/charts/istio-operator/Chart.yaml
+++ b/charts/istio-operator/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 name: istio-operator
-version: 1.5
+version: 1.9-dev
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:
   - istio
   - operator
 sources:
-  - http://github.com/istio/istio/operator
+  - https://github.com/istio/istio/operator
 engine: gotpl
 icon: https://istio.io/favicons/android-192x192.png

--- a/charts/istio-operator/values.yaml
+++ b/charts/istio-operator/values.yaml
@@ -1,4 +1,4 @@
 hub: gcr.io/istio-testing
-tag: 1.5-dev
+tag: 1.9-dev
 operatorNamespace: istio-operator
 istioNamespace: istio-system

--- a/charts/kiali-operator/Chart.yaml
+++ b/charts/kiali-operator/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kiali-operator
+description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+version: 0.0.0
+appVersion: 0.0.0
+home: https://github.com/kiali/kiali-operator
+maintainers:
+- name: Kiali
+  email: kiali-users@googlegroups.com
+  url: https://kiali.io
+keywords:
+- istio
+- kiali
+- operator
+sources:
+- https://github.com/kiali/kiali
+- https://github.com/kiali/kiali-ui
+- https://github.com/kiali/kiali-operator
+- https://github.com/kiali/helm-charts
+icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png

--- a/charts/kiali-operator/crds/crds.yaml
+++ b/charts/kiali-operator/crds/crds.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+...
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+...

--- a/charts/kiali-operator/templates/NOTES.txt
+++ b/charts/kiali-operator/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Welcome to Kiali! For more details on Kiali, see: https://kiali.io
+
+The Kiali Operator [{{ .Chart.AppVersion }}] has been installed in namespace [{{ .Release.Namespace }}]. It will be ready soon.
+
+{{- if .Values.cr.create }}
+  {{- if or (and (not .Values.watchNamespace) (not .Values.cr.namespace)) (and (.Values.watchNamespace) (eq .Values.watchNamespace .Release.Namespace)) (and (.Values.cr.namespace) (eq .Values.cr.namespace .Release.Namespace)) }}
+You have elected to install a Kiali CR in the same namespace as the operator [{{ .Release.Namespace }}]. You should be able to access Kiali soon.
+
+================================
+PLEASE READ THIS WARNING NOTICE:
+Because the Kiali CR lives in the same namespace as the operator, DO NOT uninstall the operator or delete the operator namespace without first removing the Kiali CR. If you do not follow this advice then the Kiali Operator deletion will hang indefinitely until you remove the finalizer from the Kiali CR, and then you may find your Kubernetes environment still has Kiali Server remnants left behind.
+================================
+  {{- else if .Values.watchNamespace }}
+You have elected to install a Kiali CR in the operator watch namespace [{{ .Values.watchNamespace }}]. You should be able to access Kiali soon.
+  {{- else if .Values.cr.namespace }}
+You have elected to install a Kiali CR in the namespace [{{ .Values.cr.namespace }}]. You should be able to access Kiali soon.
+  {{- else }}
+You have elected to install a Kiali CR. You should be able to access Kiali soon.
+  {{- end }}
+{{- else }}
+  {{- if (not .Values.watchNamespace) }}
+You have elected not to install a Kiali CR. You must first install a Kiali CR before you can access Kiali. The operator is watching all namespaces, so you can create the Kiali CR anywhere.
+  {{- else }}
+You have elected not to install a Kiali CR. You must first install a Kiali CR in the operator watch namespace [{{ .Values.watchNamespace }}] before you can access Kiali.
+  {{- end }}
+{{- end }}
+
+If you ever want to uninstall the Kiali Operator, remember to delete the Kiali CR first before uninstalling the operator to give the operator a chance to uninstall and remove all the Kiali Server resources.
+
+(Helm: Chart=[{{ .Chart.Name }}], Release=[{{ .Release.Name }}], Version=[{{ .Chart.Version }}])

--- a/charts/kiali-operator/templates/_helpers.tpl
+++ b/charts/kiali-operator/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kiali-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kiali-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kiali-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kiali-operator.labels" -}}
+helm.sh/chart: {{ include "kiali-operator.chart" . }}
+app: {{ include "kiali-operator.name" . }}
+{{ include "kiali-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: "kiali-operator"
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kiali-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kiali-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/kiali-operator/templates/clusterrole.yaml
+++ b/charts/kiali-operator/templates/clusterrole.yaml
@@ -1,0 +1,286 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - persistentvolumeclaims
+  - pods
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups: [""]
+  resourceNames:
+  - kiali-signing-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups: ["apps"]
+  resourceNames:
+  - kiali-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups: ["kiali.io"]
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  {{- if or (and (.Values.cr.create) (has "**" .Values.cr.spec.deployment.accessible_namespaces)) (.Values.clusterRoleCreator) }}
+  - clusterrolebindings
+  - clusterroles
+  {{- end }}
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["apiextensions.k8s.io"]
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["oauth.openshift.io"]
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["config.openshift.io"]
+  resources:
+  - clusteroperators
+  verbs:
+  - list
+  - watch
+- apiGroups: ["config.openshift.io"]
+  resourceNames:
+  - kube-apiserver
+  resources:
+  - clusteroperators
+  verbs:
+  - get
+- apiGroups: ["console.openshift.io"]
+  resources:
+  - consolelinks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - pods/proxy
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - create
+  - delete
+  - patch
+  {{- end }}
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - patch
+  {{- end }}
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - create
+  - delete
+  - patch
+  {{- end }}
+...

--- a/charts/kiali-operator/templates/clusterrolebinding.yaml
+++ b/charts/kiali-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kiali-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+...

--- a/charts/kiali-operator/templates/deployment.yaml
+++ b/charts/kiali-operator/templates/deployment.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+    {{- include "kiali-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      name: {{ include "kiali-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      labels:
+        # required for the operator SDK metric service selector
+        name: {{ include "kiali-operator.fullname" . }}
+      {{- include "kiali-operator.labels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: {{ .Values.metrics.enabled | quote }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    {{- end }}
+    spec:
+      serviceAccountName: {{ include "kiali-operator.fullname" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: operator
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+        args:
+        - "--zap-level=info"
+        volumeMounts:
+        - mountPath: /tmp/ansible-operator/runner
+          name: runner
+        env:
+        - name: WATCH_NAMESPACE
+          value: {{ .Values.watchNamespace | default "\"\""  }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERATOR_NAME
+          value: {{ include "kiali-operator.fullname" . }}
+        - name: ANSIBLE_DEBUG_LOGS
+          value: {{ .Values.debug.enabled | quote }}
+        - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+          value: {{ .Values.debug.verbosity | quote }}
+        - name: ANSIBLE_CONFIG
+        {{- if .Values.debug.enableProfiler }}
+          value: "/opt/ansible/ansible-profiler.cfg"
+        {{- else }}
+          value: "/etc/ansible/ansible.cfg"
+        {{- end }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: http-metrics
+          containerPort: 8383
+        - name: cr-metrics
+          containerPort: 8686
+        {{- if .Values.resources }}
+        resources:
+        {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: runner
+        emptyDir: {}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 8 }}
+...

--- a/charts/kiali-operator/templates/kiali-cr.yaml
+++ b/charts/kiali-operator/templates/kiali-cr.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.cr.create }}
+---
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  {{- if .Values.watchNamespace }}
+  namespace: {{ .Values.watchNamespace }}
+  {{- else if .Values.cr.namespace }}
+  namespace: {{ .Values.cr.namespace }}
+  {{- end }}
+  name: {{ .Values.cr.name }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+annotations:
+  ansible.operator-sdk/verbosity: {{ .Values.debug.verbosity | quote }}
+spec:
+  {{- toYaml .Values.cr.spec | nindent 2 }}
+...
+{{ end }}

--- a/charts/kiali-operator/templates/serviceaccount.yaml
+++ b/charts/kiali-operator/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kiali-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "kiali-operator.labels" . | nindent 4 }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+...

--- a/charts/kiali-operator/values.yaml
+++ b/charts/kiali-operator/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repo: ${HELM_IMAGE_REPO}
+  tag: ${HELM_IMAGE_TAG}
+  pullPolicy: Always
+  pullSecrets: []
+
+# Deployment options for the operator pod.
+nodeSelector: {}
+podAnnotations: {}
+env: []
+tolerations: []
+resources: {}
+affinity: {}
+replicaCount: 1
+priorityClassName: ""
+
+# metrics.enabled: set to true if you want Prometheus to collect metrics from the operator
+metrics:
+  enabled: true
+
+# debug.enabled: when true the full ansible logs are dumped after each reconciliation run
+# debug.verbosity: defines the amount of details the operator will log (higher numbers are more noisy)
+# debug.enableProfiler: when true (regardless of debug.enabled), timings for the most expensive tasks will be logged after each reconciliation loop
+debug:
+  enabled: true
+  verbosity: "1"
+  enableProfiler: false
+
+# Defines where the operator will look for Kial CR resources. "" means "all namespaces".
+watchNamespace: ""
+
+# Set to true if you want the operator to be able to create cluster roles. This is necessary
+# if you want to support Kiali CRs with spec.deployment.accessible_namespaces of '**'.
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+clusterRoleCreator: true
+
+# Set to true if you want to allow the operator to only be able to install Kiali in view-only-mode.
+# The purpose for this setting is to allow you to restrict the permissions given to the operator itself.
+onlyViewOnlyMode: false
+
+# For what a Kiali CR spec can look like, see:
+# https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
+cr:
+  create: false
+  name: kiali
+  # If you elect to create a Kiali CR (--set cr.create=true)
+  # and the operator is watching all namespaces (--set watchNamespace="")
+  # then this is the namespace where the CR will be created (the default will be the operator namespace).
+  namespace: ""
+
+  spec:
+    deployment:
+      accessible_namespaces:
+      - '**'

--- a/charts/kiali-operator/values.yaml
+++ b/charts/kiali-operator/values.yaml
@@ -55,3 +55,762 @@ cr:
     deployment:
       accessible_namespaces:
       - '**'
+      ###################################################################
+      # kiali_cr.yaml
+      #
+      # This is a fully documented Kiali custom resource yaml file.
+      # It can be used to tell the Kiali Operator to install Kiali.
+      #
+      # This is actually an empty Kiali CR, however, it provides
+      # documentation on all available settings.
+      # In each documented section, you will see a "---" marker;
+      # below that marker you will see the names of the settings along
+      # with their default values. If the setting is not defined by
+      # default, its name will be prefixed with "#".
+      ###################################################################
+
+      ##########
+      #  ---
+      #  additional_display_details:
+      #  - title: "API Documentation"
+      #    annotation: "kiali.io/api-spec"
+      #    icon_annotation: "kiali.io/api-type"
+      #
+      # A list of additional details that Kiali will look for in annotations and display, for every workload and service, in their respective details pages.
+      # It can typically be used to inject some CI metadata or documentation links into Kiali views.
+      # Each item in the list is an object with "annotation", "title" and "icon_annotation" fields to indicate which annotation Kiali needs to look for, and how it should be displayed.
+      # "icon_annotation" is optional and would display an icon next to the text.
+      # At the moment, the value of the icon annotation can only be one of "rest", "grpc" or "graphql"; otherwise, it is ignored.
+      # By default, these settings recognize API Documentation links via annotation "kiali.io/api-spec" and icon-annotation "kiali.io/api-type".
+      # For example, it would make Kiali recognize these annotations in a service or a workload definition (Deployment, StatefulSet, etc.) to display the appropriate link and text:
+      #    annotations:
+      #      kiali.io/api-spec: http://link/to/my/doc
+      #      kiali.io/api-type: rest
+      # Should you change this setting for your own custom annotations, keep in mind that it would override the current default.
+      # So you would have to copy the "API Documentation" setting as shown above if you want to preserve these links.
+
+      ##########
+      # Tag used to identify a particular instance/installation of the Kiali server.
+      #  ---
+      #  installation_tag: ""
+
+      ##########
+      # The namespaces where individual Istio components are installed.
+      # If left empty, it is assumed all Istio components are installed in the
+      # defined istio_namespace. If a component is not listed here, it is
+      # assumed that component is installed in istio_namespace. For example:
+      #  istio_component_namespaces:
+      #    prometheus: prom-ns
+      # means Prometheus is installed in the namespace "prom-ns" but all other
+      # Istio components are installed in the namespace defined in istio_namespace.
+      #  ---
+      #  istio_component_namespaces: {}
+
+      ##########
+      # The namespace where Istio is installed. If left empty, it is assumed to be the
+      # same namespace as where Kiali is installed (i.e. deployment.namespace).
+      # Note that if you install some Istio components in other namespaces, specify
+      # that component's namespace in istio_component_namespaces.
+      #  ---
+      #  istio_namespace: ""
+
+      ##########
+      # The version of the Ansible playbook to execute in order to install that version of Kiali.
+      # If not specified, a default version of Kiali will be installed which will be the most recent release of Kiali.
+      # The currently allowed values for this setting are: "default", "v1.0", "v1.12", "v1.24"
+      # Refer to this file to see where these values are defined in the master branch:
+      # https://github.com/kiali/kiali-operator/tree/master/playbooks/default-supported-images.yml
+      #
+      # This version setting affects the defaults of the deployment.image_name and
+      # deployment.image_version settings. See the comments for those settings
+      # below for additional details. But in short, this version setting will
+      # dictate which version of the Kiali image will be deployed by default.
+      # Note that if you explicitly set deployment.image_name and/or
+      # deployment.image_version you are responsible for ensuring those settings
+      # are compatible with this setting (i.e. the Kiali image must be compatible
+      # with the rest of the configuration and resources the operator will install).
+      #
+      # See the Kiali documentation to determine which of these versions support
+      # the version of Istio you are installing Kiali with.
+      #
+      #  ---
+      #  version: "default"
+
+      ##########
+      #  ---
+      #  api:
+      #
+      # Allows for controlling what namespaces/projects are returned by Kiali.
+      #
+      # 'exclude' is optional and takes a list of namespaces to be excluded from the list
+      # of namespaces provided by the API and UI. Regex is supported. This does not affect
+      # explicit namespace access.
+      #
+      # 'label_selector' is optional and takes a string value of a Kubernetes label selector
+      # (e.g. "myLabel=myValue") which is used when fetching the list of available namespaces.
+      # This does not affect explicit namespace access.
+      # Note that if you do not set this but deployment.accessible_namespaces does not have the
+      # special "all namespaces" value of "**" then this label_selector will be set
+      # to a default value of "kiali.io/member-of=<deployment.namespace>" where
+      # <deployment.namespace> is the namespace where Kiali is to be installed.
+      # If deployment.accessible_namespaces does not have the special value of "**"
+      # then the Kiali operator will add a new label to all accessible namespaces - that new
+      # label will be this label_selector.
+      #
+      #    ---
+      #    namespaces:
+      #      exclude:
+      #      - "istio-operator"
+      #      - "kube.*"
+      #      - "openshift.*"
+      #      - "ibm.*"
+      #      - "kiali-operator"
+      #      #label_selector:
+
+      ##########
+      #  ---
+      #  auth:
+      #
+      # Determines what authentication strategy to use when users log into Kiali.
+      # Options are "anonymous", "token", "openshift", "openid".
+      # Choose "anonymous" to allow full access to Kiali without requiring any credentials.
+      # Choose "token" to allow access to Kiali using service account tokens, which controls
+      #  access based on RBAC roles assigned to the service account.
+      # Choose "openshift" to use the OpenShift OAuth login which controls access based on
+      #  the individual's  RBAC roles in OpenShift. Not valid for non-OpenShift environments.
+      # Choose "openid" to enable OpenID connect based authentication. Your cluster is required to
+      #  be configured to accept the tokens issued by your IdP. There are additional required
+      #  configurations for this strategy. See below for the additional OpenID configuration section.
+      # When empty, its value will default to "openshift" on OpenShift and "token" on Kubernetes.
+      #    ---
+      #    strategy: ""
+      #
+      # To learn how to configure the OpenId authentication strategy, read the documentation
+      # at the website on https://kiali.io/documentation/latest/configuration/authentication/openid/
+      #
+      #    ---
+      #    openid:
+      #      api_proxy: ""
+      #      api_proxy_ca_data: ""
+      #      authentication_timeout: 300
+      #      authorization_endpoint: ""
+      #      client_id: ""
+      #      disable_rbac: false
+      #      http_proxy: ""
+      #      https_proxy: ""
+      #      insecure_skip_verify_tls: false
+      #      issuer_uri: ""
+      #      scopes: ["openid", "profile", "email"]
+      #      username_claim: "sub"
+      #
+      # The Route resource name and OAuthClient resource name will have this value as its prefix.
+      # This value normally should never change. The installer will ensure this value is set correctly.
+      #    ---
+      #    openshift:
+      #      client_id_prefix: kiali
+
+      ##########
+      #  ---
+      #  deployment:
+      #
+      # A list of namespaces Kiali is to be given access to.
+      # These namespaces have service mesh components that are to be observed by Kiali.
+      # You can provide names using regex expressions matched against all namespaces the operator can see.
+      # The default makes all namespaces accessible except for some internal namespaces that typically should be ignored.
+      # NOTE! If this has an entry with the special value of "**" (two asterisks), that will denote you want
+      # Kiali to be given access to all namespaces via a single cluster role (if using this special value of "**",
+      # you are required to have already granted the operator permissions to create cluster roles and cluster role bindings).
+      #    ---
+      #    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+      #
+      # Additional custom yaml to add to the service definition. This is used mainly to customize the service type.
+      # For example, if the deployment.service_type is set to "LoadBalancer" and you want to set the loadBalancerIP,
+      # you can do so here with: additional_service_yaml: { "loadBalancerIP": "78.11.24.19" }.
+      # Another example would be if the deployment.service_type is set to "ExternalName" you will need to configure
+      # the name via: additional_service_yaml: { "externalName": "my.kiali.example.com" }.
+      # A final example would be if external IPs need to be set: additional_service_yaml: { "externalIPs": ["80.11.12.10"] }
+      #    ---
+      #    #additional_service_yaml:
+      #
+      # Affinity definitions that are to be used to define the nodes where the Kiali pod should be contrained.
+      # See the Kubernetes documentation on Assigning Pods to Nodes for the proper syntax for these three
+      # different affinity types.
+      #    ---
+      #    affinity:
+      #      node: {}
+      #      pod: {}
+      #      pod_anti: {}
+      #
+      # Names of the out-of-box custom monitoring dashboards that are to be installed.
+      # The custom monitoring dashboards are defined in yaml files located within the operator.
+      # Consult the operator templates for the custom monitoring dashboard yaml files available.
+      # For example, see this for the current list of yaml files available:
+      # https://github.com/kiali/kiali-operator/tree/master/roles/default/kiali-deploy/templates/dashboards
+      # These settings will determine the additional metric graphs that you will see within the Kiali UI.
+      # You can specify an includes and excludes list, the excludes list takes precedence.
+      # Each list can have fileglob wildcard characters '*' and '?' for file matching.
+      #    ---
+      #    custom_dashboards:
+      #      excludes: ['']
+      #      includes: ['*']
+      #
+      # Determines which Kiali image to download and install.
+      # If you set this to a specific name (i.e. you do not leave it as the default empty string),
+      # you must make sure that image is supported by the operator.
+      # If empty, the operator will use a known supported image name based on which "version" was defined.
+      # Note that, as a security measure, a cluster admin may have configured the Kiali operator to
+      # ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
+      # a single, specific Kiali version, thus this setting may have no effect depending on how the
+      # operator itself was configured.
+      #    ---
+      #    image_name: ""
+      #
+      # The Kubernetes pull policy for the Kiali deployment.
+      # This is overridden to be "Always" if image_version is set to "latest".
+      #    ---
+      #    image_pull_policy: "IfNotPresent"
+      #
+      # The names of the secrets to be used when container images are to be pulled.
+      #    ---
+      #    image_pull_secrets: []
+      #
+      # Determines which version of Kiali to install.
+      # Choose "lastrelease" to use the last Kiali release.
+      # Choose "latest" to use the latest image (which may or may not be a released version of Kiali).
+      # Choose "operator_version" to use the image whose version is the same as the operator version.
+      # Otherwise, you can set this to any valid Kiali version (such as "v1.0").
+      # Note that if this is set to "latest" then the image_pull_policy will be "Always".
+      # If you set this to a specific version (i.e. you do not leave it as the default empty string),
+      # you must make sure that image is supported by the operator.
+      # If empty, the operator will use a known supported image version based on which "version" was defined.
+      # Note that, as a security measure, a cluster admin may have configured the Kiali operator to
+      # ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
+      # a single, specific Kiali version, thus this setting may have no effect depending on how the
+      # operator itself was configured.
+      #    ---
+      #    image_version: ""
+      #
+      # Determines if the Kiali endpoint should be exposed externally.
+      # If true, an Ingress will be created if on Kubernetes or a Route if on OpenShift.
+      #    ---
+      #    ingress_enabled: true
+      #
+      # Determines the logger configuration.
+      # log_format supports text and json.
+      # log_level supports trace, debug, info, warn, error, fatal.
+      # time_field_format supports a golang time format (https://golang.org/pkg/time/)
+      # sampler_rate defines a basic log sampler setting as an integer. With this setting every sampler_rate-th 
+      #    message will be logged. By default, every message is logged.
+      #    ---
+      #    logger:
+      #      log_level: info
+      #      log_format: text
+      #      sampler_rate: "1"
+      #      time_field_format: "2006-01-02T15:04:05Z07:00"
+      #
+      # The namespace into which Kiali is to be installed. If this is empty or not defined,
+      # the default will be the namespace where the Kiali CR is located.
+      #    ---
+      #    namespace: ""
+      #
+      # A set of node labels that dictate onto which node the Kiali pod will be deployed.
+      #    ---
+      #    node_selector: {}
+      #
+      # Because an ingress into a cluster can vary wildly in its desired configuration,
+      # this setting provides a way to override complete portions of the ingress resource
+      # configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
+      # to ensure this override YAML configuration is valid and supports the cluster environment
+      # since the operator will blindly copy this custom configuration into the resource it
+      # creates.
+      # This setting is not used if deployment.ingress_enabled is set to 'false'.
+      # Note that only 'metadata.annotations' and 'spec' is valid and only they will
+      # be used to override those same sections in the created resource. You can define
+      # either one or both.
+      # Example:
+      #   override_ingress_yaml:
+      #     metadata:
+      #       annotations:
+      #         nginx.ingress.kubernetes.io/secure-backends: "true"
+      #         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      #     spec:
+      #       rules:
+      #       - http:
+      #           paths:
+      #           - path: /kiali
+      #             backend:
+      #               serviceName: kiali
+      #               servicePort: 20001
+      #    ---
+      #    #override_ingress_yaml:
+      #
+      # Custom annotations to be created on the Kiali pod.
+      #    ---
+      #    pod_annotations: {}
+      #
+      # Custom labels to be created on the Kiali pod.
+      #    ---
+      #    pod_labels: {}
+      #
+      # The priorityClassName used to assign the priority of the Kiali pod.
+      #    ---
+      #    priority_class_name: ""
+      #
+      # The replica count for the Kiail deployment.
+      #    ---
+      #    replicas: 1
+      #
+      # Defines compute resources that are to be given to the Kiali pod's container.
+      # The value is a dict as defined by Kubernetes. See the Kubernetes documentation
+      # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
+      #    ---
+      #    resources: {}
+      #
+      # The name of a secret used by the Kiali. Reserved for future use - not currently used.
+      #    ---
+      #    secret_name: "kiali"
+      #
+      # Custom annotations to be created on the Kiali Service resource.
+      #    ---
+      #    service_annotations: {}
+      #
+      # The Kiali service type. Kubernetes determines what values are valid.
+      # Common values are "NodePort", "ClusterIP", and "LoadBalancer".
+      #    ---
+      #    #service_type:
+      #
+      # A list of tolerations which declare which node taints Kiali can tolerate.
+      # See the Kubernetes documentation on Taints and Tolerations for more details.
+      #    ---
+      #    tolerations: []
+      #
+      # DEPRECATED - use the logger.log_level setting.
+      # Determines which priority levels of log messages Kiali will output.
+      # Typical values are "3" for INFO and higher priority, "4" for DEBUG and higher priority.
+      #    ---
+      #    verbose_mode: "3"
+      #
+      # Kiali resources will be assigned a "version" label when they are deployed.
+      # This determines what value those "version" labels will have.
+      # When empty, its default will be determined as follows:
+      #   If image_version is "latest", version_label will be fixed to "master".
+      #   If image_version is "lastrelease", version_label will be fixed to
+      #   the last Kiali release version string.
+      #   If the image_version is anything else, version_label will be that value, too.
+      #    ---
+      #    version_label: ""
+      #
+      # When true, Kiali will be in "view only" mode, allowing the user to view and retrieve
+      # management and monitoring data for the service mesh, but not allow the user to
+      # modify the service mesh.
+      #    ---
+      #    view_only_mode: false
+
+      ##########
+      #  ---
+      #  extensions:
+      #
+      # Kiali enabled integration with Iter8 project.
+      # If this extension is enabled, Kiali will communicate with Iter8 controller allowing to manage Experiments and review results.
+      # Additional documentation https://iter8.tools/
+      #    ---
+      #    iter_8:
+      #
+      # Flag to indicate if iter8 extension is enabled in Kiali
+      #      ---
+      #      enabled: false
+
+      ##########
+      #  ---
+      #  external_services:
+      #
+      # Note about sensitive values in the external_services "auth" sections:
+      # Some external services configured below support an "auth" sub-section in order to tell Kiali how it should
+      # authenticate with the external services. Credentials used to authenticate Kiali to those external services can
+      # be defined in the "auth.password" and "auth.token" values within the "auth" sub-section.
+      # Because these are sensitive values, you may not want to declare the actual credentials here in the Kiali CR. In
+      # this case, you may store the actual password or token string in a Kubernetes secret. If you do, you need to
+      # set the "auth.password" or "auth.token" to a value in the format "secret:<secretName>:<secretKey>" where
+      # "<secretName>" is the name of the secret object that Kiali can access, and <secretKey> is the name of the key
+      # within the named secret that contains the actual password or token string. For example, if Grafana requires a
+      # password, you can store that password in a secret named "myGrafanaCredentials" in a key named "myGrafanaPw".
+      # In this case, you would set "external_services.grafana.auth.password" to "secret:myGrafanaCredentials:myGrafanaPw".
+      #
+      # **Custom-dashboards settings:
+      # enabled: enable or disable custom dashboards, including the dashboards discovery process. Default: true.
+      # is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
+      # namespace_label: Prometheus label name used for identifying namespaces in metrics for custom dashboards.
+      #   Default is "kubernetes_namespace". It is quite common to use just "namespace" as well, depending on your Prometheus configuration.
+      # prometheus: please check the section below about Prometheus-specific settings: they are identical. The Prometheus
+      #   configuration defined here is dedicated to fetching custom dashboards, hence allowing to use a different instance
+      #   of Prometheus. If omitted, the same Prometheus as for Istio metrics will be reused for custom dashboards.
+      #    ---
+      #    custom_dashboards:
+      #      enabled: true
+      #      is_core_component: false
+      #      namespace_label: "kubernetes_namespace"
+      #      prometheus:
+      #        auth:
+      #          ca_file: ""
+      #          insecure_skip_verify: false
+      #          password: ""
+      #          token: ""
+      #          type: "none"
+      #          use_kiali_token: false
+      #          username: ""
+      #        url: ""
+      #
+      # **Grafana-specific settings:
+      # auth: authentication settings to connect to Grafana:
+      #   ca_file: The certificate authority file to use when accessing Grafana using https. An empty string means no extra
+      #       certificate authority file is used. Default is an empty string.
+      #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Grafana over https.
+      #   password: Password to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions. May refer to a secret - see note above.
+      #   token: Token / API key to access Grafana, for token-based authentication. It only requires viewer permissions. May refer to a secret - see note above.
+      #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
+      #       token to the Grafana server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
+      #       Default is "none"
+      #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
+      #       and auth.token config is ignored then.
+      #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
+      # is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
+      # dashboards: A list of Grafana dashboards that Kiali can link to. Each item contains:
+      #   name: The name of the dashboard in Grafana
+      #   variables:
+      #     app: The name of a variable that holds the app name, if used in that dashboard (else it must be omitted)
+      #     namespace: The name of a variable that holds the namespace, if used in that dashboard (else it must be omitted)
+      #     service: The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)
+      #     workload: The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)
+      # enabled: When true, Grafana support will be enabled in Kiali.
+      # in_cluster_url: Set URL for in-cluster access. Example: "http://grafana.istio-system:3000". This URL can contain query parameters if needed, such as "?orgId=1".
+      # url: The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to
+      #      the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made.
+      #      This URL can contain query parameters if needed, such as "?orgId=1".
+      #    ---
+      #    grafana:
+      #      auth:
+      #        ca_file: ""
+      #        insecure_skip_verify: false
+      #        password: ""
+      #        token: ""
+      #        type: "none"
+      #        use_kiali_token: false
+      #        username: ""
+      #      is_core_component: false
+      #      dashboards:
+      #      - name: "Istio Service Dashboard"
+      #        variables:
+      #          namespace: "var-namespace"
+      #          service: "var-service"
+      #      - name: "Istio Workload Dashboard"
+      #        variables:
+      #          namespace: "var-namespace"
+      #          workload: "var-workload"
+      #      enabled: true
+      #      in_cluster_url: "http://grafana.istio-system:3000"
+      #      url: ""
+      #
+      # **Istio-specific settings:
+      # component_status:
+      #   enabled: Enable/Disable of istio component status into masthead indicator. It defaults to true.
+      #   components: A list of components that Kiali will check its statuses.
+      #     app_label: Istio component pod app label.
+      #     is_core: Whether the component is core for your deployment.
+      #     namespace: The namespace where the component is installed in. It defaults to the 'istio_namespace' setting.
+      # config_map_name: The name of the istio control plane config map. It defaults to `istio`.
+      # envoy_admin_local_port: The port which kiali will open to fetch envoy config data information.
+      # istio_identity_domain: The annotation used by Istio to identify domains.
+      # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
+      # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
+      # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
+      #    ---
+      #    istio:
+      #      component_status:
+      #        enabled: true
+      #        components:
+      #        - app_label: istiod
+      #          is_core: true
+      #        - app_label: istio-ingressgateway
+      #          is_core: true
+      #        - app_label: istio-egressgateway
+      #          is_core: false
+      #      config_map_name: "istio"
+      #      envoy_admin_local_port: 15000
+      #      istio_identity_domain: "svc.cluster.local"
+      #      istio_injection_annotation: "sidecar.istio.io/inject"
+      #      istio_sidecar_annotation: "sidecar.istio.io/status"
+      #      url_service_version: ""
+      #
+      #
+      # **Prometheus-specific settings:
+      # auth: authentication settings to connect to Prometheus:
+      #   ca_file: The certificate authority file to use when accessing Prometheus using https. An empty string means no extra
+      #       certificate authority file is used. Default is an empty string.
+      #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.
+      #   password: Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret - see note above.
+      #   token: Token / API key to access Prometheus, for token-based authentication. May refer to a secret - see note above.
+      #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
+      #       token to the Prometheus server. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
+      #       Default is "none"
+      #   use_kiali_token: When true and if auth.type is "bearer", Kiali Service Account token will be used for the API calls to Prometheus,
+      #       and auth.token config is ignored then.
+      #   username: Username to be used when making requests to Prometheus, for basic authentication.
+      # cache_duration: Prometheus caching duration expressed in seconds
+      # cache_enabled: Enable/disable Prometheus caching used for Health services
+      # cache_expiration: Prometheus caching expiration expressed in seconds
+      # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
+      #      If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
+      #    ---
+      #    prometheus:
+      #      auth:
+      #        ca_file: ""
+      #        insecure_skip_verify: false
+      #        password: ""
+      #        token: ""
+      #        type: "none"
+      #        use_kiali_token: false
+      #        username: ""
+      #      cache_duration: 10
+      #      cache_enabled: true
+      #      cache_expiration: 300
+      #      url: ""
+      #
+      # **Tracing-specific settings:
+      #  - Right now we only support Jaeger
+      # auth: authentication settings to connect to Jaeger:
+      #   ca_file: The certificate authority file to use when accessing Jaeger using https. An empty string means no extra
+      #       certificate authority file is used. Default is an empty string.
+      #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Jaeger over https.
+      #   password: Password to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions. May refer to a secret - see note above.
+      #   token: Token / API key to access Jaeger, for token-based authentication. It only requires viewer permissions. May refer to a secret - see note above.
+      #   type: The type of authentication to use when contacting the server from the Kiali backend. Use "bearer" to send the
+      #       token to Jaeger Query. Use "basic" to connect with username and password credentials. Use "none" to not use any authentication.
+      #       Default is "none"
+      #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Jaeger Query,
+      #       and auth.token config is ignored then.
+      #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
+      # is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
+      # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
+      # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
+      #      When not provided, Kiali will only show external links using the "url" config.
+      #      Example: "http://tracing.istio-system".
+      # namespace_selector: Kiali use this boolean to look traces with namespace selector : service.namespace. Default: true
+      # url: External URL that will be used to generate links to Jaeger. It must be accessible to clients external to
+      #      the cluster (e.g: browser) in order to generate valid links.
+      #      If tracing service is deployed in a QUERY_BASE_PATH set this in the url like https://<hostname>/<QUERY_BASE_PATH> . EX: https://tracing-service:8080/jaeger
+      # whitelist_istio_system: Set whitelist services in istio-system to check their traces
+      #    ---
+      #    tracing:
+      #      auth:
+      #        ca_file: ""
+      #        insecure_skip_verify: false
+      #        password: ""
+      #        token: ""
+      #        type: "none"
+      #        use_kiali_token: false
+      #        username: ""
+      #      is_core_component: false
+      #      enabled: true
+      #      in_cluster_url: ""
+      #      namespace_selector: true
+      #      url: ""
+      #      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+
+      ##########
+      #  ---
+      #  health_config:
+      #
+      # rate: A list of health configurations that Kiali uses to determine what is (and is not) healthy nodes. Each item contains:
+      #   namespace: The name of the namespace that this configuration applies to. This is a regular expression.
+      #   kind: The type of resource that this configuration applies to. This is a regular expression.
+      #   name: The name of a resource that this configuration applies to. This is a regular expression.
+      #   tolerance: A list of tolerances for this configuration. Each item contains:
+      #     protocol: The protocol that applies for this tolerance (e.g. grpc or http). This is a regular expression.
+      #     direction: The direction that applies for this tolerance (e.g. inbound or outbound). This is a regular expression.
+      #     code: The status code that applies for this tolerance. This is a regular expression.
+      #     degraded: Health will be considered degraded when the telemetry reaches this value (specified as a %).
+      #     failure: A failure status will be shown when the telemetry reaches this value (specified as a %).
+      #    ---
+      #    rate: []
+
+      ##########
+      #  ---
+      #  identity:
+      #
+      # Certificate file used to identify the file server. If set, you must go over https to access Kiali.
+      # The operator will set these if it deploys Kiali behind https.
+      # When left undefined, the operator will assign a cluster-specific cert file to provide https by default.
+      # When set to an empty string, https will be disabled.
+      #    ---
+      #    #cert_file:
+      #
+      # Private key file used to identify the server. If set, you must go over https to access Kiali.
+      # When left undefined, the operator will assign a cluster-specific private key file to provide https by default.
+      # When set to an empty string, https will be disabled.
+      #    ---
+      #    #private_key_file:
+
+      ##########
+      #  ---
+      #  istio_labels:
+      #
+      # This section defines what labels Istio is using to indicate apps and versions.
+      # Typical values are: ("app" and "version") or ("app.kubernetes.io/name" and "app.kubernetes.io/version").
+      # Kiali needs to know what labels Istio is using to be in sync with what Istio considers applications.
+      # It adds the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed.
+      #    ---
+      #    app_label_name: "app"
+      #    injection_label_name: "istio-injection"
+      #    version_label_name: "version"
+
+      ##########
+      # Kiali features that can be enabled/disabled via configuration
+      #  ---
+      #  kiali_feature_flags:
+      #
+      # Flag to indicate Kiali to enable/disable an Action to label a namespace for automatic Istio Sidecar injection.
+      #    ---
+      #    istio_injection_action: true
+
+      ##########
+      #  ---
+      #  kubernetes_config:
+      #
+      # The Burst value of the Kubernetes client.
+      #    ---
+      #    burst: 200
+      #
+      # The ratio interval (expressed in seconds) used for the cache to perform a full refresh.
+      # Only used when cache_enabled is true.
+      #    ---
+      #    cache_duration: 300
+      #
+      # Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously.
+      #    ---
+      #    cache_enabled: true
+      #
+      # Kiali can cache VirtualService,DestinationRule,Gateway and ServiceEntry Istio resources if they are present
+      # on this list of Istio types. Other Istio types are not yet supported.
+      #    ---
+      #    cache_istio_types:
+      #    - "DestinationRule"
+      #    - "Gateway"
+      #    - "ServiceEntry"
+      #    - "VirtualService"
+      #    - "Sidecar"
+      #    - "PeerAuthentication"
+      #    - "RequestAuthentication"
+      #    - "AuthorizationPolicy"
+      #
+      # List of namespaces or regex defining namespaces to include in a cache.
+      #    ---
+      #    cache_namespaces:
+      #    - ".*"
+      #
+      # Cache duration expressed in seconds
+      # Kiali cache list of namespaces per user, this is typically short lived cache compared with the duration of the
+      # namespace cache defined by previous CacheDuration parameter
+      #    ---
+      #    cache_token_namespace_duration: 10
+      #
+      # List of controllers that won't be used for Workload calculation.
+      # Kiali queries Deployment,ReplicaSet,ReplicationController,DeploymentConfig,StatefulSet,Job and CronJob controllers.
+      # Deployment and ReplicaSet will be always queried, but ReplicationController,DeploymentConfig,StatefulSet,Job and CronJobs
+      # can be skipped from Kiali workloads query if they are present in this list.
+      #    ---
+      #    excluded_workloads:
+      #    - "CronJob"
+      #    - "DeploymentConfig"
+      #    - "Job"
+      #    - "ReplicationController"
+      #
+      # The QPS value of the Kubernetes client.
+      #    ---
+      #    qps: 175
+
+      ##########
+      #  ---
+      #  login_token:
+      #
+      # The token expiration in seconds.
+      #    ---
+      #    expiration_seconds: 86400
+      #
+      # The signing key used to generate tokens for user authentication.
+      # Because this is potentially sensitive, you have the option to store this
+      # value in a secret. If you store this signing key value in a secret, you
+      # must indicate what key in what secret by setting this value to a string
+      # in the form of "secret:<secretName>:<secretKey>"
+      # If left as an empty string, a secret with a random signing key will be
+      # generated for you.
+      #    ---
+      #    signing_key: ""
+
+      ##########
+      #  ---
+      #  server:
+      #
+      # Where the Kiali server is bound. The console and API server are accessible on this host.
+      #    ---
+      #    address: ""
+      #
+      # When true, allows additional audit logging on write operations.
+      #    ---
+      #    audit_log: true
+      #
+      # When true, allows the web console to send requests to other domains other than where the console came from.
+      # Typically used for development environments only.
+      #    ---
+      #    cors_allow_all: false
+      #
+      # When true, Kiali serves http requests with gzip enabled (if the browser supports it) when the requests are
+      #  over 1400 bytes.
+      #    ---
+      #    gzip_enabled: true
+      #
+      # When true, the metrics endpoint will be available for Prometheus to scrape.
+      #    ---
+      #    metrics_enabled: true
+      #
+      # The port that the server will bind to in order to receive metric requests.
+      # This is the port Prometheus will need to scrape when collecting metrics from Kiali.
+      #    ---
+      #    metrics_port: 9090
+      #
+      # The port that the server will bind to in order to receive console and API requests.
+      #    ---
+      #    port: 20001
+      #
+      # Defines the public domain where Kiali is being served. This is the "domain" part
+      # of the URL (usually it's a fully-qualified domain name).
+      # For example, "kiali.example.org".
+      # When empty, Kiali will try to guess this value from HTTP headers.
+      #    ---
+      #    web_fqdn: ""
+      #
+      # Define the history mode of kiali UI. This can only take
+      # two possible values: either "browser" or "hash".
+      # When empty, it will always be considered as browser
+      #    ---
+      #    web_history_mode: ""
+      #
+      # Defines the ingress port where the connections come from. This is usually
+      # necessary when the application responds through a proxy/ingress, and it does
+      # not forward the correct headers so Kiali can guess the port.
+      #
+      # When empty, Kiali will try to guess this value from HTTP headers.
+      #    ---
+      #    web_port: ""
+      #
+      # Defines the context root path for the Kiali console and API endpoints and readiness probes.
+      # When providing a context root path that is not "/", do not add a trailing slash.
+      # For example, use "/kiali" not "/kiali/".
+      # When empty, will default to "/" on OpenShift and "/kiali" on Kubernetes.
+      #    ---
+      #    web_root: ""
+      #
+      # Defines the public HTTP schema used to serve Kiali. This can only take
+      # two possible values: either "http" or "https".
+      # When empty, Kiali will try to guess this value from HTTP headers.
+      #    ---
+      #    web_schema: ""

--- a/helmfile.d/helmfile-05.init.yaml
+++ b/helmfile.d/helmfile-05.init.yaml
@@ -12,6 +12,12 @@ releases:
     labels:
       pkg: istio-operator
     <<: *default
+  - name: kiali-operator
+    installed: true
+    namespace: default
+    labels:
+      pkg: kiali-operator
+    <<: *default
   - name: keycloak
     installed: {{ $c | get "keycloak.enabled" true }}
     namespace: keycloak


### PR DESCRIPTION
Issue: #164 
Task: Kiali operator added and configured

Apologies for being naive. Here, I have a basic configuration of Kiali Operator, but that's of course not sufficient. But I don't know what is under the definition of done for this story (or for any story adding new components), is it a basic configuration like this or are there any special requirements for integrating it? 

On the top of my head:

- [ ] Refactor this chunk from `values/istio-operator-raw.gotmpl`:
```
kiali:
          enabled: {{ $ia | get "kiali.enabled" true }}
          k8s:
            priorityClassName: "otomi-critical"
            resources:
              {{- with $i | get "resources.kiali" nil }}
                {{- toYaml . | nindent 14 }}
              {{- else }}
              requests:
                cpu: 100m
                memory: 512Mi
              limits:
                cpu: 500m
                memory: 1
                {{- end }}
      values:
        kiali:
          contextPath: '/kiali'
          dashboard:
            auth:
              strategy: anonymous #openid
              # openid:
              #   issuer_uri: {{ $keycloakBase }}
              #   client_id: {{ $v.oidc.clientID }}
            jaegerURL: https://{{ $appsDomain }}/tracing/
            grafanaURL: https://{{ $appsDomain }}/grafana-istio/
```
- [ ] Set new Istio version (breaking change), maybe work on #259 first.
- [ ] Configure Kiali CR (https://kiali.io/documentation/latest/installation-guide/#_create_or_edit_the_kiali_cr)
- [ ] Expose `values.yaml` in `values-schema.yaml` (and then we should make a distinction between what should be default and what should be configurable).