### PR TITLE
refactor(networkpolicies): replace labelrequirement 'app: <svc>' to '…

### DIFF
--- a/chart/otomi/templates/post-job.yaml
+++ b/chart/otomi/templates/post-job.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "otomi.name" . }}
+        otomi.io/app: {{ template "otomi.name" . }}
         release: {{ .Release.Name }}
     spec:
       restartPolicy: Never

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -63,7 +63,7 @@ spec:
       # The app label cannot be used because Knative appends revision number to the service
       serving.knative.dev/service: {{ $s.name }}
         {{- else }}
-      app: {{ $s.name }}
+      otomi.io/app: {{ $s.name }}
         {{- end }}
   policyTypes:
     - Ingress
@@ -86,7 +86,7 @@ spec:
       # The app label cannot be used because Knative appends revision number to its value
       serving.knative.dev/service: {{ $s.name }}
         {{- else }}
-      app: {{ $s.name }}
+      otomi.io/app: {{ $s.name }}
         {{- end }}
   policyTypes:
     - Ingress
@@ -100,7 +100,7 @@ spec:
             {{- if hasKey . "service" }}
           podSelector:
             matchLabels:
-              app: {{ .service }}
+              otomi.io/app: {{ .service }}
         # An extra rule for Pods that are spawn by knative-serving
         - namespaceSelector:
             matchLabels:

--- a/helmfile.tpl/helmfile-connectivity.yaml
+++ b/helmfile.tpl/helmfile-connectivity.yaml
@@ -17,8 +17,8 @@
 # team-a1     client-c2-team-a1-to-s2-team-a1   2/3     NotReady   0          3m24s
 #
 # From above:
-# The pod client-c2-team-a1-to-s2-team-a1  was able to connect workload in team-a1 namespace and label app=s2
-# The pod client-c1-team-a2-to-s1-team-a1  was NOT able able to connect with workload in team-a1 namespace and label app=s1
+# The pod client-c2-team-a1-to-s2-team-a1  was able to connect workload in team-a1 namespace and label otomi.io/app=s2
+# The pod client-c1-team-a2-to-s1-team-a1  was NOT able able to connect with workload in team-a1 namespace and label otomi.io/app=s1
 
 
 environments:
@@ -54,85 +54,85 @@ environments:
         - server:
             namespace: team-a1
             labels:
-                app: s1
+                otomi.io/app: s1
           clients:
             - namespace: team-a1
               labels:
-                app: c1
+                otomi.io/app: c1
             - namespace: team-a2
               labels:
-                app: c1
+                otomi.io/app: c1
         - server:
             namespace: team-a1
             labels:
-                app: s2
+                otomi.io/app: s2
           clients:
             - namespace: team-a1
               labels:
-                app: c2
+                otomi.io/app: c2
             - namespace: team-a2
               labels:
-                app: c2
+                otomi.io/app: c2
         - server:
             namespace: team-a1
             labels:
-                app: s3
+                otomi.io/app: s3
           clients:
             - namespace: team-a1
               labels:
-                app: c3
+                otomi.io/app: c3
             - namespace: team-a2
               labels:
-                app: c3
+                otomi.io/app: c3
         - server:
             namespace: team-a1
             labels:
-                app: s4
+                otomi.io/app: s4
           clients:
             - namespace: team-a1
               labels:
-                app: c4
+                otomi.io/app: c4
             - namespace: team-a2
               labels:
-                app: c4
+                otomi.io/app: c4
         - server:
             namespace: team-a1
             labels:
-                app: s5
+                otomi.io/app: s5
           clients:
             - namespace: team-a1
               labels:
-                app: c5
+                otomi.io/app: c5
             - namespace: team-a2
               labels:
-                app: c5
+                otomi.io/app: c5
         - server:
             namespace: team-a1
             labels:
-                app: s6
+                otomi.io/app: s6
           clients:
             - namespace: team-a1
               labels:
-                app: c6
+                otomi.io/app: c6
             - namespace: team-a1
               labels:
-                app: c6b
+                otomi.io/app: c6b
             - namespace: team-a2
               labels:
-                app: c6
+                otomi.io/app: c6
         - server:
             namespace: team-a1
             labels:
-                app: s7-00001
+                otomi.io/app: s7-00001
                 serving.knative.dev/service: s7
             ksvc: true
           clients:
             - namespace: team-a1
               labels:
-                app: c7
+                otomi.io/app: c7
             - namespace: team-a2
               labels:
-                app: c7
+                otomi.io/app: c7
 releases:
   - name: inter-team-connectivity
     installed: true

--- a/tests/network-policies/helmfile-connectivity.yaml
+++ b/tests/network-policies/helmfile-connectivity.yaml
@@ -5,96 +5,96 @@ environments:
           - server:
               namespace: team-a1
               labels:
-                app: s1
+                otomi.io/app: s1
             clients:
               - namespace: team-a1
                 labels:
-                  app: c1
+                  otomi.io/app: c1
               - namespace: team-a2
                 labels:
-                  app: c1
+                  otomi.io/app: c1
           - server:
               namespace: team-a1
               labels:
-                app: s2
+                otomi.io/app: s2
             clients:
               - namespace: team-a1
                 labels:
-                  app: c2
+                  otomi.io/app: c2
               - namespace: team-a2
                 labels:
-                  app: c2
+                  otomi.io/app: c2
           - server:
               namespace: team-a1
               labels:
-                app: s3
+                otomi.io/app: s3
             clients:
               - namespace: team-a1
                 labels:
-                  app: c3
+                  otomi.io/app: c3
               - namespace: team-a2
                 labels:
-                  app: c3
+                  otomi.io/app: c3
           - server:
               namespace: team-a1
               labels:
