### PR TITLE
moz/fix/policies test

### DIFF
--- a/charts/gatekeeper-operator/templates/post-job.yaml
+++ b/charts/gatekeeper-operator/templates/post-job.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: postinstall
-          image: badouralix/curl-http2:latest
+          image: badouralix/curl-http2:alpine
           command:
             - sh
             - -c
@@ -41,5 +41,7 @@ spec:
             requests:
               cpu: 10m
               memory: 16Mi
+          securityContext:
+            runAsNonRoot: true
 
 

--- a/charts/operator-lifecycle-manager/templates/0000_50_olm_07-olm-operator.deployment.yaml
+++ b/charts/operator-lifecycle-manager/templates/0000_50_olm_07-olm-operator.deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         app: olm-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: olm-operator-serviceaccount
       {{- if and .Values.installType (eq .Values.installType "ocp") }}
       priorityClassName: "system-cluster-critical"

--- a/charts/operator-lifecycle-manager/templates/0000_50_olm_08-catalog-operator.deployment.yaml
+++ b/charts/operator-lifecycle-manager/templates/0000_50_olm_08-catalog-operator.deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         app: catalog-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: olm-operator-serviceaccount
       {{- if and .Values.installType (eq .Values.installType "ocp") }}
       priorityClassName: "system-cluster-critical"

--- a/charts/otomi-api/templates/tests/test-connection.yaml
+++ b/charts/otomi-api/templates/tests/test-connection.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: busybox:stable
       command: ['wget']
       args:  ['{{ include "otomi-api.fullname" . }}:{{ .Values.service.port }}']
       resources:

--- a/charts/otomi-console/templates/tests/test-connection.yaml
+++ b/charts/otomi-console/templates/tests/test-connection.yaml
@@ -12,9 +12,16 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: busybox:stable
       command: ['wget']
       args:  ['{{ include "otomi-console.fullname" . }}:{{ .Values.service.port }}']
+      resources:
+        limits:
+          cpu: 100m
+          memory: 64Mi
+        requests:
+          cpu: 10m
+          memory: 16Mi
   restartPolicy: Never
   {{- with .Values.podSecurityContext }}
   securityContext:  {{- toYaml . | nindent 4 }}

--- a/k8s/knative-init/operator.yaml
+++ b/k8s/knative-init/operator.yaml
@@ -756,6 +756,8 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          securityContext:
+            runAsNonRoot: true
 
 ---
 # Copyright 2020 The Knative Authors

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "score-templates": "TESTING=1 binzx/otomi score-templates",
     "spellcheck": "cspell '/docs/**/**.md' '/values-schema.yaml' '/*.md' '/.values/README.md'",
     "tasks:copy-certs": "binzx/otomi task -n copyCerts",
-    "test": "TESTING=1 run-p lint validate-templates test:ts",
+    "test": "TESTING=1 run-s test:ts validate-values lint validate-templates check-policies",
     "test:opa": "binzx/otomi x opa test policies -v",
     "test:ts": "jest",
     "test:ts-cov": "jest --coverage",

--- a/policies/lib/measurements.rego
+++ b/policies/lib/measurements.rego
@@ -1,129 +1,129 @@
 package lib.measurements
 
 # 10 ** 21
-mem_multiple("E") = 1000000000000000000000 { true }
+mem_multiple("E") = 1000000000000000000000
 
 # 10 ** 18
-mem_multiple("P") = 1000000000000000000 { true }
+mem_multiple("P") = 1000000000000000000
 
 # 10 ** 15
-mem_multiple("T") = 1000000000000000 { true }
+mem_multiple("T") = 1000000000000000
 
 # 10 ** 12
-mem_multiple("G") = 1000000000000 { true }
+mem_multiple("G") = 1000000000000
 
 # 10 ** 9
-mem_multiple("M") = 1000000000 { true }
+mem_multiple("M") = 1000000000
 
 # 10 ** 6
-mem_multiple("k") = 1000000 { true }
+mem_multiple("k") = 1000000
 
 # 10 ** 3
-mem_multiple("") = 1000 { true }
+mem_multiple("") = 1000
 
 # Kubernetes accepts millibyte precision when it probably shouldn't.
 # https://github.com/kubernetes/kubernetes/issues/28741
 # 10 ** 0
-mem_multiple("m") = 1 { true }
+mem_multiple("m") = 1
 
 # 1000 * 2 ** 10
-mem_multiple("Ki") = 1024000 { true }
+mem_multiple("Ki") = 1024000
 
 # 1000 * 2 ** 20
-mem_multiple("Mi") = 1048576000 { true }
+mem_multiple("Mi") = 1048576000
 
 # 1000 * 2 ** 30
-mem_multiple("Gi") = 1073741824000 { true }
+mem_multiple("Gi") = 1073741824000
 
 # 1000 * 2 ** 40
-mem_multiple("Ti") = 1099511627776000 { true }
+mem_multiple("Ti") = 1099511627776000
 
 # 1000 * 2 ** 50
