### PR TITLE
fix: 🐛 gitea-push, after refactor process exit wast ran

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -181,18 +181,20 @@ vars=(
   OTOMI_SERVER
   OTOMI_TAG
   OTOMI_USERNAME
+  OTOMI_NON_INTERACTIVE
   PROFILE
   STATIC_COLORS
   SHELL
   TESTING
   TRACE
+  VERBOSITY
   VAULT_TOKEN
 )
 dump_vars "${vars[@]}"
 
 cat >>$tmp_env <<EOF
 OTOMI_CALLER_COMMAND=${BASH_SOURCE[0]##*/}
-OTOMI_IN_DOCKER=true
+IN_DOCKER=1
 EOF
 
 helm_config="$HOME/.config/helm"
@@ -225,7 +227,7 @@ if [[ $base_dir == *"otomi-core"* ]] || [[ $(pwd) == *"otomi-core"* ]]; then
   else
     executable="node --no-warnings --experimental-specifier-resolution=node --loader ts-node/esm ${stack_dir}/src/otomi.ts --"
   fi
-  echo "OTOMI_DEV=true" >>$tmp_env
+  echo "OTOMI_DEV=1" >>$tmp_env
 fi
 
 check_volume_path() {
@@ -264,7 +266,7 @@ if [[ $calling_args == 'server'* ]]; then
 fi
 
 mkdir -p /tmp/otomi
-if [ -n "$OTOMI_IN_DOCKER" ]; then
+if [ -n "$IN_DOCKER" ]; then
   $cmd
   status=$?
 elif [[ $calling_args == *'--get-yargs-completions'* ]]; then

--- a/src/common/envalid.ts
+++ b/src/common/envalid.ts
@@ -12,7 +12,7 @@ const cleanSpec = {
   GCLOUD_SERVICE_KEY: json({ default: undefined }),
   KUBE_VERSION_OVERRIDE: str({ default: undefined }),
   OTOMI_DEV: bool({ default: false }),
-  OTOMI_IN_DOCKER: bool({ default: false }),
+  IN_DOCKER: bool({ default: false }),
   OTOMI_IN_TERMINAL: bool({ default: true }),
   STATIC_COLORS: bool({ default: false }),
   TESTING: bool({ default: false }),

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -17,7 +17,6 @@ export const parser = yargs(process.argv.slice(3))
 export const getFilename = (path: string): string => fileURLToPath(path).split('/').pop()?.split('.')[0] as string
 
 export interface BasicArguments extends YargsArguments {
-  inDocker: boolean
   logLevel: string
   nonInteractive: boolean
   skipCleanup: boolean
@@ -28,7 +27,6 @@ export interface BasicArguments extends YargsArguments {
 export const defaultBasicArguments: BasicArguments = {
   _: [],
   $0: 'defaultBasicArgs',
-  inDocker: true,
   logLevel: 'WARN',
   nonInteractive: true,
   skipCleanup: false,
@@ -68,8 +66,11 @@ export const capitalize = (s: string): string =>
       .join(' ')) ||
   ''
 
-export const loadYaml = (path: string): any => {
-  if (!existsSync(path)) throw new Error(`${path} does not exists`)
+export const loadYaml = (path: string, opts?: { noError: boolean }): any => {
+  if (!existsSync(path)) {
+    if (opts?.noError) return null
+    throw new Error(`${path} does not exists`)
+  }
   return load(readFileSync(path, 'utf-8')) as any
 }
 

--- a/src/common/yargs-opts.ts
+++ b/src/common/yargs-opts.ts
@@ -113,14 +113,13 @@ export const basicOptions: { [key: string]: Options } = {
   verbose: {
     alias: 'v',
     count: true,
-    coerce: (val: number) =>
-      Math.min(
-        val,
-        Object.keys(logLevels)
-          .filter((logLevelVal) => !Number.isNaN(Number(logLevelVal)))
-          .map(Number)
-          .reduce((prev, curr) => Math.max(prev, curr)),
-      ),
+    coerce: (val: number) => {
+      const ll = Object.keys(logLevels)
+        .filter((logLevelVal) => !Number.isNaN(Number(logLevelVal)))
+        .map(Number)
+        .reduce((prev, curr) => Math.max(prev, curr))
+      return Math.min(Math.max(val, Number(process.env.VERBOSITY || '0')), ll)
+    },
   },
   'non-interactive': {
     alias: 'ni',
@@ -133,11 +132,6 @@ export const basicOptions: { [key: string]: Options } = {
     hidden: true,
   },
   dev: {
-    boolean: true,
-    default: false,
-    hidden: true,
-  },
-  inDocker: {
     boolean: true,
     default: false,
     hidden: true,

--- a/src/otomi.ts
+++ b/src/otomi.ts
@@ -18,7 +18,7 @@ import { basicOptions } from './common/yargs-opts'
 const debug = terminal('global')
 const terminalScale = 0.75
 const isAutoCompletion = process.argv.includes('--get-yargs-completions')
-if (!env.OTOMI_IN_DOCKER && !isAutoCompletion) {
+if (!env.IN_DOCKER && !isAutoCompletion) {
   debug.error(process.argv)
   debug.error('Please run this script using the `otomi` entry script')
   process.exit(1)


### PR DESCRIPTION
Found a critical bug in gitea-push, because of refactoring of CLI it was now exiting, whereas it should throw an error and exit on an undefined variable.
Fixed in this PR