### PR TITLE
Print kubernetes events on helmfile error

### DIFF
--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -119,18 +119,18 @@ export const module: CommandModule = {
   describe: 'Apply all, or supplied, k8s resources',
   builder: (parser: Argv): Argv => helmOptions(parser),
   handler: async (argv: HelmArguments): Promise<void> => {
-    const d = terminal(`cmd:${cmdName}`)
-
     setParsedArgs(argv)
     setup()
     await prepareEnvironment()
     try {
       await apply()
     } catch (error) {
-      console.log(error)
-      const res = await nothrow($`kubectl get events -A --sort-by='.lastTimestamp'`)
-      if (res.exitCode === 0) d.error(res.stdout)
-      else d.info('Unable to fetch kubernetes events')
+      if (error.exitCode === 1) {
+        const d = terminal(`cmd:${cmdName}:k8s:events`)
+        const res = await nothrow($`kubectl get events -A --sort-by='.lastTimestamp'`)
+        if (res.exitCode === 0) d.warn(res.stdout)
+        else d.info('Unable to fetch kubernetes events')
+      }
       throw error
     }
   },

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -129,7 +129,7 @@ export const module: CommandModule = {
         const d = terminal(`cmd:${cmdName}:k8s:events`)
         const res = await nothrow($`kubectl get events -A --sort-by='.lastTimestamp'`)
         if (res.exitCode === 0) d.warn(res.stdout)
-        else d.info('Unable to fetch kubernetes events')
+        else d.error('Unable to fetch kubernetes events')
       }
       throw error
     }


### PR DESCRIPTION
When performing `otomi apply`, print kubernetes events on error from helmfile
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
