### PR TITLE
refactor: don't require ppa, but get yq from developer's docker image

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -27,9 +27,10 @@ ARG BATS_FILE_VERSION=0.2.0
 WORKDIR /
 
 RUN apt-get update -qq \
-  && apt install apt-transport-https ca-certificates curl software-properties-common -qqy --no-install-recommends
-RUN add-apt-repository ppa:rmescandon/yq && apt-get update -qq \
-  && apt-get install -qqy --no-install-recommends \
+  && apt install -qqy --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  curl \
   coreutils \
   gettext \
   git \
@@ -41,9 +42,10 @@ RUN add-apt-repository ppa:rmescandon/yq && apt-get update -qq \
   nano \
   groff \
   jq \
-  yq \
   awscli \
   && rm -rf /var/lib/apt/lists/*
+
+COPY --from=mikefarah/yq:3 /usr/bin/yq /usr/bin/yq
 
 RUN mkdir -p /home/app
 RUN groupadd -r app &&\


### PR DESCRIPTION
Copy the yq binary directly from the developers own docker image, this way ppa is no longer required
and other dependencies can be removed, and the two run apt install layers can be merged into one.

fix #272