### PR TITLE
fix(grafana): grafana patch 8.0.3 to 8.0.7 for CVE-2021-43798

### DIFF
--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -127,7 +127,7 @@ grafana:
         cpu: 50m
         memory: 50Mi
   image:
-    tag: 8.0.3
+    tag: 8.0.7
   initChownData:
     resources:
       limits:


### PR DESCRIPTION
In [CVE-2021-43798](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798) a solution is given for the vulnerability in current grafana version. The image
has to be upgraded to 8.0.7 asap

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
