### PR TITLE
Fix ambiguous error on bootstrap

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -14,7 +14,6 @@
 # shellcheck disable=SC2128
 [ "${BASH_VERSINFO:-0}" -lt 4 ] && echo "You are using $BASH_VERSINFO, while we only support Bash -ge than version 4. Please upgrade." && exit 1
 calling_args="$*"
-
 if [ -n "$TESTING" ]; then
   CI=1
   ENV_DIR="$PWD/tests/fixtures"
@@ -320,6 +319,7 @@ else
     $(check_volume_path $ENV_DIR "$stack_dir/env") \
     $(check_volume_path $ENV_DIR "$ENV_DIR") \
     $(check_volume_path /var/run/docker.sock "/var/run/docker.sock") \
+    $DOCKER_EXTRA_ARGS \
     --env-file "$tmp_env" \
     -w "$stack_dir" \
     "$otomi_tools_image" \

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -124,10 +124,12 @@ const copyBasicFiles = async (): Promise<void> => {
 const processValues = async (): Promise<Record<string, any>> => {
   let originalValues: Record<string, any>
   if (isChart) {
+    console.debug(`Loading values from ${env.VALUES_INPUT}`)
     originalValues = loadYaml(env.VALUES_INPUT) as Record<string, any>
     // store chart input values, so they can be merged with gerenerated passwords
     await writeValues(originalValues)
   } else {
+    console.debug(`Loading values from ${env.ENV_DIR}`)
     originalValues = (await getCurrentValues()) as Record<string, any>
   }
   const generatedSecrets = await getOtomiSecrets(originalValues)

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -124,12 +124,12 @@ const copyBasicFiles = async (): Promise<void> => {
 const processValues = async (): Promise<Record<string, any>> => {
   let originalValues: Record<string, any>
   if (isChart) {
-    console.debug(`Loading values from ${env.VALUES_INPUT}`)
+    console.debug(`Loading chart values from ${env.VALUES_INPUT}`)
     originalValues = loadYaml(env.VALUES_INPUT) as Record<string, any>
     // store chart input values, so they can be merged with gerenerated passwords
     await writeValues(originalValues)
   } else {
-    console.debug(`Loading values from ${env.ENV_DIR}`)
+    console.debug(`Loading repo values from ${env.ENV_DIR}`)
     originalValues = (await getCurrentValues()) as Record<string, any>
   }
   const generatedSecrets = await getOtomiSecrets(originalValues)

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -300,7 +300,7 @@ export const flattenObject = (obj: Record<string, any>, path = ''): { [key: stri
   return Object.entries(obj)
     .flatMap(([key, value]) => {
       const subPath = path.length ? `${path}.${key}` : key
-      if (typeof value === 'object' && !Array.isArray(value)) return flattenObject(value, subPath)
+      if (typeof value === 'object' && !Array.isArray(value) && value !== null) return flattenObject(value, subPath)
       return { [subPath]: value }
     })
     .reduce((acc, base) => {
@@ -463,8 +463,9 @@ export const createK8sSecret = async (
   const rawString = dump(data)
   const path = `/tmp/${name}`
   writeFileSync(path, rawString)
-  const result =
-    await $`kubectl create secret generic ${name} -n ${namespace} --from-file ${path} --dry-run=client -o yaml | kubectl apply -f -`
+  const result = await nothrow(
+    $`kubectl create secret generic ${name} -n ${namespace} --from-file ${path} --dry-run=client -o yaml | kubectl apply -f -`,
+  )
   if (result.stderr) debug.error(result.stderr)
   debug.debug(`kubectl create secret output: \n ${result.stdout}`)
 }


### PR DESCRIPTION
Some folks has experienced the following error while bootstrapping values
```
TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at Object.flattenObject (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:300:17)
    at /Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:303:70
    at Array.flatMap (<anonymous>)
    at Object.flattenObject (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:301:6)
    at /Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:303:70
    at Array.flatMap (<anonymous>)
    at Object.flattenObject (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:301:6)
    at Object.gucci (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:318:14)
    at Object.generateSecrets (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:446:38)
```

This error could occur if values are defined as follows 
```
charts:
  drone:
```

The error occurred because `null` is also an object in JS world.



I also add DOCKER_EXTRA_ARGS which helps me mounting extra volume and adding other extra docker arguments.