### PR TITLE
fix: remove old init script from harbor job

### DIFF
--- a/values/jobs/harbor.gotmpl
+++ b/values/jobs/harbor.gotmpl
@@ -20,13 +20,7 @@ type: Job
 enabled: true
 runPolicy: Always
 description: Configure OIDC as a primary auhentication method and populate teams to harbor projects
-init:
-  image:
-    repository: otomi/tools
-    tag: '1.4.11'
-    pullPolicy: IfNotPresent
-  # move secret for harbor to use
-  script: kubectl -n {{ $ns }} get secret harbor-{{ $v.cluster.domain | replace "." "-" }} -o yaml --export | kubectl -n harbor apply -f -
+
 name: harbor
 image:
   repository: otomi/tasks


### PR DESCRIPTION
I noticed that harbor job fails on otomi-eks-dev cluster
It happens in the InitContainer while performing:
kubectl -n istio-system get secret harbor-dev-eks-otomi-cloud -o yaml --export | kubectl -n harbor apply -f -
It is caused by the --export flag has been deprecated in k8s 1.14 and no longer available in 1.18

We agreed on removing the init container as it does not serve purpose anymore.