### PR TITLE
ci: run integration test in GitHub actions

### DIFF
--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -1,0 +1,26 @@
+name: Add integration testing to checks
+on:
+  workflow_dispatch: {}
+  # TODO: Test manually before activating this
+  # pull_request:
+  #   paths-ignore:
+  #     - 'docs/**'
+
+env:
+  CHECK_CONTEXT: continuous-integration/integration-test
+
+jobs:
+  require-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.GITHUB_REPOSITORY }}/statuses/{{ github.sha }} \
+            -f state='pending'
+            -f description='Integration test run required'
+            -f context='${{ env.CHECK_CONTEXT }}'
+        # TODO: Insert target URL of workflow with -f target_url='https://example.com/build/status'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,95 @@
+name: Run integration test
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+on:
+  workflow_dispatch:
+    inputs:
+      install_profile:
+        description: Otomi installation profile
+        required: true
+        default: full
+        type: choice
+        options:
+          - minimal
+          - full
+
+env:
+  DIGITALOCEAN_PROJECT: 888d7eee-cd33-4f22-8499-274c393f9b80
+  DIGITALOCEAN_CLUSTER_REGION: ams3
+  DIGITALOCEAN_CLUSTER_SIZE: s-8vcpu-16gb
+  DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3
+
+jobs:
+  create-integration-test-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Get default VPC for region
+        run: |
+          echo DIGITALOCEAN_VPC_UUID=`doctl vpcs list --format Region,Default,ID --no-header|sed -nr 's/${{ env.DIGITALOCEAN_CLUSTER_REGION }} +true +(.*)/\1/p'` >> $GITHUB_ENV
+      - name: Create k8s cluster for testing
+        run: |
+          doctl kubernetes cluster create integration-test-${{ github.sha }} \
+            --tag integration-test \
+            --region ${{ env.DIGITALOCEAN_CLUSTER_REGION }} \
+            --vpc-uuid ${{ env.DIGITALOCEAN_VPC_UUID }} \
+            --node-pool "name=pool-int-test-${{ github.sha }};size=${{ env.DIGITALOCEAN_CLUSTER_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \
+            --wait
+
+  integration:
+    needs:
+      - create-integration-test-cluster
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Retrieve cluster id
+        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
+      - name: Assign the cluster to the project
+        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Save kubectl config with auth token
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Get kubectl environment
+        run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
+      - name: Create image pull secret on test cluster
+        run: |
+          kubectl create secret docker-registry reg-otomi-github \
+            --docker-server=${{ env.CACHE_REGISTRY }} \
+            --docker-username=${{ env.GIT_USER }} \
+            --docker-password='${{ secrets.NPM_TOKEN }}'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prepare Otomi chart
+        run: |
+          tag=${GITHUB_REF##*/}
+          sed --in-place "s/APP_VERSION_PLACEHOLDER/$tag/g" chart/otomi/Chart.yaml
+          sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
+          sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/${{ inputs.install_profile }}.yaml
+          cat << EOF > values-temp.yaml
+          imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"
+          imagePullSecretNames:
+            - reg-otomi-github
+          EOF
+      - name: Otomi install
+        run: helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi --values tests/integration/${{ inputs.install_profile }}.yaml --values values-temp.yaml
+      - name: Gather events on failure
+        if: failure()
+        run: |
+          kubectl get events --sort-by='.lastTimestamp' -A
+          kubectl logs jobs/otomi --tail 150
+
+  cleanup-integration-test-cluster:
+    needs: integration
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Remove the test cluster
+        run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ env:
   DIGITALOCEAN_NODE_SIZE: s-8vcpu-16gb
   DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3
   DIGITALOCEAN_CLUSTER_NAME: integration-test-${{ github.sha }}
+  CHECK_CONTEXT: continuous-integration/integration-test
 
 jobs:
   create-integration-test-cluster:
@@ -80,11 +81,33 @@ jobs:
           EOF
       - name: Otomi install
         run: helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi --values tests/integration/${{ inputs.install_profile }}.yaml --values values-temp.yaml
-      - name: Gather events on failure
+      - name: Gather events on failure and report
         if: failure()
         run: |
           kubectl get events --sort-by='.lastTimestamp' -A
           kubectl logs jobs/otomi --tail 150
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.GITHUB_REPOSITORY }}/statuses/{{ github.sha }} \
+            -f state='failure' \
+            -f target_url='${{ github.event.workflow_run.html_url }}' \
+            -f description='Integration test run failed' \
+            -f context='${{ env.CHECK_CONTEXT }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Report if test succeeded
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.GITHUB_REPOSITORY }}/statuses/{{ github.sha }} \
+            -f state='success' \
+            -f target_url='${{ github.event.workflow_run.html_url }}' \
+            -f description='Integration test run succeeded' \
+            -f context='${{ env.CHECK_CONTEXT }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-integration-test-cluster:
     needs: integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,13 +11,17 @@ on:
         options:
           - minimal
           - full
