### PR TITLE
Labels and duplicated ports

### DIFF
--- a/charts/team-ns/templates/istio-serviceentry.yaml
+++ b/charts/team-ns/templates/istio-serviceentry.yaml
@@ -25,8 +25,8 @@ spec:
     - {{ $hostName }}  # not used but still mandatory
   addresses:
     - {{ $host | quote }}
-{{- range $port := $entry.ports }}
   ports:
+{{- range $port := $entry.ports }}
   - number: {{ $port.number }}
     name: {{ printf "%s-%s" (lower $port.protocol) (toString $port.number) }}
     protocol: {{ $port.protocol }}
@@ -47,8 +47,8 @@ metadata:
 spec:
   hosts:
   - {{ $host }}
-{{- range $port := $entry.ports }}
   ports:
+{{- range $port := $entry.ports }}
   - number: {{ $port.number }}
     name: {{ printf "%s-%s" (lower $port.protocol) (toString $port.number) }}
     protocol: {{ $port.protocol }}

--- a/charts/team-ns/templates/istio-serviceentry.yaml
+++ b/charts/team-ns/templates/istio-serviceentry.yaml
@@ -1,5 +1,6 @@
 {{- $v := .Values | merge (dict) }}
 {{/* Above merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
+{{- $ := . }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $egressFilteringEnabled := dig "networkPolicy" "egressPublic" true  $v }}
 {{- if $egressFilteringEnabled }}
@@ -18,6 +19,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: {{ $serviceName }}
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   hosts:
     - {{ $hostName }}  # not used but still mandatory
@@ -41,6 +43,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: {{ $serviceName }}
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   hosts:
   - {{ $host }}
@@ -65,6 +68,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: platform-keycloak
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   hosts:
     - {{ trimPrefix "https://" .Values.charts.keycloak.address }}

--- a/charts/team-ns/templates/istio-sidecar.yaml
+++ b/charts/team-ns/templates/istio-sidecar.yaml
@@ -1,4 +1,5 @@
 {{- $v := .Values | merge (dict) }}
+{{- $ := . }}
 {{- $egressFilteringEnabled := dig "networkPolicy" "egressPublic" true $v }}
 {{- if $egressFilteringEnabled }}
 {{- if not (eq $v.teamId "admin") }}
@@ -7,6 +8,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
   name: default
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   outboundTrafficPolicy: 
     mode: REGISTRY_ONLY

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- $v := .Values | merge (dict) }}
 {{/* Above merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
-
+{{- $ := . }}
 {{- if not (eq $v.teamId "admin") }}
 {{- if (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
@@ -8,6 +8,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-ingress-deny
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   podSelector: {}
   policyTypes:
@@ -17,6 +18,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-ingress-platform
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   # Match all Pods in this namespace
   podSelector: {}
@@ -55,6 +57,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $s.name }}-ingress-from-all-teams
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
@@ -77,6 +80,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $s.name }}-ingress-allow-only
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
Added missing helm labels to the resources.
Also fixed duplicated port `key` issue that me and Bart have just found out today.
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file.
