### PR TITLE
fix: otomi server create symlink

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -278,6 +278,7 @@ fi
 mkdir -p /tmp/otomi
 container_name='otomi-core-dev-container'
 count=$(ps -a | grep $container_name | wc -l) >/dev/null
+count=$(($count))
 container_name="$container_name-$count"
 
 if [ -n "$IN_DOCKER" ]; then

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -65,10 +65,10 @@ export const startServer = (): void => {
   if (k8sEnvDirPath && !existsSync(k8sEnvDirPath)) {
     debug.info('Creating k8s values folder for symlink: ', k8sEnvDirPath)
     mkdirSync(k8sEnvDirPath)
-    if (!existsSync(dockerEnvDir)) {
-      debug.info(`Creating symlink from ${k8sEnvDirPath} to ${dockerEnvDir}`)
-      symlinkSync(k8sEnvDirPath, dockerEnvDir)
-    }
+  }
+  if (!existsSync(dockerEnvDir)) {
+    debug.info(`Creating symlink from ${k8sEnvDirPath} to ${dockerEnvDir}`)
+    symlinkSync(k8sEnvDirPath, dockerEnvDir)
   }
   server = app.listen(17771, '0.0.0.0')
   debug.log(`Container listening on http://0.0.0.0:17771`)


### PR DESCRIPTION
#256
Fix server symlink, needs to check for symlink even if ENV_DIR exists.
Also add fix for @mojtabaimani's `wc -l` containing spaces issue