### PR TITLE
Disable non-OIDC gitea user registration

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -57,7 +57,7 @@ gitea:
       {{- toYaml . | nindent 4}}
     {{- end }}
     service:
-      DISABLE_REGISTRATION: true
+      ALLOW_ONLY_EXTERNAL_REGISTRATION: true
     server:
       DOMAIN: {{ $giteaDomain }}
       ROOT_URL: "https://{{ $giteaDomain }}/"

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -50,11 +50,14 @@ gitea:
       LEVEL: trace
     openid:
       ENABLE_OPENID_SIGNIN: true
+      ENABLE_OPENID_SIGNUP: true
     repository:
       DEFAULT_BRANCH: main
     {{- with $g | get "config" nil }}
       {{- toYaml . | nindent 4}}
     {{- end }}
+    service:
+      DISABLE_REGISTRATION: true
     server:
       DOMAIN: {{ $giteaDomain }}
       ROOT_URL: "https://{{ $giteaDomain }}/"


### PR DESCRIPTION
Based on #591 any user was able to register.

Now only OIDC users are allowed to register, thus limiting the users allowed by keycloak.
The admin user can still sign-in.

Deployed on eks-dev, so you can see it in live environment.

Closes #591 