### PR TITLE
Fix jobs

### DIFF
--- a/.demo/env/clouds/aws/demo/jobs.demo.yaml
+++ b/.demo/env/clouds/aws/demo/jobs.demo.yaml
@@ -11,6 +11,10 @@ teamConfig:
                       /config/some-file3: |-
                           some data on another line
                           another line
+                  podSecurityContext:
+                      runAsNonRoot: true
+                      runAsUser: 1002
+                      runAsGroup: 1002
                   image:
                       repository: busybox
                       tag: latest

--- a/bin/check-policies.sh
+++ b/bin/check-policies.sh
@@ -25,7 +25,7 @@ validate_policies() {
   mkdir -p $k8s_resources_path
   # generate_manifests
   echo "Generating k8s $k8s_version manifests for cluster '$cluster_env'"
-  hf_templates_init "$k8s_resources_path/$k8s_version" "$@" >/dev/null
+  hf_templates "$k8s_resources_path/$k8s_version" "$@"
 
   echo "Processing templates"
   # generate parameter constraints file from values

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -128,9 +128,9 @@ function for_each_cluster() {
   done
 }
 
-hf_templates_init() {
+hf_templates() {
   local out_dir="$1"
   shift
-  [ -z "$*" ] && hf -f helmfile.tpl/helmfile-init.yaml template --skip-deps --output-dir="$out_dir" >/dev/null 2>&1
-  hf "$@" template --skip-deps --output-dir="$out_dir" >/dev/null 2>&1
+  [ -z "$*" ] && hf -f helmfile.tpl/helmfile-init.yaml template --skip-deps --output-dir="$out_dir" >/dev/null
+  hf "$@" template --skip-deps --output-dir="$out_dir" >/dev/null
 }

--- a/bin/otomi
+++ b/bin/otomi
@@ -255,6 +255,7 @@ function execute() {
       if [ "$*" != '' ]; then
         validate_cluster_env
       fi
+      check_kube_context=0
       drun bin/check-policies.sh "$@"
       ;;
     commit)
@@ -333,6 +334,7 @@ function execute() {
     template)
       evaluate_secrets
       validate_cluster_env
+      check_kube_context=0
       set -o pipefail
       drun helmfile -e $CLOUD-$CLUSTER --quiet "$@" template --skip-deps | grep -Ev $helmfile_output_hide_tpl
       ;;

--- a/bin/validate-templates.sh
+++ b/bin/validate-templates.sh
@@ -70,7 +70,7 @@ function validate_templates() {
 
   setup $k8s_version
   echo "Generating k8s $k8s_version manifests for cluster '$cluster_env'"
-  hf_templates_init "$k8s_resources_path/$k8s_version"
+  hf_templates "$k8s_resources_path/$k8s_version"
 
   echo "Processing CRD files"
   # generate canonical schemas

--- a/charts/jobs/templates/cronjob.yaml
+++ b/charts/jobs/templates/cronjob.yaml
@@ -106,7 +106,7 @@ spec:
                 name: {{ include "fileConfigMapName" $location }}
             {{- end }}
           {{- end }}
-  backoffLimit: 3
-  ttlSecondsAfterFinished: {{ $v.ttlSecondsAfterFinished | default 86400 }}
+      backoffLimit: 3
+      ttlSecondsAfterFinished: {{ $v.ttlSecondsAfterFinished | default 86400 }}
 ---
 {{- end }}

--- a/charts/jobs/templates/cronjob.yaml
+++ b/charts/jobs/templates/cronjob.yaml
@@ -7,9 +7,9 @@ metadata:
   name: job-{{ $v.name }}
   labels: {{- include "jobs.labels" $ | nindent 4 }}
   annotations:
-    policy.otomi.io/ignore: psp-allowed-users
     checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum | trunc 63 }}
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum | trunc 63 }}
+    
 spec:
   schedule: "{{ $v.schedule }}"
   successfulJobsHistoryLimit: 1

--- a/charts/jobs/templates/cronjob.yaml
+++ b/charts/jobs/templates/cronjob.yaml
@@ -1,5 +1,7 @@
 {{- $v := .Values }}
 {{- $teamSecrets := (include "itemsByName" ($v.teamSecrets | default list) | fromYaml) }}
+{{- $podSecurityContext := get $v "podSecurityContext" | default (dict "runAsNonRoot" true "runAsUser" 1001 "runAsGroup" 1001) }}
+
 {{- if eq $v.type "CronJob" }}
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -22,6 +24,7 @@ spec:
       template:
         spec:
           serviceAccountName: {{ $v.serviceAccountName | default "default" }}
+          securityContext: {{- toYaml $podSecurityContext | nindent 12 }}
           {{- with $v.init }}
           initContainers:
           - image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"

--- a/charts/jobs/templates/job.yaml
+++ b/charts/jobs/templates/job.yaml
@@ -16,7 +16,6 @@ spec:
     metadata:
       labels: {{- include "jobs.labels" $ | nindent 8 }}
       annotations:
