### PR TITLE
Revert "fix: harbor login (#661)"

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1406,7 +1406,7 @@ properties:
                 properties:
                   htpasswd:
                     type: string
-                    x-secret: 'htpasswd -nbBC10 .dot.username (.dot.password | default .o.adminPassword)'
+                    x-secret: 'htpasswd .dot.username (.dot.password | default .o.adminPassword)'
                   username:
                     type: string
                     $ref: '#/definitions/secretTemplates/definitions/otomiAdminUsername'


### PR DESCRIPTION
This reverts commit d2af293ba179964e45ac77aa158608aee1e2b977.

Unfortunately the sprig implementation of htpasswd function does not support arguments:
```
  otomi:generateSecrets:info Second round of templating +2ms
  otomi:global:error Error: Error parsing template(s): template: -:33: bad number syntax: "-n"
  otomi:global:error     at Object.gucci (/Users/jehoszafatzimnowoda/workspace/otomi/otomi-core/src/common/utils.ts:335:30)                                   
```

See alos:
http://masterminds.github.io/sprig/crypto.html#htpasswd
https://github.com/Masterminds/sprig/commit/173256c8049ac8beac7984a7a51f5361c1c5078c