### PR TITLE
Add slack notify workflow

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,13 @@
+on: push
+name: Slack Notification
+jobs:
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: github-ci


### PR DESCRIPTION
Let's add some visibility into our builds. What do you think team?

If so, please add the secret for `SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}`: https://github.com/marketplace/actions/slack-notify.

I've set it to a newly created `github-ci` channel to not pollute other channels. 