### PR TITLE
fix: api and console only need podsecuritycontext

### DIFF
--- a/charts/otomi-api/templates/deployment.yaml
+++ b/charts/otomi-api/templates/deployment.yaml
@@ -32,7 +32,6 @@ spec:
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
@@ -61,9 +60,7 @@ spec:
             - name: core-values
               mountPath: /etc/otomi/core.yaml
               subPath: core.yaml
-        {{- if .Values.tools.enabled }}
         - name: {{ .Chart.Name }}-tools
-          securityContext: {{- toYaml .Values.tools.securityContext | nindent 12 }}
           image: "{{ .Values.tools.image.registry }}/{{ .Values.tools.image.repository }}:{{ .Values.tools.image.tag }}"
           imagePullPolicy: {{ .Values.tools.image.pullPolicy }}
           command: ['sh']
@@ -89,7 +86,6 @@ spec:
           volumeMounts:
             - name: repo
               mountPath: /tmp
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/otomi-api/values.yaml
+++ b/charts/otomi-api/values.yaml
@@ -89,15 +89,11 @@ env:
 core: {}
 
 tools:
-  enabled: true
   image:
     registry: docker.io
     repository: otomi/core
     tag: latest
     pullPolicy: IfNotPresent
-
-  securityContext:
-    runAsUser: 999
 
   resources: {}
     # limits:

--- a/charts/otomi-console/templates/deployment.yaml
+++ b/charts/otomi-console/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.env }}

--- a/charts/otomi-console/values.yaml
+++ b/charts/otomi-console/values.yaml
@@ -23,13 +23,6 @@ serviceAccount:
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-
 service:
   type: ClusterIP
   port: 80

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -94,7 +94,7 @@ tools:
     VERBOSITY: '1'
 
 podSecurityContext:
-  runAsUser: 1000
+  runAsUser: 999
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}
 imagePullSecrets:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
