### PR TITLE
fix: downgrade kes

### DIFF
--- a/values/kubernetes-external-secrets/kubernetes-external-secrets.gotmpl
+++ b/values/kubernetes-external-secrets/kubernetes-external-secrets.gotmpl
@@ -3,7 +3,7 @@
 
 # @TODO:
 image:
-  tag: 8.5.0
+  tag: 6.1.0
 env:
   # VAULT_ADDR - If vault is deployed in different namespace then you need to update this address
   VAULT_ADDR: http://vault:8200


### PR DESCRIPTION
Refer to: https://github.com/external-secrets/kubernetes-external-secrets/issues/826

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
