### PR TITLE
Bump semver to 0.4.51

### DIFF
--- a/values/otomi-console/otomi-console.gotmpl
+++ b/values/otomi-console/otomi-console.gotmpl
@@ -39,7 +39,7 @@ resources:
 image:
   registry: docker.io
   repository: otomi/console
-  tag: {{ $o | get "image.tag" "v0.4.50" }}
+  tag: {{ $o | get "image.tag" "v0.4.51" }}
   pullPolicy: {{ $o | get "image.pullPolicy" "IfNotPresent" }}
 
 env:


### PR DESCRIPTION
This is the new release for `otomi-console` without the red screen error.