### PR TITLE
fix: 🐛 Bug where tr can't parse /dev/urandom force UTF-8 chars

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -303,7 +303,8 @@ if [[ $calling_args == 'server'* ]]; then
 fi
 
 mkdir -p /tmp/otomi
-container_name="otomi-core-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)"
+# Issue arises due to OSX not assuming UTF-8 format: https://unix.stackexchange.com/a/64905 need to set LC_ALL=C
+container_name="otomi-core-$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)"
 
 if [ -n "$IN_DOCKER" ]; then
   silent echo $cmd


### PR DESCRIPTION
By changing LC_ALL=C. Issue found by @mojtabaimani