### PR TITLE
fix: removing empty keys from value skeleton

### DIFF
--- a/.values/env/charts/secrets.gitea.yaml
+++ b/.values/env/charts/secrets.gitea.yaml
@@ -1,3 +1,2 @@
 charts:
-    gitea:
-        postgresqlPassword:
+    gitea: {}

--- a/.values/env/charts/secrets.harbor.yaml
+++ b/.values/env/charts/secrets.harbor.yaml
@@ -1,11 +1,2 @@
 charts:
-    harbor:
-        core:
-            secret:
-            xsrfKey:
-        jobservice:
-            secret:
-        registry:
-            credentials:
-                secret:
-        secretKey:
+    harbor: {}

--- a/.values/env/charts/secrets.keycloak.yaml
+++ b/.values/env/charts/secrets.keycloak.yaml
@@ -1,5 +1,2 @@
 charts:
-    keycloak:
-        idp:
-            clientSecret:
-        postgresqlPassword:
+    keycloak: {}

--- a/.values/env/charts/secrets.kubeapps.yaml
+++ b/.values/env/charts/secrets.kubeapps.yaml
@@ -1,3 +1,2 @@
 charts:
-    kubeapps:
-        postgresqlPassword:
+    kubeapps: {}

--- a/.values/env/charts/secrets.loki.yaml
+++ b/.values/env/charts/secrets.loki.yaml
@@ -1,3 +1,2 @@
 charts:
-    loki:
-        adminPassword:
+    loki: {}

--- a/.values/env/charts/secrets.oauth2-proxy.yaml
+++ b/.values/env/charts/secrets.oauth2-proxy.yaml
@@ -1,4 +1,2 @@
 charts:
-    oauth2-proxy:
-        config:
-            cookieSecret:
+    oauth2-proxy: {}

--- a/.values/env/cluster.yaml
+++ b/.values/env/cluster.yaml
@@ -1,9 +1,1 @@
-cluster:
-    apiName:
-    apiServer:
-    domainSuffix:
-    k8sVersion:
-    name:
-    owner:
-    provider:
-    region:
+cluster: {}

--- a/chart/otomi/localtest.sh
+++ b/chart/otomi/localtest.sh
@@ -6,14 +6,14 @@ set -e
 function run_core() {
   image=$1
   shift
-  docker run --rm -it --env-file=../.env -e VERBOSE=1 -e IN_DOCKER=1 -e CI=1 -e OTOMI_VERSION=$OTOMI_VERSION -e OTOMI_VALUES_INPUT=/secret/values.yaml -w ${WORKDIR:-$PWD} -e ENV_DIR=/home/app/stack/env -v $ENV_OUT:/home/app/stack/env -v $PWD:$PWD -v $VALUES_DIR:/secret -v /tmp:/tmp $image "$@"
+  docker run --rm -it --env-file=$HOME/opt/.sops-secrets -e VERBOSE=1 -e IN_DOCKER=1 -e CI=1 -e OTOMI_VERSION=$OTOMI_VERSION -e OTOMI_VALUES_INPUT=/secret/values.yaml -w ${WORKDIR:-$PWD} -e ENV_DIR=/home/app/stack/env -v $ENV_OUT:/home/app/stack/env -v $PWD:$PWD -v $VALUES_DIR:/secret -v /tmp:/tmp $image "$@"
 }
 
 function run_task() {
   docker run --rm -it -e OTOMI_ENV_DIR=/env -e IN_DOCKER=1 -e CI=1 -e OTOMI_VALUES_INPUT=/secret/values.yaml -e OTOMI_SCHEMA_PATH=/env/values-schema.yaml -v $ENV_OUT:/env -v $VALUES_DIR:/secret -v /tmp:/tmp otomi/tasks:master "$@"
 }
 
-coreTag=chart-schema
+coreTag=master
 
 run_core otomi/core:$coreTag bash -c "$(cat chart/otomi/scripts/bootstrap-values.sh)"
 

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -43,7 +43,7 @@ env:
   GIT_REPO_URL: {{ $o | get "git.repoUrl" $giteaValuesUrl }}
   GIT_BRANCH: {{ $o | get "git.branch" "main" }}
   CLUSTER_ID: {{ printf "%s/%s" $c.provider $c.name }}
-  CLUSTER_NAME: {{ $c.apiName }}
+  CLUSTER_NAME: {{ $c | get "apiName" "api" }}
   CLUSTER_APISERVER: {{ $c.apiServer }}
   {{- if hasKey $o "disableSync" }}
   DISABLE_SYNC: true

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -42,9 +42,6 @@ env:
   VERBOSE: '1'
   GIT_REPO_URL: {{ $o | get "git.repoUrl" $giteaValuesUrl }}
   GIT_BRANCH: {{ $o | get "git.branch" "main" }}
-  CLUSTER_ID: {{ printf "%s/%s" $c.provider $c.name }}
-  CLUSTER_NAME: {{ $c | get "apiName" "api" }}
-  CLUSTER_APISERVER: {{ $c.apiServer }}
   {{- if hasKey $o "disableSync" }}
   DISABLE_SYNC: true
   {{- end }}


### PR DESCRIPTION
Empty keys in value skeleton makes validation problem after merging with otomi chart values if user doesn't provide values for those empty keys. 