### PR TITLE
fix: trap function return recent exit code

### DIFF
--- a/bin/validate-templates.sh
+++ b/bin/validate-templates.sh
@@ -13,7 +13,8 @@ exitcode=0
 . bin/common.sh
 
 cleanup() {
-  [ $? -eq 0 ] && [ $exitcode -eq 0 ] && echo "Validation Success" || echo "Validation Failed"
+  exitcode=$?
+  [ $exitcode -eq 0 ] && echo "Validation Success" || echo "Validation Failed"
   rm -rf $extractCrdSchemaJQFile
   rm -rf $k8sResourcesPath -rf $outputPath $schemaOutputPath
   exit $exitcode

--- a/helmfile.d/helmfile-19.ingress-init.yaml
+++ b/helmfile.d/helmfile-19.ingress-init.yaml
@@ -6,7 +6,7 @@ bases:
 {{- $c := $v.charts }}
 
 releases:
-  - name: jobs-keycloak
+  - name: job-keycloak
     installed: {{ $c | get "keycloak.enabled" true }}
     labels:
       pkg: keycloak


### PR DESCRIPTION
Fixes: https://github.com/redkubes/otomi-core/issues/284

Fixes both: validate-templates.sh script and recently introduced bug in our template, which was not properly reported.