+      cluster_region:
+        description: DigitalOcean cluster region
+        required: true
+        default: ams3
+        type: string
 
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: redkubes/otomi-core
   REPO: otomi/core
   GIT_USER: redkubesbot
-  DIGITALOCEAN_CLUSTER_REGION: ams3
   DIGITALOCEAN_NODE_SIZE: s-8vcpu-16gb
   DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3
   DIGITALOCEAN_CLUSTER_NAME: integration-test-${{ github.sha }}
@@ -33,12 +37,12 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Get default VPC for region
         run: |
-          echo DIGITALOCEAN_VPC_UUID=`doctl vpcs list --format Region,Default,ID --no-header|sed -nr 's/${{ env.DIGITALOCEAN_CLUSTER_REGION }} +true +(.*)/\1/p'` >> $GITHUB_ENV
+          echo DIGITALOCEAN_VPC_UUID=`doctl vpcs list --format Region,Default,ID --no-header|sed -nr 's/${{ inputs.cluster_region }} +true +(.*)/\1/p'` >> $GITHUB_ENV
       - name: Create k8s cluster for testing
         run: |
           doctl kubernetes cluster create ${{ env.DIGITALOCEAN_CLUSTER_NAME }} \
             --tag integration-test \
-            --region ${{ env.DIGITALOCEAN_CLUSTER_REGION }} \
+            --region ${{ inputs.cluster_region }} \
             --vpc-uuid ${{ env.DIGITALOCEAN_VPC_UUID }} \
             --node-pool "name=pool-int-test-${{ github.sha }};size=${{ env.DIGITALOCEAN_NODE_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \
             --wait

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ on:
           - full
 
 env:
+  CACHE_REGISTRY: ghcr.io
+  CACHE_REPO: redkubes/otomi-core
+  REPO: otomi/core
+  GIT_USER: redkubesbot
   DIGITALOCEAN_CLUSTER_REGION: ams3
   DIGITALOCEAN_NODE_SIZE: s-8vcpu-16gb
   DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,10 +13,10 @@ on:
           - full
 
 env:
-  DIGITALOCEAN_PROJECT: 888d7eee-cd33-4f22-8499-274c393f9b80
   DIGITALOCEAN_CLUSTER_REGION: ams3
-  DIGITALOCEAN_CLUSTER_SIZE: s-8vcpu-16gb
+  DIGITALOCEAN_NODE_SIZE: s-8vcpu-16gb
   DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3
+  DIGITALOCEAN_CLUSTER_NAME: integration-test-${{ github.sha }}
 
 jobs:
   create-integration-test-cluster:
@@ -31,12 +31,16 @@ jobs:
           echo DIGITALOCEAN_VPC_UUID=`doctl vpcs list --format Region,Default,ID --no-header|sed -nr 's/${{ env.DIGITALOCEAN_CLUSTER_REGION }} +true +(.*)/\1/p'` >> $GITHUB_ENV
       - name: Create k8s cluster for testing
         run: |
-          doctl kubernetes cluster create integration-test-${{ github.sha }} \
+          doctl kubernetes cluster create ${{ env.DIGITALOCEAN_CLUSTER_NAME }} \
             --tag integration-test \
             --region ${{ env.DIGITALOCEAN_CLUSTER_REGION }} \
             --vpc-uuid ${{ env.DIGITALOCEAN_VPC_UUID }} \
