### PR TITLE
fix(blackbox-exporter): fix: #792

### DIFF
--- a/helmfile.d/snippets/blackbox-targets.gotmpl
+++ b/helmfile.d/snippets/blackbox-targets.gotmpl
@@ -27,4 +27,4 @@
     - source_labels: [__param_target]
       target_label: instance
     - target_label: __address__
-      replacement: prometheus-blackbox-exporter.{{ . | get "namespace" "monitoring" }}:9115
+      replacement: prometheus-blackbox-exporter.monitoring:9115


### PR DESCRIPTION
prometheus-blackbox-exporter is running in monitoring namespace, not in team namespaces.

fix #792

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
