### PR TITLE
Job env variables

### DIFF
--- a/charts/jobs/templates/configmap.yaml
+++ b/charts/jobs/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $v := .Values }}
-{{- if or (or $v.env $v.init.env) $v.files }}
+{{- if $v.env }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +9,15 @@ data:
   {{- with $v.env }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+---
+{{- end }}
+{{- if $v.init.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-init-{{ $v.name }}
+  labels: {{- include "jobs.labels" $ | nindent 4 }}
+data:
   {{- with $v.init.env  }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/jobs/templates/configmap.yaml
+++ b/charts/jobs/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: job-init-{{ $v.name }}
+  name: job-{{ $v.name }}-name
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
   {{- with $v.init.env  }}

--- a/charts/jobs/templates/configmap.yaml
+++ b/charts/jobs/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: job-{{ $v.name }}
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
-  {{- toYaml ($v | get "env" dict) | nindent 4 }}
+  {{- toYaml $v.env | nindent 4 }}
 ---
 {{- end }}
 {{- if $v.init.env }}
@@ -16,7 +16,7 @@ metadata:
   name: job-{{ $v.name }}-name
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
-  {{- toYaml ($v | get "init.env" dict) | nindent 4 }}
+  {{- toYaml $v.init.env | nindent 4 }}
 ---
 {{- end }}
 {{- range $location, $content := $v.files }}

--- a/charts/jobs/templates/configmap.yaml
+++ b/charts/jobs/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: job-{{ $v.name }}-name
+  name: job-{{ $v.name }}-init
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
   {{- toYaml $v.init.env | nindent 4 }}

--- a/charts/jobs/templates/configmap.yaml
+++ b/charts/jobs/templates/configmap.yaml
@@ -6,9 +6,7 @@ metadata:
   name: job-{{ $v.name }}
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
-  {{- with $v.env }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- toYaml ($v | get "env" dict) | nindent 4 }}
 ---
 {{- end }}
 {{- if $v.init.env }}
@@ -18,9 +16,7 @@ metadata:
   name: job-{{ $v.name }}-name
   labels: {{- include "jobs.labels" $ | nindent 4 }}
 data:
-  {{- with $v.init.env  }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- toYaml ($v | get "init.env" dict) | nindent 4 }}
 ---
 {{- end }}
 {{- range $location, $content := $v.files }}

--- a/charts/jobs/templates/job.yaml
+++ b/charts/jobs/templates/job.yaml
@@ -37,7 +37,7 @@ spec:
         {{- if $v.init.env }}
         envFrom:
         - configMapRef:
-            name: job-{{ $v.name }}
+            name: job-{{ $v.name }}-init
         {{- end }}
         {{- with $v.secrets }}
         env:

--- a/values/jobs/gitea.gotmpl
+++ b/values/jobs/gitea.gotmpl
@@ -15,12 +15,14 @@ secret:
 annotations:
   policy.otomi.io/ignore: "banned-image-tags"
 init:
+  env:
+    GITEA_URL: https://gitea.{{ $v.cluster.domain }}
   image:
     repository: badouralix/curl-http2
   script: |
     {{ if $skipVerify }}export INSECURE='--insecure'{{ end }}
-    echo "Waiting until gitea is accessible at https://gitea.{{ $v.cluster.domain }}"
-    until $(curl $INSECURE --output /dev/null --silent --head --fail -I https://gitea.{{ $v.cluster.domain }}); do 
+    echo "Waiting until gitea is accessible at $GITEA_URL"
+    until $(curl $INSECURE --output /dev/null --silent --head --fail -I $GITEA_URL); do 
       printf '.'
       sleep 5
     done


### PR DESCRIPTION
Fixes #338 

Create a separate init configmap, so env variables aren't shared and don't cause collision.