-                app: s4
+                otomi.io/app: s4
             clients:
               - namespace: team-a1
                 labels:
-                  app: c4
+                  otomi.io/app: c4
               - namespace: team-a2
                 labels:
-                  app: c4
+                  otomi.io/app: c4
           - server:
               namespace: team-a1
               labels:
-                app: s5
+                otomi.io/app: s5
             clients:
               - namespace: team-a1
                 labels:
-                  app: c5
+                  otomi.io/app: c5
               - namespace: team-a2
                 labels:
-                  app: c5
+                  otomi.io/app: c5
           - server:
               namespace: team-a1
               labels:
-                app: s6
+                otomi.io/app: s6
             clients:
               - namespace: team-a1
                 labels:
-                  app: c6
+                  otomi.io/app: c6
               - namespace: team-a1
                 labels:
-                  app: c6b
+                  otomi.io/app: c6b
               - namespace: team-a2
                 labels:
-                  app: c6
+                  otomi.io/app: c6
           - server:
               namespace: team-a1
               labels:
-                app: s7-00001
+                otomi.io/app: s7-00001
                 serving.knative.dev/service: s7
               ksvc: true
             clients:
               - namespace: team-a1
                 labels:
-                  app: c7
+                  otomi.io/app: c7
               - namespace: team-a2
                 labels:
-                  app: c7
+                  otomi.io/app: c7
         egressPublic:
           - namespace: team-a1
             labels:
-              app: ce1
+              otomi.io/app: ce1
             hosts:
               - https://otomi.io
               - https://116.203.255.68
               - https://httpbin.org/headers
           - namespace: team-a2
             labels:
-              app: ce1
+              otomi.io/app: ce1
             hosts:
               - https://otomi.io
               - https://116.203.255.68

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -528,7 +528,7 @@ definitions:
     properties:
       ingressPrivate:
         title: Internal ingress filtering
-        description: 'Pods belonging to this service must contain "app: <service name>" label'
+        description: 'Pods belonging to this service must contain "otomi.io/app: <service name>" label'
         oneOf:
           - title: Deny all
             description: Deny traffic from all teams (including this one)
@@ -555,7 +555,7 @@ definitions:
                       type: string
                     service:
                       title: Service name
-                      description: 'Allow traffic from pods with "app: <some service name>" label'
+                      description: 'Allow traffic from pods with "otomi.io/app: <some service name>" label'
                       type: string
                   required:
                     - team

--- a/values/connectivity/connectivity-raw.gotmpl
+++ b/values/connectivity/connectivity-raw.gotmpl
@@ -3,8 +3,8 @@
 resources:
 {{- range $item:=$v.teamConnectivity }}
 {{- $server := $item.server }}
-{{- $serverSubdomain:= printf "conn-%s" $server.labels.app }}
-{{- $serverHostname:= printf "server-%s" $server.labels.app }}
+{{- $serverSubdomain:= printf "conn-%s" $server.labels.otomi\.io/app }}
+{{- $serverHostname:= printf "server-%s" $server.labels.otomi\.io/app }}
 {{- $serverUrl:= printf "%s.%s.%s.svc.cluster.local" $serverHostname $serverSubdomain $server.namespace }}
 
 # Server
@@ -53,7 +53,7 @@ resources:
             port: 8080
 
 {{- range $client:=$item.clients }}
-{{- $clientName:= printf "client-%s-%s-to-%s-%s" $client.labels.app $client.namespace $server.labels.app $server.namespace}}
+{{- $clientName:= printf "client-%s-%s-to-%s-%s" $client.labels.otomi\.io/app $client.namespace $server.labels.otomi\.io/app $server.namespace}}
 - apiVersion: v1
   kind: Pod
   metadata:

--- a/values/tests/connectivity-raw.gotmpl
+++ b/values/tests/connectivity-raw.gotmpl
@@ -3,8 +3,8 @@
 resources:
 {{- range $item:=$v.teamConnectivity }}
 {{- $server := $item.server }}
-{{- $serverSubdomain:= printf "conn-%s" $server.labels.app }}
-{{- $serverHostname:= printf "server-%s" $server.labels.app }}
+{{- $serverSubdomain:= printf "conn-%s" $server.labels.otomi\.io/app }}
+{{- $serverHostname:= printf "server-%s" $server.labels.otomi\.io/app }}
 {{- $serverUrl:= printf "%s.%s.svc.cluster.local" $serverSubdomain $server.namespace }}
 
 # Server
@@ -58,7 +58,7 @@ resources:
             port: 8080
 
 {{- range $client:=$item.clients }}
-{{- $clientName:= printf "client-%s-%s-to-%s-%s" $client.labels.app $client.namespace $server.labels.app $server.namespace}}
+{{- $clientName:= printf "client-%s-%s-to-%s-%s" $client.labels.otomi\.io/app $client.namespace $server.labels.otomi\.io/app $server.namespace}}
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -122,7 +122,7 @@ resources:
 
 {{- range $client:=$v.egressPublic }}
 {{- range $host:=$client.hosts }}
-{{- $clientName := printf "client-%s-%s-%s" $client.labels.app $client.namespace ($host | replace "://" "-" | replace "/" "-" | replace "." "-" | replace "::" "-" | replace ":" "-") }}
+{{- $clientName := printf "client-%s-%s-%s" $client.labels.otomi\.io/app $client.namespace ($host | replace "://" "-" | replace "/" "-" | replace "." "-" | replace "::" "-" | replace ":" "-") }}
 
 - apiVersion: v1
   kind: Pod


### PR DESCRIPTION
Draft PR, replace label 'app' with 'otomi.io/app' used by networkpolicies



fix: #739
