### PR TITLE
KMS schema is not valid JSON Schema/OpenAPI schema

### DIFF
--- a/profiles/aws/env/secrets.settings.yaml
+++ b/profiles/aws/env/secrets.settings.yaml
@@ -12,7 +12,7 @@ home:
 kms:
     sops:
         aws:
-            clientKey: somesecretvalue
+            accessKey: somesecretvalue
             secretKey: somesecretvalue
             region: somesecretvalue
 oidc:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1614,7 +1614,6 @@ properties:
           - $ref: '#/definitions/azureCreds'
           - $ref: '#/definitions/googleCreds'
           - $ref: '#/definitions/vaultCreds'
-    type: object
   oidc:
     additionalProperties: false
     description: 'Holds many parts used in different locations. Please see keycloak, istio and oauth-proxy all consuming parts.'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -78,6 +78,8 @@ definitions:
           - accessKey
           - secretKey
           - region
+    required:
+      - aws
   azureCreds:
     properties:
       azure:
@@ -94,6 +96,8 @@ definitions:
           - clientId
           - clientSecret
           - tenantId
+    required:
+      - azure
   azureMonitor:
     properties:
       appInsightsApiKey:
@@ -188,6 +192,8 @@ definitions:
             type: string
           project:
             type: string
+    required:
+      - google
   hostPort:
     pattern: '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]):()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$'
     type: string
@@ -675,6 +681,8 @@ definitions:
             type: string
         required:
           - token
+    required:
+      - vault
 properties:
   alerts:
     $ref: '#/definitions/alerts'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1606,7 +1606,6 @@ properties:
     required:
       - namespaces
     kms:
-      additionalProperties: false
       properties:
         sops:
           oneOf:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -66,30 +66,34 @@ definitions:
     description: A set of annotations.
   awsCreds:
     properties:
-      accessKey:
-        type: string
-      secretKey:
-        type: string
-      region:
-        type: string
-    required:
-      - accessKey
-      - secretKey
-      - region
+      aws:
+        properties:
+          accessKey:
+            type: string
+          secretKey:
+            type: string
+          region:
+            type: string
+        required:
+          - accessKey
+          - secretKey
+          - region
   azureCreds:
     properties:
-      clientId:
-        type: string
-      clientSecret:
-        type: string
-      environment:
-        type: string
-      tenantId:
-        type: string
-    required:
-      - clientId
-      - clientSecret
-      - tenantId
+      azure:
+        properties:
+          clientId:
+            type: string
+          clientSecret:
+            type: string
+          environment:
+            type: string
+          tenantId:
+            type: string
+        required:
+          - clientId
+          - clientSecret
+          - tenantId
   azureMonitor:
     properties:
       appInsightsApiKey:
@@ -178,10 +182,12 @@ definitions:
     title: Environment variables
   googleCreds:
     properties:
-      accountJson:
-        type: string
-      project:
-        type: string
+      google:
+        properties:
+          accountJson:
+            type: string
+          project:
+            type: string
   hostPort:
     pattern: '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]):()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$'
     type: string
@@ -663,10 +669,12 @@ definitions:
     type: array
   vaultCreds:
     properties:
-      token:
-        type: string
-    required:
-      - token
+      vault:
+        properties:
+          token:
+            type: string
+        required:
+          - token
 properties:
   alerts:
     $ref: '#/definitions/alerts'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1605,15 +1605,16 @@ properties:
         type: array
     required:
       - namespaces
-    kms:
-      properties:
-        sops:
-          oneOf:
-            - $ref: '#/definitions/awsCreds'
-            - $ref: '#/definitions/azureCreds'
-            - $ref: '#/definitions/googleCreds'
-            - $ref: '#/definitions/vaultCreds'
-      type: object
+  kms:
+    additionalProperties: false
+    properties:
+      sops:
+        oneOf:
+          - $ref: '#/definitions/awsCreds'
+          - $ref: '#/definitions/azureCreds'
+          - $ref: '#/definitions/googleCreds'
+          - $ref: '#/definitions/vaultCreds'
+    type: object
   oidc:
     additionalProperties: false
     description: 'Holds many parts used in different locations. Please see keycloak, istio and oauth-proxy all consuming parts.'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1605,28 +1605,16 @@ properties:
         type: array
     required:
       - namespaces
-  kms:
-    additionalProperties: false
-    properties:
-      sops:
-        oneOf:
-          - aws:
-              $ref: '#/definitions/awsCreds'
-            required:
-              - aws
-          - azure:
-              $ref: '#/definitions/azureCreds'
-            required:
-              - azure
-          - google:
-              $ref: '#/definitions/googleCreds'
-            required:
-              - google
-          - vault:
-              $ref: '#/definitions/vaultCreds'
-            required:
-              - vault
-        type: object
+    kms:
+      additionalProperties: false
+      properties:
+        sops:
+          oneOf:
+            - $ref: '#/definitions/awsCreds'
+            - $ref: '#/definitions/azureCreds'
+            - $ref: '#/definitions/googleCreds'
+            - $ref: '#/definitions/vaultCreds'
+      type: object
   oidc:
     additionalProperties: false
     description: 'Holds many parts used in different locations. Please see keycloak, istio and oauth-proxy all consuming parts.'


### PR DESCRIPTION
I created this pull request because the `otomi-api` schema will rely on this schema. @j-zimnowoda made it clear that we don't want divergence in the schemas and I agree of course.

The story: The `openapi-generator` was complaining about this schema. At first I assumed that this schema is valid JSON schema but not OpenAPI schema, but I can't find anything about the previous modification being valid any schema.

An `oneOf` takes an array of subschemas, and not an array of objects. It is not possible to use `$ref` anywhere one likes. "`$ref` can only be used in place of a subschema."

If this breaks anything, how can we integrate it?