### PR TITLE
Quickfix otomi server start 

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,8 @@ import { Server } from 'http'
 import { commit } from '../cmd/commit'
 import { validateValues } from '../cmd/validate-values'
 import { decrypt, encrypt } from '../common/crypt'
-import { terminal } from '../common/utils'
+import { env } from '../common/envalid'
+import { rootDir, terminal } from '../common/utils'
 
 const debug = terminal('server')
 const app = express()
@@ -57,10 +58,10 @@ app.get('/commit', async (req: Request, res: Response) => {
   }
 })
 
-export const startServer = async (): Promise<void> => {
+export const startServer = (): void => {
   server = app.listen(17771, '0.0.0.0')
-  const k8sEnvDirPath = '/tmp/otomi-values'
-  const dockerEnvDir = '/home/app/stack/env'
+  const k8sEnvDirPath = env.ENV_DIR
+  const dockerEnvDir = `${rootDir}/env`
   // accomodate k8s deployment with shared values dir, and make symlink to /home/app/stack/env
   if (k8sEnvDirPath && !existsSync(k8sEnvDirPath)) {
     debug.info('Creating k8s values folder for symlink: ', k8sEnvDirPath)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,7 +59,6 @@ app.get('/commit', async (req: Request, res: Response) => {
 })
 
 export const startServer = (): void => {
-  server = app.listen(17771, '0.0.0.0')
   const k8sEnvDirPath = env.ENV_DIR
   const dockerEnvDir = `${rootDir}/env`
   // accomodate k8s deployment with shared values dir, and make symlink to /home/app/stack/env
@@ -71,6 +70,7 @@ export const startServer = (): void => {
       symlinkSync(k8sEnvDirPath, dockerEnvDir)
     }
   }
+  server = app.listen(17771, '0.0.0.0')
   debug.log(`Container listening on http://0.0.0.0:17771`)
 }
 


### PR DESCRIPTION
Point to `ENV_DIR`, doesn't need to be hardcoded as it is passed to ENV_DIR as well.
Idem for `rootDir`
