### PR TITLE
fix: team services may not exist

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -91,7 +91,7 @@ releases:
                 static_configs:
                   - targets:
                     {{ $registry := list }}
-                    {{- range $s := $team.services }}
+                    {{- range $s := $team | get "services" list }}
                     {{- if and (hasKey $s "isPublic") (not ($s | get "ksvc.scaleToZero" false)) }}
                     {{- $svcDomain := ($s | get "domain" (printf "%s.%s" $s.name $domain)) }}
                     {{- $path := "/" }}{{ if hasKey $s "paths" }}{{ $path = index $s.paths 0 }}{{ end }}


### PR DESCRIPTION
A brand new team that is onboarded may not have any service in the cluster.

This change prevents the following error:
```
in helmfile.d/helmfile-60.teams.yaml: error during helmfile-60.teams.yaml.part.1 parsing: template: stringTemplate:91:41: executing "stringTemplate" at <$team.services>: map has no entry for key "services"
```