### PR TITLE
fix: 🐛 Package is not core if /home/app/stack path is used

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -49,15 +49,14 @@ docker_tag_exists() {
 # shellcheck disable=SC2155
 readonly base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-packageIsCore() {
+package_is_core() {
   path=$1
-  [[ $path == "/home/app/stack"* ]] && return 1
-  [ ! -f "$path/package.json" ] && return 1
+  { [ "$path" = "/home/app/stack" ] || [ ! -f "$path/package.json" ]; } && return 1
   packageName=$(grep name "$path/package.json" | sed 's/.*"name": "\(.*\)".*/\1/')
-  [[ $packageName == 'otomi-core' ]] && return 0 || return 1
+  [ $packageName = 'otomi-core' ] && return 0 || return 1
 }
 
-if [ -z $CI ] && packageIsCore $(pwd); then
+if [ -z $CI ] && package_is_core $(pwd); then
   in_core=1
   core_path=$(pwd)
 fi

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -51,6 +51,7 @@ readonly base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 packageIsCore() {
   path=$1
+  [[ $path == "/home/app/stack"* ]] && return 1
   [ ! -f "$path/package.json" ] && return 1
   packageName=$(grep name "$path/package.json" | sed 's/.*"name": "\(.*\)".*/\1/')
   [[ $packageName == 'otomi-core' ]] && return 0 || return 1


### PR DESCRIPTION
Issue messaged to me by @srodenhuis 
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ts-node' imported from /home/app/stack/
    at new NodeError (node:internal/errors:363:5)
    at packageResolve (node:internal/modules/esm/resolve:712:9)
    at moduleResolve (node:internal/modules/esm/resolve:753:18)
    at Loader.defaultResolve [as _resolve] (node:internal/modules/esm/resolve:867:11)
    at Loader.resolve (node:internal/modules/esm/loader:89:40)
    at Loader.getModuleJob (node:internal/modules/esm/loader:242:28)
    at Loader.import (node:internal/modules/esm/loader:177:28)
    at node:internal/process/esm_loader:57:31
    at initializeLoader (node:internal/process/esm_loader:62:5)
    at Object.loadESM (node:internal/process/esm_loader:67:11) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

This has to do that `/home/app/stack` also contains a package.json with `otomi-core` in it. So we must make sure that that path is omitted when checking if we are working in core (aka. dev mode)

Because the container doesn't install the devDependencies (such as `ts-node`)