-            --node-pool "name=pool-int-test-${{ github.sha }};size=${{ env.DIGITALOCEAN_CLUSTER_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \
+            --node-pool "name=pool-int-test-${{ github.sha }};size=${{ env.DIGITALOCEAN_NODE_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \
             --wait
+      - name: Retrieve cluster id
+        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get ${{ env.DIGITALOCEAN_CLUSTER_NAME }} --format ID --no-header` >> $GITHUB_ENV
+      - name: Assign the cluster to the project
+        run: doctl projects resources assign ${{ secrets.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
 
   integration:
     needs:
@@ -47,10 +51,6 @@ jobs:
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Retrieve cluster id
-        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
-      - name: Assign the cluster to the project
-        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
       - name: Save kubectl config with auth token
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
       - name: Get kubectl environment
@@ -92,4 +92,4 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Remove the test cluster
-        run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
+        run: doctl kubernetes cluster delete ${{ env.DIGITALOCEAN_CLUSTER_NAME }} -f --dangerous

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
 
   create-integration-test-cluster:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -72,6 +73,7 @@ jobs:
     needs:
       - build-test-cache
       - create-integration-test-cluster
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Install doctl
@@ -117,14 +119,13 @@ jobs:
   cleanup-integration-test-cluster:
     needs: integration
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.ref == 'refs/heads/main'
     steps:
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Remove the test cluster
-        if: always()
         run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
 
   push-to-docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
         run: |
-          sed --in-place 's/APP_VERSION_PLACEHOLDER/${{ env.TAG }}/g' chart/otomi/Chart.yaml
+          tag=${GITHUB_REF##*/}
+          sed --in-place "s/APP_VERSION_PLACEHOLDER/$tag/g" chart/otomi/Chart.yaml
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,7 @@ jobs:
           tags: |
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
-  integration:
-    needs: build-test-cache
+  create-integration-test-cluster:
     runs-on: ubuntu-latest
     steps:
       - name: Install doctl
@@ -68,6 +67,17 @@ jobs:
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
             --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
+
+  integration:
+    needs:
+      - build-test-cache
+      - create-integration-test-cluster
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Retrieve cluster id
         run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
       - name: Assign the cluster to the project
@@ -103,14 +113,22 @@ jobs:
         run: |
           kubectl get events --sort-by='.lastTimestamp' -A
           kubectl logs jobs/otomi --tail 150
+
+  cleanup-integration-test-cluster:
+    needs: integration
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Remove the test cluster
         if: always()
         run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
 
   push-to-docker:
-    # needs: [build-test-cache, integration]
-    needs: build-test-cache
-    # needs: [build-test-cache]
+    needs: integration
     if: always() && ((contains(needs.build-test-cache.result, 'success') && !contains(needs.integration.outputs.started, 'true')) || (contains(needs.integration.result, 'success'))) && !github.event.act
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Retrieve cluster id
         run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
       - name: Assign the cluster to the project
-        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:cluster:${{ env.DIGITALOCEAN_CLUSTER_ID }}
+        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
 
   push-to-docker:
     # needs: [build-test-cache, integration]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,7 @@ jobs:
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
   integration:
-    # needs: build-test-cache
-    # skip integration check for releases, as the main they are derived from have already been integration tested:
+    needs: build-test-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install doctl
@@ -74,7 +73,20 @@ jobs:
         run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
       - name: Assign the cluster to the project
         run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
-        # --- Add Otomi setup here ---
+      - name: Save kubectl config with auth token
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Otomi CLI install
+        run: |
+          image="$CACHE_REGISTRY/$CACHE_REPO:$TAG"
+          export ENV_DIR=`mktemp -d`
+          docker pull $image
+          docker tag $image $REPO:$TAG
+          export NOPULL=1
+          export OTOMI_TAG=$TAG 
+          binzx/otomi bootstrap
+          binzx/otomi apply
       - name: Remove the test cluster
         run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,22 +83,10 @@ jobs:
         run: |
           sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
+          sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
+          sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml
       - name: Otomi install
-        uses: 'deliverybot/helm@v1'
-        with:
-          release: otomi
-          namespace: otomi
-          chart: chart/otomi
-          values: >-
-            cluster:
-              provider: digitalocean
-              k8sContext: ${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}
-          value-files: >-
-            [
-              "tests/integration/minimal.yaml"
-            ]
-        env:
-          KUBECONFIG_FILE: /home/runner/.kube/config
+        run: helm install --wait --wait-for-jobs otomi chart/otomi --values tests/integration/minimal.yaml
       - name: Gather events on failure
         if: failure()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
   integration:
-    # needs: build-test-cache
+    needs: build-test-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install doctl
@@ -76,6 +76,17 @@ jobs:
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
       - name: Get kubectl environment
         run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.CACHE_REGISTRY }}
+          username: ${{ env.GIT_USER }}
+          password: '${{ secrets.NPM_TOKEN }}'
+      - name: Create image pull secret on test cluster
+        run: |
+          kubectl create secret generic reg-otomi-github \
+            --from-file=.dockerconfigjson=~/.docker/config.json \
+            --type=kubernetes.io/dockerconfigjson
       - name: Checkout
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
@@ -85,8 +96,13 @@ jobs:
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml
+          cat << EOF > values-temp.yaml
+          imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"
+          imagePullSecretNames:
+            - reg-otomi-github
+          EOF
       - name: Otomi install
-        run: helm install --wait --wait-for-jobs --timeout 15m0s otomi chart/otomi --values tests/integration/minimal.yaml
+        run: helm install --wait --wait-for-jobs --timeout 25m0s otomi chart/otomi --values tests/integration/minimal.yaml --values values-temp.yaml
       - name: Gather events on failure
         if: failure()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,10 +71,9 @@ jobs:
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id
-        id: get_k8s_cluster_id
-        run: doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header
+        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
       - name: Assign the cluster to the project
-        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get_k8s_cluster_id.outputs.value }}
+        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:cluster:${{ env.DIGITALOCEAN_CLUSTER_ID }}
 
   push-to-docker:
     # needs: [build-test-cache, integration]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,9 +71,8 @@ jobs:
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id
-        uses: sergeysova/jq-action@v2
         id: get-k8s-cluster-id
-        run: doctl kubernetes cluster get integration-test-${{ env.GITHUB_SHA }} -o json|jq -r '.[0].id'
+        run: doctl kubernetes cluster get integration-test-${{ env.GITHUB_SHA }} --format ID --no-header
       - name: Assign the cluster to the project
         run: doctl projects resources assign {{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get-k8s-cluster-id.outputs.value }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             --tag integration-test \
             --region ams3 \
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
+            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=3;" \
             --wait
 
   integration:
@@ -107,7 +107,7 @@ jobs:
             - reg-otomi-github
           EOF
       - name: Otomi install
-        run: helm install --wait --wait-for-jobs --timeout 25m0s otomi chart/otomi --values tests/integration/minimal.yaml --values values-temp.yaml
+        run: helm install --wait --wait-for-jobs --timeout 30m0s otomi chart/otomi --values tests/integration/full.yaml --values values-temp.yaml
       - name: Gather events on failure
         if: failure()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,23 +76,17 @@ jobs:
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
       - name: Get kubectl environment
         run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
-      - name: Login to Github Packages
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.CACHE_REGISTRY }}
-          username: ${{ env.GIT_USER }}
-          password: '${{ secrets.NPM_TOKEN }}'
       - name: Create image pull secret on test cluster
         run: |
-          kubectl create secret generic reg-otomi-github \
-            --from-file=.dockerconfigjson=~/.docker/config.json \
-            --type=kubernetes.io/dockerconfigjson
+          kubectl create secret docker-registry reg-otomi-github \
+            --docker-server=${{ env.CACHE_REGISTRY }} \
+            --docker-username=${{ env.GIT_USER }} \
+            --docker-password='${{ secrets.NPM_TOKEN }}'
       - name: Checkout
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
         run: |
-          # sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
-          sed --in-place 's/APP_VERSION_PLACEHOLDER/main/g' chart/otomi/Chart.yaml
+          sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
   integration:
-    needs: build-test-cache
+    # needs: build-test-cache
     # skip integration check for releases, as the main they are derived from have already been integration tested:
     runs-on: ubuntu-latest
     steps:
@@ -63,11 +63,11 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Create k8s cluster for testing
         run: |
-          doctl kubernetes cluster create integration-test-${{ github.sha }} \                                                        
+          doctl kubernetes cluster create integration-test-${{ github.sha }} \
             --tag integration-test \
             --region ams3 \
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-integration-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
+            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ env:
   CACHE_REPO: redkubes/otomi-core
   REPO: otomi/core
   GIT_USER: redkubesbot
-  DIGITALOCEAN_PROJECT: 8f3ba81d-2bfb-4b20-bb27-9c83c40b570d
+  DIGITALOCEAN_PROJECT: 888d7eee-cd33-4f22-8499-274c393f9b80
 
 jobs:
   build-test-cache:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ env:
   CACHE_REPO: redkubes/otomi-core
   REPO: otomi/core
   GIT_USER: redkubesbot
+  DIGITALOCEAN_PROJECT: 8f3ba81d-2bfb-4b20-bb27-9c83c40b570d
 
 jobs:
   build-test-cache:
@@ -51,41 +52,30 @@ jobs:
           tags: |
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
-  # integration:
-  #   needs: build-test-cache
-  #   # skip integration check for releases, as the main they are derived from have already been integration tested:
-  #   if: contains(github.event.head_commit.message, '[kind]') || (github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release)')) || github.event.act
-  #   outputs:
-  #     started: 'true'
-  #   runs-on: self-hosted
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Set globalPullSecret if not running locally
-  #       if: (!github.event.act)
-  #       run: |
-  #         cmd="docker run --rm -v $PWD/tests/kind/env/settings.yaml:$PWD/settings.yaml mikefarah/yq:3.3.4 yq w -i $PWD/settings.yaml"
-  #         $cmd otomi.globalPullSecret.password '${{ secrets.DOCKERHUB_OTOMI_TOKEN }}'
-  #         $cmd otomi.globalPullSecret.username otomi
-  #     - name: Validate input values and deploy otomi on kind cluster
-  #       run: |
-  #         ACT=${{ github.event.act }}
-  #         ACT=${ACT:-false}
-  #         TAG=${GITHUB_REF##*/}
-  #         image="$CACHE_REGISTRY/$CACHE_REPO:$TAG"
-  #         if $ACT; then
-  #           image=$REPO:$TAG
-  #         else
-  #           docker login -u $GIT_USER -p '${{ secrets.NPM_TOKEN }}' ghcr.io
-  #           echo "Pulling the following tag: $image..."
-  #           docker pull $image
-  #         fi
-
-  #         docker run --rm -e CI=1 -v $PWD/tests/kind:/home/app/stack/env $image node dist/src/otomi.js -- validate-values
-  #         docker network inspect kind >/dev/null 2>&1 || docker network create --driver bridge kind && docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network kind --pull always --user root otomi/kind:latest
-  #         docker cp kind-control-plane:/etc/kubernetes/admin.conf $PWD/kind/kubeconfig
-  #         chmod +r ./kind/kubeconfig
-  #         docker run --rm -v $PWD/kind/kubeconfig:/home/app/.kube/config -e CI=1 -e VERBOSITY=1 -e DISABLE_SYNC=1 --network kind -v $PWD/tests/kind:/home/app/stack/env -u 0 $image sh -c "binzx/otomi bootstrap && binzx/otomi apply"
+  integration:
+    needs: build-test-cache
+    # skip integration check for releases, as the main they are derived from have already been integration tested:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Create k8s cluster for testing
+        run: |
+          doctl kubernetes cluster create integration-test-${{ env.GITHUB_SHA }} \                                                        
+            --tag integration-test \
+            --region ams3 \
+            --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
+            --node-pool "name=pool-integration-test-${{ env.GITHUB_SHA }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
+            --wait
+        # Also saves the kubeconfig by default
+      - name: Retrieve cluster id
+        uses: sergeysova/jq-action@v2
+        id: get-k8s-cluster-id
+        run: doctl kubernetes cluster get integration-test-${{ env.GITHUB_SHA }} -o json|jq -r '.[0].id'
+      - name: Assign the cluster to the project
+        run: doctl projects resources assign {{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get-k8s-cluster-id.outputs.value }}
 
   push-to-docker:
     # needs: [build-test-cache, integration]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
   integration:
-    needs: build-test-cache
+    # needs: build-test-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install doctl
@@ -75,19 +75,37 @@ jobs:
         run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
       - name: Save kubectl config with auth token
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Get kubectl environment
+        run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Otomi CLI install
+      - name: Prepare Otomi chart
         run: |
-          image="$CACHE_REGISTRY/$CACHE_REPO:$TAG"
-          export ENV_DIR=`mktemp -d`
-          docker pull $image
-          docker tag $image $REPO:$TAG
-          export NOPULL=1
-          export OTOMI_TAG=$TAG 
-          binzx/otomi bootstrap
-          binzx/otomi apply
+          sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
+          sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
+      - name: Otomi install
+        uses: 'deliverybot/helm@v1'
+        with:
+          release: otomi
+          namespace: otomi
+          chart: chart/otomi
+          values: >-
+            cluster:
+              provider: digitalocean
+              k8sContext: ${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}
+          value-files: >-
+            [
+              "tests/integration/minimal.yaml"
+            ]
+        env:
+          KUBECONFIG_FILE: /home/runner/.kube/config
+      - name: Gather events on failure
+        if: failure()
+        run: |
+          kubectl get events --sort-by='.lastTimestamp' -A
+          kubectl logs jobs/otomi --tail 150
       - name: Remove the test cluster
+        if: always()
         run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
 
   push-to-docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
         run: |
-          sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
+          sed --in-place 's/APP_VERSION_PLACEHOLDER/${{ env.TAG }}/g' chart/otomi/Chart.yaml
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,16 +63,16 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Create k8s cluster for testing
         run: |
-          doctl kubernetes cluster create integration-test-${{ GITHUB_SHA }} \                                                        
+          doctl kubernetes cluster create integration-test-${{ github.sha }} \                                                        
             --tag integration-test \
             --region ams3 \
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-integration-test-${{ GITHUB_SHA }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
+            --node-pool "name=pool-integration-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id
         id: get-k8s-cluster-id
-        run: doctl kubernetes cluster get integration-test-${{ GITHUB_SHA }} --format ID --no-header
+        run: doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header
       - name: Assign the cluster to the project
         run: doctl projects resources assign {{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get-k8s-cluster-id.outputs.value }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,16 +63,16 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Create k8s cluster for testing
         run: |
-          doctl kubernetes cluster create integration-test-${{ env.GITHUB_SHA }} \                                                        
+          doctl kubernetes cluster create integration-test-${{ GITHUB_SHA }} \                                                        
             --tag integration-test \
             --region ams3 \
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-integration-test-${{ env.GITHUB_SHA }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
+            --node-pool "name=pool-integration-test-${{ GITHUB_SHA }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id
         id: get-k8s-cluster-id
-        run: doctl kubernetes cluster get integration-test-${{ env.GITHUB_SHA }} --format ID --no-header
+        run: doctl kubernetes cluster get integration-test-${{ GITHUB_SHA }} --format ID --no-header
       - name: Assign the cluster to the project
         run: doctl projects resources assign {{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get-k8s-cluster-id.outputs.value }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
         run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
       - name: Assign the cluster to the project
         run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
+        # --- Add Otomi setup here ---
+      - name: Remove the test cluster
+        run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
 
   push-to-docker:
     # needs: [build-test-cache, integration]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,14 @@ jobs:
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
             --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
-          echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
-          doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
-          doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
-          DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
+      - name: Retrieve cluster id
+        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
+      - name: Assign the cluster to the project
+        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Save kubectl config with auth token
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
+      - name: Get kubectl environment
+        run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
@@ -82,7 +86,7 @@ jobs:
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml
       - name: Otomi install
-        run: helm install --wait --wait-for-jobs otomi chart/otomi --values tests/integration/minimal.yaml
+        run: helm install --wait --wait-for-jobs --timeout 15m0s otomi chart/otomi --values tests/integration/minimal.yaml
       - name: Gather events on failure
         if: failure()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ env:
   CACHE_REPO: redkubes/otomi-core
   REPO: otomi/core
   GIT_USER: redkubesbot
-  DIGITALOCEAN_PROJECT: 888d7eee-cd33-4f22-8499-274c393f9b80
 
 jobs:
   build-test-cache:
@@ -52,84 +51,8 @@ jobs:
           tags: |
             ${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}:${{ env.TAG }}
 
-  create-integration-test-cluster:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Create k8s cluster for testing
-        run: |
-          doctl kubernetes cluster create integration-test-${{ github.sha }} \
-            --tag integration-test \
-            --region ams3 \
-            --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=3;max-nodes=5;count=3;" \
-            --wait
-
-  integration:
-    needs:
-      - build-test-cache
-      - create-integration-test-cluster
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Retrieve cluster id
-        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
-      - name: Assign the cluster to the project
-        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
-      - name: Save kubectl config with auth token
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
-      - name: Get kubectl environment
-        run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
-      - name: Create image pull secret on test cluster
-        run: |
-          kubectl create secret docker-registry reg-otomi-github \
-            --docker-server=${{ env.CACHE_REGISTRY }} \
-            --docker-username=${{ env.GIT_USER }} \
-            --docker-password='${{ secrets.NPM_TOKEN }}'
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Prepare Otomi chart
-        run: |
-          tag=${GITHUB_REF##*/}
-          sed --in-place "s/APP_VERSION_PLACEHOLDER/$tag/g" chart/otomi/Chart.yaml
-          sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
-          sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
-          sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml
-          cat << EOF > values-temp.yaml
-          imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"
-          imagePullSecretNames:
-            - reg-otomi-github
-          EOF
-      - name: Otomi install
-        run: helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi --values tests/integration/full.yaml --values values-temp.yaml
-      - name: Gather events on failure
-        if: failure()
-        run: |
-          kubectl get events --sort-by='.lastTimestamp' -A
-          kubectl logs jobs/otomi --tail 150
-
-  cleanup-integration-test-cluster:
-    needs: integration
-    runs-on: ubuntu-latest
-    if: always() && github.ref == 'refs/heads/main'
-    steps:
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Remove the test cluster
-        run: doctl kubernetes cluster delete integration-test-${{ github.sha }} -f --dangerous
-
   push-to-docker:
-    needs: integration
+    needs: build-test-cache
     if: always() && ((contains(needs.build-test-cache.result, 'success') && !contains(needs.integration.outputs.started, 'true')) || (contains(needs.integration.result, 'success'))) && !github.event.act
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,20 +68,16 @@ jobs:
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
             --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=2;" \
             --wait
-        # Also saves the kubeconfig by default
-      - name: Retrieve cluster id
-        run: echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
-      - name: Assign the cluster to the project
-        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
-      - name: Save kubectl config with auth token
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
-      - name: Get kubectl environment
-        run: echo DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
+          echo DIGITALOCEAN_CLUSTER_ID=`doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header` >> $GITHUB_ENV
+          doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=do:kubernetes:${{ env.DIGITALOCEAN_CLUSTER_ID }}
+          doctl kubernetes cluster kubeconfig save --expiry-seconds 3600 ${{ env.DIGITALOCEAN_CLUSTER_ID }}
+          DIGITALOCEAN_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
       - name: Prepare Otomi chart
         run: |
-          sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
+          # sed --in-place 's/APP_VERSION_PLACEHOLDER/"${{ github.sha }}"/g' chart/otomi/Chart.yaml
+          sed --in-place 's/APP_VERSION_PLACEHOLDER/main/g' chart/otomi/Chart.yaml
           sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/minimal.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/full.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             --tag integration-test \
             --region ams3 \
             --vpc-uuid=2c840be3-de75-48c4-b0d6-66b214e2d39e \
-            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=2;max-nodes=5;count=3;" \
+            --node-pool "name=pool-int-test-${{ github.sha }};size=s-8vcpu-16gb;tag=integration-test;auto-scale=true;min-nodes=3;max-nodes=5;count=3;" \
             --wait
 
   integration:
@@ -107,7 +107,7 @@ jobs:
             - reg-otomi-github
           EOF
       - name: Otomi install
-        run: helm install --wait --wait-for-jobs --timeout 30m0s otomi chart/otomi --values tests/integration/full.yaml --values values-temp.yaml
+        run: helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi --values tests/integration/full.yaml --values values-temp.yaml
       - name: Gather events on failure
         if: failure()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,10 +71,10 @@ jobs:
             --wait
         # Also saves the kubeconfig by default
       - name: Retrieve cluster id
-        id: get-k8s-cluster-id
+        id: get_k8s_cluster_id
         run: doctl kubernetes cluster get integration-test-${{ github.sha }} --format ID --no-header
       - name: Assign the cluster to the project
-        run: doctl projects resources assign {{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get-k8s-cluster-id.outputs.value }}
+        run: doctl projects resources assign ${{ env.DIGITALOCEAN_PROJECT }} --resource=${{ steps.get_k8s_cluster_id.outputs.value }}
 
   push-to-docker:
     # needs: [build-test-cache, integration]

--- a/chart/otomi/templates/job.yaml
+++ b/chart/otomi/templates/job.yaml
@@ -1,4 +1,5 @@
 {{- $kms := .Values.kms | default dict }}
+{{- $imageName := .Values.imageName | default "otomi/core" }}
 {{- $version := .Values.otomi.version | default .Chart.AppVersion }}
 apiVersion: batch/v1
 kind: Job
@@ -21,8 +22,14 @@ spec:
         runAsGroup: 999
       containers:
         - name: install
-          image: otomi/core:{{ $version }}
-          imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }} 
+          image: {{ $imageName }}:{{ $version }}
+          imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }}
+          {{- if hasKey .Values "imagePullSecretNames" }}
+          imagePullSecrets:
+            {{- range .Values.imagePullSecretNames }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
           resources:
             limits:
               memory: 2Gi

--- a/chart/otomi/templates/job.yaml
+++ b/chart/otomi/templates/job.yaml
@@ -24,12 +24,6 @@ spec:
         - name: install
           image: {{ $imageName }}:{{ $version }}
           imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }}
-          {{- if hasKey .Values "imagePullSecretNames" }}
-          imagePullSecrets:
-            {{- range .Values.imagePullSecretNames }}
-            - name: {{ . }}
-            {{- end }}
-          {{- end }}
           resources:
             limits:
               memory: 2Gi
@@ -65,3 +59,9 @@ spec:
             secretName: {{ .Release.Name }}-values
         - name: otomi-values
           emptyDir: {}
+      {{- if hasKey .Values "imagePullSecretNames" }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecretNames }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}

--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -1,0 +1,56 @@
+# Minimal values file with all apps enabled
+cluster:
+  k8sVersion: '1.22'
+  name: 'dev'
+  provider: digitalocean
+otomi:
+  isMultitenant: true
+apps:
+  alertmanager:
+    enabled: true
+  argocd:
+    enabled: true
+  cert-manager:
+    issuer: custom-ca
+  external-dns:
+    domainFilters: []
+  gatekeeper:
+    enabled: true
+  grafana:
+    enabled: true
+  harbor:
+    enabled: true
+  hello:
+    enabled: true
+  httpbin:
+    enabled: true
+  jaeger:
+    enabled: true
+  kiali:
+    enabled: true
+  knative:
+    enabled: true
+  kube-descheduler:
+    enabled: true
+  kubeapps:
+    enabled: true
+  kubeclarity:
+    enabled: true
+  kured:
+    enabled: true
+  loki:
+    enabled: true
+  metrics-server:
+    enabled: true
+  prometheus:
+    enabled: true
+  promtail:
+    enabled: true
+  redis-shared:
+    enabled: true
+  snapshot-controller:
+    enabled: true
+  tigera-operator:
+    enabled: true
+  vault:
+    enabled: true

--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -3,6 +3,7 @@ cluster:
   k8sVersion: '1.22'
   name: 'dev'
   provider: digitalocean
+  k8sContext: CONTEXT_PLACEHOLDER
 otomi:
   isMultitenant: true
 apps:

--- a/tests/integration/minimal.yaml
+++ b/tests/integration/minimal.yaml
@@ -3,3 +3,4 @@ cluster:
   k8sVersion: '1.22'
   name: 'dev'
   provider: digitalocean
+  k8sContext: CONTEXT_PLACEHOLDER

--- a/tests/integration/minimal.yaml
+++ b/tests/integration/minimal.yaml
@@ -1,0 +1,5 @@
+# Minimal values file with defaults
+cluster:
+  k8sVersion: '1.22'
+  name: 'dev'
+  provider: digitalocean


### PR DESCRIPTION
This PR implements redkubes/unassigned-issues#418.

The following might want to be changed, but is possibly out of scope of this issue:
- [ ] Probably we also want to run tests on a feature branch before merging into main. We have to discuss a way to do this on-demand (e.g. contents of a commit message) since it takes a lot of time to run this each time.
- [ ] This is not new, but currently all images with successful unit-tests are pushed to Docker Hub. That might not be intended. We probably want to have this only done for `main` and release tags.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
