### PR TITLE
feat: expose values for knative serving replicas

### DIFF
--- a/chart/otomi/values-production.yaml
+++ b/chart/otomi/values-production.yaml
@@ -1,0 +1,15 @@
+charts:
+  istio:
+    autoscaling:
+      pilot:
+        minReplicas: 2
+  knative:
+    serving:
+      # See: https://github.com/knative/operator/issues/376
+      replicas: 5
+  nginx-ingress:
+    autoscaling:
+      minReplicas: 2
+    private:
+      autoscaling:
+        minReplicas: 2

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -44,6 +44,7 @@ environments:
             autoscaling:
               pilot:
                 minReplicas: 1
+                maxReplicas: 10
           jaeger:
             enabled: true
           keycloak:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -40,6 +40,10 @@ environments:
             enabled: false
           httpbin:
             enabled: false
+          istio:
+            autoscaling:
+              pilot:
+                minReplicas: 1
           jaeger:
             enabled: true
           keycloak:
@@ -48,6 +52,9 @@ environments:
             theme: otomi
           kiali:
             enabled: true
+          knative:
+            serving:
+              replicas: 1
           kubeapps:
             enabled: false
           kube-descheduler:
@@ -56,8 +63,14 @@ environments:
             enabled: true
           loki: {}
           nginx-ingress:
+            autoscaling:
+              minReplicas: 1
+              maxReplicas: 10
             private:
               enabled: false
+              autoscaling:
+                minReplicas: 1
+                maxReplicas: 6
           oauth2-proxy: {}
           oauth2-proxy-redis: {}
           otomi-api: {}

--- a/tests/fixtures/env/charts/knative.yaml
+++ b/tests/fixtures/env/charts/knative.yaml
@@ -1,0 +1,4 @@
+charts:
+    knative:
+        serving:
+            replicas: 5

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1641,6 +1641,17 @@ properties:
             type: string
         required:
           - postgresqlPassword
+      knative:
+        additionalProperties: false
+        properties:
+          serving:
+            type: object
+            properties:
+              replicas:
+                description: For HA mode set to 5. Read more at https://github.com/knative/operator/issues/376
+                default: 1
+                type: integer
+                minimum: 1
       kubeapps:
         additionalProperties: false
         properties:

--- a/values/istio-operator/istio-operator-raw.gotmpl
+++ b/values/istio-operator/istio-operator-raw.gotmpl
@@ -31,8 +31,8 @@ resources:
               sidecar.istio.io/inject: "true"
             priorityClassName: "otomi-critical"
             hpaSpec:
-              minReplicas: {{ $i | get "autoscaling.pilot.minReplicas" 2 }}
-              maxReplicas: {{ $i | get "autoscaling.pilot.maxReplicas" 10 }}
+              minReplicas: {{ $i.autoscaling.pilot.minReplicas }}
+              maxReplicas: {{ $i.autoscaling.pilot.maxReplicas }}
             resources:
               {{- with $i | get "resources.pilot" nil }}
                 {{- toYaml . | nindent 14 }}

--- a/values/knative/knative-serving-raw.gotmpl
+++ b/values/knative/knative-serving-raw.gotmpl
@@ -7,11 +7,8 @@ resources:
       namespace: knative-serving
     spec:
       version: 0.23.0
-      # Temporary increase # of replicas, related to issue: https://github.com/knative/operator/issues/376 
-      # if replicas <5 then pods cannot be evicted (due to pdb) 
-      # TODO: revisit this to check if pdb is made configurable in operator
       high-availability:
-        replicas: 5
+        replicas: {{ $v.charts.knative.serving.replicas }}
       config:
         defaults:
           revision-timeout-seconds: "300"  # 5 minutes

--- a/values/nginx-ingress/nginx-ingress-private.gotmpl
+++ b/values/nginx-ingress/nginx-ingress-private.gotmpl
@@ -15,8 +15,8 @@ controller:
         memory: 512Mi
     {{- end }}
   autoscaling:
-    minReplicas: {{ $n | get "private.autoscaling.minReplicas" 2 }}
-    maxReplicas: {{ $n | get "private.autoscaling.maxReplicas" 6 }}
+    minReplicas: {{ $n.private.autoscaling.minReplicas }}
+    maxReplicas: {{ $n.private.autoscaling.maxReplicas }}
   service:
     loadBalancerIP: {{ $n | get "private.loadBalancerIP" nil }}
     {{ if or ($n | get "private.loadBalancerRG" nil) ($n | get "private.service.annotations" nil) }}

--- a/values/nginx-ingress/nginx-ingress.gotmpl
+++ b/values/nginx-ingress/nginx-ingress.gotmpl
@@ -34,8 +34,8 @@ controller:
   minAvailable: 1
   autoscaling:
     enabled: {{ $n | get "autoscaling.enabled" true }}
-    minReplicas: {{ $n | get "autoscaling.minReplicas" 2 }}
-    maxReplicas: {{ $n | get "autoscaling.maxReplicas" 10 }}
+    minReplicas: {{ $n.autoscaling.minReplicas }}
+    maxReplicas: {{ $n.autoscaling.maxReplicas }}
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 75
 {{- if eq $v.cluster.provider "azure" }}


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.

https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/redkubes/otomi-console/123

If this is approved then I will make another PR to otomi-api