### PR TITLE
fix(remove image attribute): removing image atteibute in console and api

### DIFF
--- a/tests/fixtures/env/charts/otomi-api.yaml
+++ b/tests/fixtures/env/charts/otomi-api.yaml
@@ -4,6 +4,3 @@ charts:
         git:
             localPath: /tmp/otomi-values
             repoUrl: github.com/redkubes/otomi-values-demo.git
-        image:
-            pullPolicy: Always
-            tag: latest

--- a/tests/fixtures/env/charts/otomi-console.yaml
+++ b/tests/fixtures/env/charts/otomi-console.yaml
@@ -1,6 +1,3 @@
 charts:
     otomi-console:
         _rawValues: {}
-        image:
-            pullPolicy: Always
-            tag: latest

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1915,8 +1915,6 @@ properties:
                 $ref: '#/definitions/repoUrl'
               user:
                 type: string
-          image:
-            $ref: '#/definitions/imageSimple'
           resources:
             additionalProperties: false
             properties:
@@ -1929,8 +1927,6 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
-          image:
-            $ref: '#/definitions/imageSimple'
         allOf:
           - anyOf:
               - not:


### PR DESCRIPTION

removing image attribute from otomi-conole and otomi-api

## Checklist

- [x] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
