### PR TITLE
fix: releasing a chart after adding cluster.owner

### DIFF
--- a/chart/otomi/Chart.yaml
+++ b/chart/otomi/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for installing otomi in Kubernetes
 home: https://otomi.io/
 icon: https://otomi.io/img/otomi-logo.svg
 type: application
-version: '0.1.7-rc1'
+version: '0.2.0-rc1'
 appVersion: 'APP_VERSION_PLACEHOLDER'
 keywords:
   - otomi

--- a/chart/otomi/Chart.yaml
+++ b/chart/otomi/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for installing otomi in Kubernetes
 home: https://otomi.io/
 icon: https://otomi.io/img/otomi-logo.svg
 type: application
-version: '0.1.6'
+version: '0.1.7-rc1'
 appVersion: 'APP_VERSION_PLACEHOLDER'
 keywords:
   - otomi


### PR DESCRIPTION
Chart doesn't work because of the change in cluster.owner and we need to release a new chart version. 