### PR TITLE
Waitfor keycloak

### DIFF
--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -1,5 +1,7 @@
 {{- $v := .Values }}
 {{- $c := $v.charts }}
+{{- $o := $v.oidc }}
+{{- $k := $c.keycloak }}
 {{- $cm := index $v.charts "cert-manager" }}
 {{- $versions := (readFile "../versions.yaml" | fromYaml) }}
 {{- $pkgVersion := (readFile "../package.json") | regexFind "\"version\": \"([0-9.]+)\"" | regexFind "[0-9]+.[0-9]+.[0-9]+" }}
@@ -31,6 +33,19 @@ environments:
     values:
       - _derived: # < introduced to hold compound logic in meaningful prop names for easier consumption
           untrustedCA: {{ or (eq $issuer "custom-ca") (and (eq $issuer "letsencrypt") (eq ($cm | get "stage" "") "staging")) }}
+          {{- if $c.keycloak.enabled }}
+          openidName: {{ $k | get "idp.alias" "otomi-idp" }}
+          openidBaseUrl: {{ printf "https://keycloak.%s/realms/otomi" $domainSuffix }}
+          openIdWellKnownUrl: {{ printf "https://keycloak.%s/realms/otomi/.well-known/openid-configuration" $domainSuffix }}
+          openIdClientId: {{ $k.idp.clientID  }}
+          openIdClientSecret: {{ $k.idp.clientSecret }}
+          {{- else }}
+          openidName: "otomi"
+          openidBaseUrl: {{ $o | get "issuer" nil }}
+          openIdWellKnownUrl: {{ printf "%s/.well-known/openid-configuration" ($o | get "issuer" nil) }}
+          openIdClientId: {{ $o | get "clientID" nil }}
+          openIdClientSecret: {{ $o | get "clientSecret" nil }}
+          {{- end }}
         charts:
           aws-alb-ingress-controller:
             enabled: {{ and $v.otomi.hasCloudLB (eq $provider "aws") }}

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -1,7 +1,8 @@
 {{- $v := .Values }}
 {{- $c := $v.charts }}
