### PR TITLE
fix: gatekeeper post job

### DIFF
--- a/charts/gatekeeper-operator/templates/post-job.yaml
+++ b/charts/gatekeeper-operator/templates/post-job.yaml
@@ -28,9 +28,8 @@ spec:
             - -c
           args:
             - |
-              {{ if .Values.untrustedCA }}export INSECURE='--insecure'{{ end }}
               echo "Waiting until admission webhook service is accessible"
-              until $(curl $INSECURE --output /dev/null --silent --head -I {{ $hookUrl }}); do 
+              until $(curl --insecure --output /dev/null --silent --head -I {{ $hookUrl }}); do 
                 printf '.'
                 sleep 5
               done


### PR DESCRIPTION
Gatekeeper issues its own local certificates, so job always use --insecure flag
## Checklist

- [x] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
