### PR TITLE
fix: 🐛 Fixes sourcing secrets file - #517

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@hkdobrev/run-if-changed": "^0.3.1",
         "@types/debug": "^4.1.5",
         "@types/express": "^4.17.13",
+        "@types/ignore-walk": "^3.0.2",
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^15.12.4",
         "@types/tar": "^4.0.4",
@@ -1282,6 +1283,15 @@
       "dev": true,
       "dependencies": {
         "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ignore-walk": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ignore-walk/-/ignore-walk-3.0.2.tgz",
+      "integrity": "sha512-piannjEnKe/Ka68B2kz6lhs/Yv7T7aKgMGaqfZ4IZUK18KUk4VS1cpke+8s76JjNigFWcOydfG/KKnAuxmWTFA==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -12280,6 +12290,15 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/ignore-walk": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ignore-walk/-/ignore-walk-3.0.2.tgz",
+      "integrity": "sha512-piannjEnKe/Ka68B2kz6lhs/Yv7T7aKgMGaqfZ4IZUK18KUk4VS1cpke+8s76JjNigFWcOydfG/KKnAuxmWTFA==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@hkdobrev/run-if-changed": "^0.3.1",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.13",
+    "@types/ignore-walk": "^3.0.2",
     "@types/js-yaml": "^4.0.1",
     "@types/node": "^15.12.4",
     "@types/tar": "^4.0.4",

--- a/src/common/envalid.ts
+++ b/src/common/envalid.ts
@@ -1,8 +1,8 @@
-import { parse } from 'dotenv'
+import { DotenvParseOutput, parse } from 'dotenv'
 import { bool, cleanEnv, json, str } from 'envalid'
 import { existsSync, readFileSync } from 'fs'
 
-export const dotEnvParse = (path: string): void => {
+export const dotEnvParse = (path: string): DotenvParseOutput => {
   if (!existsSync(path)) {
     throw new Error(`${path} does not exist.`)
   }
@@ -15,6 +15,7 @@ export const dotEnvParse = (path: string): void => {
     process.env[k] = v
     return v
   })
+  return result
 }
 
 const cleanSpec = {


### PR DESCRIPTION
This PR fixes #517 
We cannot rely on just dotenv, since it cannot & will not parse lines that start with `export `
This change works around it :)