-{{- $o := $v.oidc }}
-{{- $k := $c.keycloak }}
+{{- $k := $c | get "keycloak" dict }}
+{{- $o := $v | get "oidc" dict }}
+
 {{- $cm := index $v.charts "cert-manager" }}
 {{- $versions := (readFile "../versions.yaml" | fromYaml) }}
 {{- $pkgVersion := (readFile "../package.json") | regexFind "\"version\": \"([0-9.]+)\"" | regexFind "[0-9]+.[0-9]+.[0-9]+" }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "otomi-core",
       "version": "0.14.43",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -526,7 +526,7 @@ export const getOtomiLoadBalancerIP = async (): Promise<string> => {
   if (firstIngressData.ip) return firstIngressData.ip
   if (firstIngressData.hostname) {
     // Wait until DNS records are propagated to the cluster DNS
-    await waitTillAvailable(`https://${firstIngressData.hostname}`, { skipSsl: true })
+    await waitTillAvailable(`https://${firstIngressData.hostname}`, { skipSsl: true, status: 404 })
     const resolveData = await resolveAny(firstIngressData.hostname)
     const resolveDataFiltered = resolveData.filter((val) => val.type === 'A' || val.type === 'AAAA') as (
       | AnyARecord

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -526,7 +526,7 @@ export const getOtomiLoadBalancerIP = async (): Promise<string> => {
   if (firstIngressData.ip) return firstIngressData.ip
   if (firstIngressData.hostname) {
     // Wait until DNS records are propagated to the cluster DNS
-    await waitTillAvailable(`https://${firstIngressData.hostname}`)
+    await waitTillAvailable(`https://${firstIngressData.hostname}`, { skipSsl: true })
     const resolveData = await resolveAny(firstIngressData.hostname)
     const resolveDataFiltered = resolveData.filter((val) => val.type === 'A' || val.type === 'AAAA') as (
       | AnyARecord

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -525,6 +525,8 @@ export const getOtomiLoadBalancerIP = async (): Promise<string> => {
 
   if (firstIngressData.ip) return firstIngressData.ip
   if (firstIngressData.hostname) {
+    // Wait until DNS records are propagated to the cluster DNS
+    await waitTillAvailable(firstIngressData.hostname)
     const resolveData = await resolveAny(firstIngressData.hostname)
     const resolveDataFiltered = resolveData.filter((val) => val.type === 'A' || val.type === 'AAAA') as (
       | AnyARecord

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -526,7 +526,7 @@ export const getOtomiLoadBalancerIP = async (): Promise<string> => {
   if (firstIngressData.ip) return firstIngressData.ip
   if (firstIngressData.hostname) {
     // Wait until DNS records are propagated to the cluster DNS
-    await waitTillAvailable(firstIngressData.hostname)
+    await waitTillAvailable(`https://${firstIngressData.hostname}`)
     const resolveData = await resolveAny(firstIngressData.hostname)
     const resolveDataFiltered = resolveData.filter((val) => val.type === 'A' || val.type === 'AAAA') as (
       | AnyARecord

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -1,17 +1,13 @@
 {{- $v := .Values }}
 {{- $o := $v | get "oidc" dict }}
 {{- $g := $v.charts.gitea }}
-{{- $k := $v.charts.keycloak }}
-{{- $hasKeycloak := $k.enabled }}
-{{- $keycloakUrl := printf "https://keycloak.%s" $v.cluster.domainSuffix }}
-{{- $keycloakIssuer := printf "%s/realms/otomi" $keycloakUrl }}
 {{- $giteaDomain := printf "gitea.%s" $v.cluster.domainSuffix }}
 {{- $cm := $v.charts | get "cert-manager" }}
 
 
 nameOverride: gitea
 fullnameOverride: gitea
-waitForUrl: {{ $keycloakUrl }}
+waitForUrl: {{ $v._derived.openIdWellKnownUrl }}
 otomiVersion: {{ $v.otomi.version }}
 
 resources:
@@ -78,11 +74,11 @@ gitea:
         prometheus: system
   oauth:
     enabled: true
-    name: {{ $hasKeycloak | ternary ($k | get "idp.alias" "otomi-idp") "otomi" }}
+    name: {{ $v._derived.openidName }}
     provider: openidConnect
-    key: {{ $hasKeycloak | ternary $k.idp.clientID ($o | get "clientID" nil) }}
-    secret: {{ $hasKeycloak | ternary $k.idp.clientSecret ($o | get "clientSecret" nil) }}
-    autoDiscoverUrl: '{{ $hasKeycloak | ternary $keycloakIssuer ($o | get "issuer" nil) }}/.well-known/openid-configuration'
+    key: {{ $v._derived.openIdClientId }}
+    secret: {{ $v._derived.openIdClientSecret }}
+    autoDiscoverUrl: {{ $v._derived.openIdWellKnownUrl }}
 
 init:
   resources:

--- a/values/jobs/harbor.gotmpl
+++ b/values/jobs/harbor.gotmpl
@@ -13,7 +13,7 @@ runPolicy: OnSpecChange
 nativeSecrets:
   HARBOR_PASSWORD:  {{ $h | get "adminPassword" $v.otomi.adminPassword  }}
   HARBOR_USER: admin
-  OIDC_ENDPOINT: '{{ $v._derived.openidName }}'
+  OIDC_ENDPOINT: '{{ $v._derived.openidBaseUrl }}'
   OIDC_CLIENT_ID: {{ $v._derived.openIdClientId }}
   OIDC_CLIENT_SECRET: {{ $v._derived.openIdClientSecret }}
 

--- a/values/jobs/harbor.gotmpl
+++ b/values/jobs/harbor.gotmpl
@@ -2,10 +2,7 @@
 {{- $c := $v.charts }}
 {{- $o := $v | get "oidc" dict }}
 {{- $h := $c.harbor }}
-{{- $k := $c.keycloak }}
 {{- $ns := $v.otomi.hasCloudLB | ternary "ingress" "istio-system" }}
-{{- $hasKeycloak := $k | get "enabled" }}
-{{- $keycloakIssuer := printf "https://keycloak.%s/realms/otomi" $v.cluster.domainSuffix }}
 {{- $harborRepo := printf "harbor.%s" $v.cluster.domainSuffix }}
 {{- $teams := keys $v.teamConfig.teams }}
 
@@ -16,15 +13,10 @@ runPolicy: OnSpecChange
 nativeSecrets:
   HARBOR_PASSWORD:  {{ $h | get "adminPassword" $v.otomi.adminPassword  }}
   HARBOR_USER: admin
-  {{- if $hasKeycloak }}
-  OIDC_ENDPOINT: '{{ $keycloakIssuer }}'
-  OIDC_CLIENT_ID: {{ $k.idp.clientID }}
-  OIDC_CLIENT_SECRET: {{ $k.idp.clientSecret }}
-  {{- else }}
-  OIDC_ENDPOINT: '{{ $o.issuer }}'
-  OIDC_CLIENT_ID: {{ $o.clientID }}
-  OIDC_CLIENT_SECRET: {{ $o.clientSecret }}
-  {{- end }}
+  OIDC_ENDPOINT: '{{ $v._derived.openidName }}'
+  OIDC_CLIENT_ID: {{ $v._derived.openIdClientId }}
+  OIDC_CLIENT_SECRET: {{ $v._derived.openIdClientSecret }}
+
 env:
   DEBUG: '*'
   HARBOR_BASE_URL: http://harbor-core.harbor

--- a/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
@@ -1,8 +1,6 @@
 {{- $v := .Values }}
 {{- $domain := printf "auth.%s" $v.cluster.domainSuffix }}
 {{- $cm := $v.charts | get "cert-manager" }}
-{{- $k := $v.charts.keycloak }}
-{{- $hasKeycloak := $k.enabled }}
 {{- $name := $domain | replace "." "-" }}
 resources:
   - apiVersion: networking.k8s.io/v1beta1
@@ -18,7 +16,7 @@ resources:
         {{- end }}
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: {{ if $v.otomi.hasCloudLB }}"false"{{ else }}"true"{{ end }}
-        {{- if $hasKeycloak }}
+        {{- if $v.charts.keycloak.enabled }}
         nginx.ingress.kubernetes.io/auth-response-headers: Authorization
         {{- end }}
         nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -4,8 +4,6 @@
 {{- $oauth2 := $v.charts | get "oauth2-proxy" }}
 {{- $r := $v.charts | get "oauth2-proxy-redis" }}
 {{- $o := $v | get "oidc" dict }}
-{{- $hasKeycloak := $k.enabled }}
-{{- $keycloakIssuer := printf "https://keycloak.%s/realms/otomi" $v.cluster.domainSuffix }}
 {{- $joinTpl := readFile "../../helmfile.d/utils/joinListWithSep.gotmpl" }}
 
 image:
@@ -13,8 +11,8 @@ image:
   repository: quay.io/oauth2-proxy/oauth2-proxy
 
 config:
-  clientID: {{ $hasKeycloak | ternary $k.idp.clientID ($o | get "clientID" nil) }}
-  clientSecret: {{ $hasKeycloak | ternary $k.idp.clientSecret ($o | get "clientSecret" nil) }}
+  clientID: {{ $v._derived.openIdClientId }}
+  clientSecret: {{ $v._derived.openIdClientSecret }}
   cookieSecret: {{ $oauth2 | get "config.cookieSecret" (randAlpha 16) }}
 
 replicas: 2
@@ -80,7 +78,7 @@ extraArgs:
   # exclude-logging-paths: /ping
   set-authorization-header: true
   # set-xauthrequest: true
-  oidc-issuer-url: {{ $hasKeycloak | ternary $keycloakIssuer ($o | get "issuer" nil) }}
+  oidc-issuer-url: {{ $v._derived.openidBaseUrl }}
   insecure-oidc-allow-unverified-email: true
   show-debug-on-error: true
 

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -2,7 +2,6 @@
 {{- $c := $v.cluster }}
 {{- $o := $v.charts | get "otomi-api" }}
 {{- $g := $v.charts.gitea }}
-{{- $k := $v.charts.keycloak }}
 {{- $cm := $v.charts | get "cert-manager" }}
 {{- $sops := $v | get "kms.sops" dict }}
 {{- $hasGitea := $g.enabled }}

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -4,11 +4,10 @@
 {{- $o := $v | get "oidc" dict }}
 {{- $p := $v.charts | get "prometheus-operator" }}
 {{- $hasKeycloak := $k.enabled }}
-{{- $keycloakBase := printf "https://keycloak.%s/realms/otomi" $v.cluster.domainSuffix }}
 {{- $appsDomain := printf "apps.%s" $v.cluster.domainSuffix }}
 {{- $grafanaDomain := printf "grafana.%s" $v.cluster.domainSuffix }}
 {{- $slackTpl := tpl (readFile "../../helmfile.d/snippets/slack.gotmpl") $v | toString }}
-{{- $grafanaIni := tpl (readFile "../../helmfile.d/snippets/grafana.gotmpl") (dict "keycloakBase" $keycloakBase "hasKeycloak" $hasKeycloak "oidc" $o "untrustedCA" $v._derived.untrustedCA "keycloak" ($k | get "idp")) | toString }}
+{{- $grafanaIni := tpl (readFile "../../helmfile.d/snippets/grafana.gotmpl") (dict "keycloakBase" $v._derived.openidBaseUrl "hasKeycloak" $hasKeycloak "oidc" $o "untrustedCA" $v._derived.untrustedCA "keycloak" ($k | get "idp")) | toString }}
 
 nameOverride: po
 fullnameOverride: po

--- a/values/vault-operator/vault-operator-raw.gotmpl
+++ b/values/vault-operator/vault-operator-raw.gotmpl
@@ -1,5 +1,4 @@
 {{- $v := .Values }}
-{{- $k := $v.charts.keycloak }}
 {{- $tc := $v.teamConfig }}
 {{- $vault := $v.charts.vault }}
 {{- $seal := $vault | get "seal"  (dict "type" "default") }}
@@ -148,9 +147,9 @@ resources:
         auth:
           - type: oidc
             config:
-              oidc_discovery_url: https://keycloak.{{ $v.cluster.domainSuffix }}/realms/otomi
-              oidc_client_id: {{ $k.idp.clientID }}
-              oidc_client_secret: {{ $k.idp.clientSecret }}
+              oidc_discovery_url: {{ $v._derived.openidBaseUrl }}
+              oidc_client_id: {{ $v._derived.openIdClientId }}
+              oidc_client_secret: {{ $v._derived.openIdClientSecret }}
               namespace_in_state: true
               default_role: team
             roles:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.


This PR contains fixes for:
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/redkubes/otomi-core/483
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/redkubes/unassigned-issues/352

Moved logic for deriving openId settings to `_derived` property

I did test on AWS with quickstart and saw that issue with gitea is gone. 
And I also observed that otomi apply is waiting for DNS record propagation.

Since these issues were caused by some race condition, I would like to ask you test it as well before merging.


Feel free to contribute to this PR to make it better;)