-mem_multiple("Pi") = 1125899906842624000 { true }
+mem_multiple("Pi") = 1125899906842624000
 
 # 1000 * 2 ** 60
-mem_multiple("Ei") = 1152921504606846976000 { true }
+mem_multiple("Ei") = 1152921504606846976000
 
 get_suffix(mem) = suffix {
-    not is_string(mem)
-    suffix := ""
+	not is_string(mem)
+	suffix := ""
 }
 
 get_suffix(mem) = suffix {
-    is_string(mem)
-    count(mem) > 0
-    suffix := substring(mem, count(mem) - 1, -1)
-    mem_multiple(suffix)
+	is_string(mem)
+	count(mem) > 0
+	suffix := substring(mem, count(mem) - 1, -1)
+	mem_multiple(suffix)
 }
 
 get_suffix(mem) = suffix {
-    is_string(mem)
-    count(mem) > 1
-    suffix := substring(mem, count(mem) - 2, -1)
-    mem_multiple(suffix)
+	is_string(mem)
+	count(mem) > 1
+	suffix := substring(mem, count(mem) - 2, -1)
+	mem_multiple(suffix)
 }
 
 get_suffix(mem) = suffix {
-    is_string(mem)
-    count(mem) > 1
-    not mem_multiple(substring(mem, count(mem) - 1, -1))
-    not mem_multiple(substring(mem, count(mem) - 2, -1))
-    suffix := ""
+	is_string(mem)
+	count(mem) > 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+	not mem_multiple(substring(mem, count(mem) - 2, -1))
+	suffix := ""
 }
 
 get_suffix(mem) = suffix {
-    is_string(mem)
-    count(mem) == 1
-    not mem_multiple(substring(mem, count(mem) - 1, -1))
-    suffix := ""
+	is_string(mem)
+	count(mem) == 1
+	not mem_multiple(substring(mem, count(mem) - 1, -1))
+	suffix := ""
 }
 
 get_suffix(mem) = suffix {
-    is_string(mem)
-    count(mem) == 0
-    suffix := ""
+	is_string(mem)
+	count(mem) == 0
+	suffix := ""
 }
 
 canonify_mem(orig) = new {
-    is_number(orig)
-    new := orig * 1000
+	is_number(orig)
+	new := orig * 1000
 }
 
 canonify_mem(orig) = new {
-    not is_number(orig)
-    suffix := get_suffix(orig)
-    raw := replace(orig, suffix, "")
-    re_match("^[0-9]+$", raw)
-    new := to_number(raw) * mem_multiple(suffix)
+	not is_number(orig)
+	suffix := get_suffix(orig)
+	raw := replace(orig, suffix, "")
+	re_match("^[0-9]+[.]?[0-9]+$", raw)
+	new := to_number(raw) * mem_multiple(suffix)
 }
 
 canonify_storage(orig) = new {
-    is_number(orig)
-    new := orig
+	is_number(orig)
+	new := orig
 }
 
 canonify_storage(orig) = new {
-    not is_number(orig)
-    suffix := get_suffix(orig)
-    raw := replace(orig, suffix, "")
-    re_match("^[0-9]+$", raw)
-    new := to_number(raw) * mem_multiple(suffix)
+	not is_number(orig)
+	suffix := get_suffix(orig)
+	raw := replace(orig, suffix, "")
+	re_match("^[0-9]+$", raw)
+	new := to_number(raw) * mem_multiple(suffix)
 }
 
 canonify_cpu(orig) = new {
-    is_number(orig)
-    new := orig * 1000
+	is_number(orig)
+	new := orig * 1000
 }
 
 canonify_cpu(orig) = new {
-    not is_number(orig)
-    endswith(orig, "m")
-    new := to_number(replace(orig, "m", ""))
+	not is_number(orig)
+	endswith(orig, "m")
+	new := to_number(replace(orig, "m", ""))
 }
 
 canonify_cpu(orig) = new {
-    not is_number(orig)
-    not endswith(orig, "m")
-    re_match("^[0-9]+$", orig)
-    new := to_number(orig) * 1000
+	not is_number(orig)
+	not endswith(orig, "m")
+	re_match("^[0-9]+$", orig)
+	new := to_number(orig) * 1000
 }

