### PR TITLE
fix: ensure path existence

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1406,13 +1406,13 @@ properties:
                 properties:
                   htpasswd:
                     type: string
-                    x-secret: 'htpasswd .dot.username (.dot.password | default .o.adminPassword)'
+                    x-secret: 'htpasswd .dot.username .dot.password'
                   username:
                     type: string
                     $ref: '#/definitions/secretTemplates/definitions/otomiAdminUsername'
                   password:
                     type: string
-                    x-secret: ''
+                    x-secret: 'randAlphaNum 32'
             required:
               - secret
               - credentials


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
