### PR TITLE
Update sops-env.gotmpl

### DIFF
--- a/helmfile.d/snippets/sops-env.gotmpl
+++ b/helmfile.d/snippets/sops-env.gotmpl
@@ -21,4 +21,3 @@ GOOGLE_REGION: {{ requiredEnv "GOOGLE_REGION" }}{{ end }}
 {{- end }}
 {{- with . | get "vault" nil }}
 VAULT_TOKEN: {{ requiredEnv "VAULT_TOKEN" }}{{ end }}
-{{- end }}


### PR DESCRIPTION
There was an unexpected `{{ end }}` according to otomi lint (both old & new CLI)