### PR TITLE
Fix removing authz header

### DIFF
--- a/charts/team-ns/templates/istio-virtualservices.yaml
+++ b/charts/team-ns/templates/istio-virtualservices.yaml
@@ -78,12 +78,15 @@ spec:
           {{- end }}
             port:
               number: {{ $s.port | default 80 }}
-      # fix for istio (=envoy) incorrectly setting proto to http
-      # (@see https://github.com/istio/istio/issues/7964):
           headers:
             request:
               set:
+                # fix for istio (=envoy) incorrectly setting proto to http
+                # (@see https://github.com/istio/istio/issues/7964):
                 X-Forwarded-Proto: https
+              {{- if hasKey $s "removeRequestHeaders" }}
+              remove: {{- $s.removeRequestHeaders | toYaml | nindent 16 }}
+              {{- end }}
         {{- end }}
 ---
         {{- if and ($hasAuth) (hasKey $s "authz") }}

--- a/core.yaml
+++ b/core.yaml
@@ -178,13 +178,9 @@ services:
     svc: po-grafana
     ownHost: true
     namespace: monitoring
-    # specifying authz will strip the bearer token by default, unless forwardOriginalToken=true
-    # this mechanism allows us to not bother services that need the same "Bearer" header for their own oidc
-    # it also adds an in-cluster enforcement that only payloads containing the right authn may access it
-    authz:
-      workload:
-        app.kubernetes.io/instance: prometheus-operator
-        app.kubernetes.io/name: po-grafana
+    removeRequestHeaders:
+      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
+      - authorization
     type: public
     isShared: true
     auth: true
@@ -209,6 +205,7 @@ services:
     type: public
     auth: true
     removeRequestHeaders:
+      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
       - authorization
   - name: drone
     svc: drone
@@ -218,6 +215,9 @@ services:
     type: public
     paths: [/hook, /api/user, /api/repo]
     forwardPath: true
+    removeRequestHeaders:
+      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
+      - authorization
   - name: jaeger
     svc: jaeger-operator-jaeger-query
     port: 16686

--- a/core.yaml
+++ b/core.yaml
@@ -179,7 +179,6 @@ services:
     ownHost: true
     namespace: monitoring
     removeRequestHeaders:
-      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
       - authorization
     type: public
     isShared: true
@@ -205,7 +204,6 @@ services:
     type: public
     auth: true
     removeRequestHeaders:
-      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
       - authorization
   - name: drone
     svc: drone
@@ -216,7 +214,6 @@ services:
     paths: [/hook, /api/user, /api/repo]
     forwardPath: true
     removeRequestHeaders:
-      # strip authorization header from client side requests, so it does not conflict with other headers that this application is using for authentication.
       - authorization
   - name: jaeger
     svc: jaeger-operator-jaeger-query
@@ -305,10 +302,8 @@ teamConfig:
     - name: grafana
       svc: po-grafana
       hasPrefix: true
-      authz:
-        workload:
-          app.kubernetes.io/instance: prometheus-__TEAM
-          app.kubernetes.io/name: __TEAM-po-grafana
+      removeRequestHeaders:
+        - authorization
       type: public
       auth: true
     - name: prometheus

--- a/core.yaml
+++ b/core.yaml
@@ -206,12 +206,10 @@ services:
     svc: drone
     namespace: team-admin
     ownHost: true
-    authz:
-      workload:
-        app: drone
-        component: server
     type: public
     auth: true
+    removeRequestHeaders:
+      - authorization
   - name: drone
     svc: drone
     namespace: team-admin

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -897,6 +897,12 @@ definitions:
           - private
           - cluster
         type: string
+      removeRequestHeaders:
+        description: >-
+          Strip selected headers from HTTP request.
+        type: array
+        items:
+          type: string
     required:
       - name
       - type


### PR DESCRIPTION
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/redkubes/unassigned-issues/349

As a result of this change:
- the deployment time of the platform takes 13 minutes.
- the JWKS issue is removed

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
