### PR TITLE
Feat: run yq in container if necessary

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -9,8 +9,15 @@ readonly replacePathsPattern="s@../env@${ENV_DIR}@g"
 readonly yqDockerImage="mikefarah/yq:3"
 
 function dyq() {
-  local command=$@
-  docker run --rm -v ${ENV_DIR}:${ENV_DIR} ${yqDockerImage} yq ${command}
+  local yqcommand=$@
+  if [ -x "$(command -v yq)" ] && [[ "$(yq --version 2>&1 | sed 's/yq version //g')" == "3."* ]] ; then
+    yq ${yqcommand}
+  elif [ -x "$(command -v docker)" ]; then
+    docker run --rm -v ${ENV_DIR}:${ENV_DIR} ${yqDockerImage} yq ${yqcommand}
+  else
+    echo "Either docker needs to be installed, or yq@3 needs to be installed."
+    exit 1
+  fi
 }
 
 get_k8s_version() {


### PR DESCRIPTION
Implemented a function `dyq` that runs the `yq` command in a docker container when the local version is either not installed or not in version 3.

This code prefers local execution over containerised execution due to performance. Plus, why run it in a container, when you can run in locally? 