-        policy.otomi.io/ignore: psp-allowed-users
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum | trunc 63 }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum | trunc 63 }}
         {{- range $key, $value := $v.annotations }}

--- a/charts/jobs/templates/job.yaml
+++ b/charts/jobs/templates/job.yaml
@@ -1,6 +1,7 @@
 {{- $v := .Values }} 
 {{- $ := . }}
 {{- $teamSecrets := (include "itemsByName" ($v.teamSecrets | default list) | fromYaml) }}
+{{- $podSecurityContext := get $v "podSecurityContext" | default (dict "runAsNonRoot" true "runAsUser" 1001 "runAsGroup" 1001) }}
 {{- if eq $v.type "Job" }}
 apiVersion: batch/v1
 kind: Job
@@ -23,9 +24,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ $v.serviceAccountName | default "default" }}
-      {{- with $v.podSecurityContext }}
-      securityContext: {{- toYaml . | nindent 8 }}
-      {{- end }}
+      securityContext: {{- toYaml $podSecurityContext | nindent 8 }}
       {{- if $v.init }}
       initContainers:
       - image: "{{ $v.init.image.repository }}:{{ $v.init.image.tag | default "latest" }}"

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -274,6 +274,8 @@ definitions:
           $ref: '#/definitions/secrets'
         script:
           $ref: '#/definitions/script'
+        podSecurityContext:
+          $ref: '#/definitions/podSecurityContext'
         ttlSecondsAfterFinished:
           default: 86400
           type: number
@@ -317,6 +319,21 @@ definitions:
     maximum: 32768
     minimum: 80
     type: number
+  podSecurityContext:
+    properties:
+      runAsNonRoot:
+        type: boolean
+        default: true
+      runAsUser:
+        type: integer
+        minimum": 0
+        maximum": 65535
+        default: 1001
+      runAsGroup:
+        type: integer
+        minimum": 0
+        maximum": 65535
+        default: 1001
   registry:
     pattern: '^[a-z0-9]+(?:[._-][a-z0-9]+)*$'
     type: string

--- a/values/jobs/harbor.gotmpl
+++ b/values/jobs/harbor.gotmpl
@@ -14,7 +14,6 @@
 {{- range $teams -}}
 {{- $teamNames = print "team-" . | append $teamNames -}}
 {{- end -}}
-{{- $addIgnorePolicyAnnotation := readFile "../../helmfile.d/utils/addIgnorePolicyAnnotation.gotmpl" }}
 
 type: Job
 enabled: true

--- a/values/jobs/keycloak.gotmpl
+++ b/values/jobs/keycloak.gotmpl
@@ -18,6 +18,8 @@ type: Job
 enabled: true
 runPolicy: Always
 description: Configure OIDC as a primary auhentication method and populate teams to harbor projects
+annotations:
+    policy.otomi.io/ignore: "banned-image-tags"
 init:
   image:
     repository: badouralix/curl-http2

--- a/values/jobs/keycloak.gotmpl
+++ b/values/jobs/keycloak.gotmpl
@@ -12,15 +12,14 @@
 {{- $cm := $c | get "cert-manager" -}}
 {{- $k := $c | get "keycloak" dict }}
 {{- $skipVerify := eq ($cm | get "stage") "staging" }}
-{{- $addIgnorePolicyAnnotation := readFile "../../helmfile.d/utils/addIgnorePolicyAnnotation.gotmpl" }}
 
 type: Job
 enabled: true
 runPolicy: Always
 description: Configure OIDC as a primary auhentication method and populate teams to harbor projects
-annotations:
-    policy.otomi.io/ignore: "banned-image-tags"
 init:
+  annotations:
+    policy.otomi.io/ignore.job-keycloak-init: "banned-image-tags"
   image:
     repository: badouralix/curl-http2
   script: |
@@ -52,7 +51,7 @@ secret:
   IDP_ALIAS: {{ $k.idp.alias }}
   IDP_GROUP_OTOMI_ADMIN: {{ $v.oidc.adminGroupID }}
   IDP_GROUP_TEAM_ADMIN: {{ $v.oidc.teamAdminGroupID }}
-  IDP_USERNAME_CLAIM_MAPPER: {{ $v | get "oidc.usernameClaimMapper" "${CLAIM.email}" }}
+  IDP_USERNAME_CLAIM_MAPPER: {{ $v | get "oidc.usernameClaimMapper" "${CLAIM.upn}" }}
   IDP_GROUP_MAPPINGS_TEAMS: '{{ $teamsMapping | toJson }}'
   IDP_OIDC_URL: {{ $v.oidc.issuer }}
   REDIRECT_URIS: '[


### PR DESCRIPTION
The job-keycloak release may be deployed but the job will not start because of `gatekeeper` that bans `latest` tag for `badouralix/curl-http2:latest image` 

I created a default podSecurityContext that can be overwritten if needed. 
Tested for both core and team jobs