### PR TITLE
feat: allow adding new charts even if they are not defined in the schema spec

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -659,7 +659,7 @@ properties:
       - subscriptionId
       - tenantId
   charts:
-    additionalProperties: false
+    additionalProperties: true
     properties:
       cert-manager:
         additionalProperties: false


### PR DESCRIPTION
It is quite painful to provide values to otomi-values repo for new charts, because `otomi validate-values` will rise an error, e.g.:                                                                                         
```
[
  {
    keyword: 'additionalProperties',
    dataPath: '.charts',
    schemaPath: '#/properties/charts/additionalProperties',
    params: { additionalProperty: 'vault' },
    message: 'should NOT have additional properties'
  }
]
```

I would really appreciate if we can make schema more permissive for new charts names, so developers do not stumble on "chicken egg" problem and can provide working settings to values repo that can accompany PRs in otomi-core.