--- a/src/cmd/check-policies.ts
+++ b/src/cmd/check-policies.ts
@@ -1,4 +1,4 @@
-import { rmSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { Argv } from 'yargs'
 import { $, nothrow } from 'zx'
 import { cleanupHandler, prepareEnvironment } from '../common/cli'
@@ -21,12 +21,16 @@ const setup = (argv: BasicArguments): void => {
   cleanupHandler(() => cleanup(argv))
 }
 
-const checkPolicies = async (): Promise<void> => {
+export const checkPolicies = async (): Promise<void> => {
   const argv: BasicArguments = getParsedArgs()
   setup(argv)
   debug.info('Policy checking STARTED')
 
   const policiesFile = `${env().ENV_DIR}/env/policies.yaml`
+  const parametersFile = `${outDir}/parameters.yaml`
+  if (!existsSync(outDir)) mkdirSync(outDir)
+  // the policy parameters file's root prop is 'policies:', but conftest expects it to be served with 'parameters:'
+  writeFileSync(parametersFile, readFileSync(policiesFile, 'utf8').replace('policies:', 'parameters:'))
   const settingsFile = `${env().ENV_DIR}/env/settings.yaml`
   const settings = loadYaml(settingsFile)
   if (settings?.otomi?.addons?.conftest && !settings?.otomi?.addons?.conftest.enabled) {
@@ -43,7 +47,7 @@ const checkPolicies = async (): Promise<void> => {
   debug.info('Checking manifest against policies')
   const confTestOutput = (
     await nothrow(
-      $`conftest test ${extraArgs} --fail-on-warn --all-namespaces -d ${policiesFile} -p policies ${outDir}`,
+      $`conftest test ${extraArgs} --fail-on-warn --all-namespaces -d ${parametersFile} -p policies ${outDir}`,
     )
   ).stdout
   const cleanConftest: string = confTestOutput

--- a/src/cmd/check-policies.ts
+++ b/src/cmd/check-policies.ts
@@ -37,14 +37,14 @@ export const checkPolicies = async (): Promise<void> => {
     debug.log('Skipping')
     return
   }
-  debug.info('Generating k8s manifest for cluster')
+  debug.info('Generating k8s manifests for cluster')
   await hfTemplate(argv, outDir, { stdout: debug.stream.debug })
 
   const extraArgs: string[] = []
   if (logLevel() === logLevels.TRACE) extraArgs.push('--trace')
   if (env().CI) extraArgs.push('--no-color')
 
-  debug.info('Checking manifest against policies')
+  debug.info('Checking manifests for policy violations')
   const confTestOutput = (
     await nothrow(
       $`conftest test ${extraArgs} --fail-on-warn --all-namespaces -d ${parametersFile} -p policies ${outDir}`,

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -1,21 +1,14 @@
-import { existsSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, unlinkSync } from 'fs'
 import { Argv } from 'yargs'
-import { $ } from 'zx'
 import { cleanupHandler, prepareEnvironment } from '../common/cli'
-import { OtomiDebugger, terminal } from '../common/debug'
-import { env } from '../common/envalid'
-import { hf } from '../common/hf'
 import { getFilename } from '../common/utils'
-import { HelmArguments, getParsedArgs, helmOptions, setParsedArgs } from '../common/yargs'
-import { ProcessOutputTrimmed } from '../common/zx-enhance'
-import { diff } from './diff'
+import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from '../common/yargs'
 import { lint } from './lint'
 import { validateTemplates } from './validate-templates'
 import { validateValues } from './validate-values'
 
 const cmdName = getFilename(__filename)
 const tmpFile = '/tmp/otomi/test.yaml'
-let debug: OtomiDebugger
 
 const cleanup = (argv: HelmArguments): void => {
   if (argv.skipCleanup) return
@@ -24,7 +17,6 @@ const cleanup = (argv: HelmArguments): void => {
 
 const setup = (argv: HelmArguments): void => {
   cleanupHandler(() => cleanup(argv))
-  debug = terminal(cmdName)
 }
 
 const test = async (): Promise<void> => {
@@ -32,25 +24,7 @@ const test = async (): Promise<void> => {
   await validateValues()
   await lint()
   await validateTemplates()
-  // await checkPolicies(argv)
-
-  const output: ProcessOutputTrimmed = await hf({
-    fileOpts: 'helmfile.tpl/helmfile-init.yaml',
-    args: ['template', '--skip-deps'],
-  })
-
-  if (output.exitCode > 0) {
-    throw new Error(output.stderr)
-  } else if (output.stderr.length > 0) {
-    debug.error(output.stderr)
-  }
-  const hfOutput: string = output.stdout
-  writeFileSync(tmpFile, hfOutput.replace(/^.*basePath=.*$/gm, ''))
-  debug.log((await $`kubectl apply --dry-run=client -f ${tmpFile}`).stdout)
-
-  const diffOutput = await diff()
-  debug.log(diffOutput.stdout.replaceAll('../env', env().ENV_DIR))
-  debug.error(diffOutput.stderr.replaceAll('../env', env().ENV_DIR))
+  // await checkPolicies()
 }
 
 export const module = {

--- a/values/nginx-ingress/nginx-ingress.gotmpl
+++ b/values/nginx-ingress/nginx-ingress.gotmpl
@@ -21,7 +21,7 @@ controller:
     {{- else }}
     limits:
         cpu: 2
-        memory: 1.5Gi
+        memory: 1500Mi
     requests:
         cpu: 200m
         memory: 512Mi


### PR DESCRIPTION
`otomi check-policies` is working again, and is activate during build time so we don't introduce faulty workloads in otomi-core. The drone pipeline should only run it when`charts.gatekeeper-operator.disableValidatingWebhook: false` to be able to stop them from being deployed altogether. That is now not the case, but it should be built imo