### PR TITLE
feat: add configurable username claim mapper

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1218,6 +1218,7 @@ properties:
         $ref: '#/definitions/url'
       usernameClaimMapper:
         type: string
+        description: 'Claim name used by Keycloak to identify incoming users from identity provider'
   otomi:
     additionalProperties: false
     properties:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1216,6 +1216,8 @@ properties:
         type: string
       tokenUrl:
         $ref: '#/definitions/url'
+      usernameClaimMapper:
+        type: string
   otomi:
     additionalProperties: false
     properties:

--- a/values/jobs/keycloak.gotmpl
+++ b/values/jobs/keycloak.gotmpl
@@ -31,7 +31,7 @@ tasks:
         echo READY!
     image:
       repository: {{ $c | get "jobs.keycloak.image.repository" "otomi/tasks" }}
-      tag: {{ $c | get "jobs.keycloak.image.tag" "v0.2.1" }}
+      tag: {{ $c | get "jobs.keycloak.image.tag" "v0.2.4" }}
       pullPolicy: {{ $c | get "jobs.keycloak.image.pullPolicy" "IfNotPresent" }}
     env:
       KEYCLOAK_THEME_LOGIN: {{ $k | get "theme" "default" }}

--- a/values/jobs/keycloak.gotmpl
+++ b/values/jobs/keycloak.gotmpl
@@ -49,6 +49,7 @@ tasks:
       IDP_ALIAS: {{ $k.idp.alias }}
       IDP_GROUP_OTOMI_ADMIN: {{ $v.oidc.adminGroupID }}
       IDP_GROUP_TEAM_ADMIN: {{ $v.oidc.teamAdminGroupID }}
+      IDP_USERNAME_CLAIM_MAPPER: {{ $v | get "oidc.usernameClaimMapper" "${CLAIM.email}" }}
       IDP_GROUP_MAPPINGS_TEAMS: '{{ $teamsMapping | toJson }}'
       IDP_OIDC_URL: {{ $v.oidc.issuer }}
       REDIRECT_URIS: '[


### PR DESCRIPTION
As discused, I added `IDP_USERNAME_CLAIM_MAPPER` environment variable which can be used for the `Username` field mapping on user registration stage.
Updated Values repo with default value of `IDP_USERNAME_CLAIM_MAPPER="${CLAIM.email}"` but it can also be `"${CLAIM.oid}"`.