### PR TITLE
fix: allow admin group to access all secrets

### DIFF
--- a/values/vault-operator/vault-operator-cr.gotmpl
+++ b/values/vault-operator/vault-operator-cr.gotmpl
@@ -221,16 +221,19 @@ spec:
         policies: 
         - allow-all-secrets
         metadata: {}
+      - name: admin
+        type: external
+        policies: 
+        - allow-all-secrets
+        metadata: {}
     group-aliases:
       {{- range $teamId, $team := $tc }}
-      {{- if ne $teamId "admin" }}
       - name: team-{{ $teamId }}
         group: team-{{ $teamId }}
         mountpath: oidc/
       {{- end }}
-      {{- end }}
-      - name: team-admin
-        group: team-admin
+      - name: admin
+        group: admin
         mountpath: oidc/
     secrets:
       - path: secret
@@ -243,7 +246,6 @@ spec:
     # See https://www.vaultproject.io/docs/secrets/kv/index.html for more information.
     startupSecrets:
     {{- range $teamId, $team := $tc }}
-      {{- if ne $teamId "admin" }}
       {{- if eq $teamId "demo" }}
       - type: kv
         path: secret/data/teams/team-{{ $teamId }}/mysecret-generic
@@ -257,12 +259,6 @@ spec:
           data:
             HELLO: "Welcome {{ $teamId }} team"
     {{- end }}
-    {{- end }}
-      - type: kv
-        path: secret/data/teams/team-admin/otomi-welcome
-        data:
-          data:
-            HELLO: "Welcome admin team"
 
   {{- if and (hasKey $seal "kmsKeyId") (hasKey $kms "gcpckms")  }}
   credentialsConfig:

--- a/values/vault-operator/vault-operator-raw.gotmpl
+++ b/values/vault-operator/vault-operator-raw.gotmpl
@@ -222,16 +222,19 @@ resources:
             policies: 
             - allow-all-secrets
             metadata: {}
+          - name: admin
+            type: external
+            policies: 
+            - allow-all-secrets
+            metadata: {}
         group-aliases:
           {{- range $teamId, $team := $tc }}
-          {{- if ne $teamId "admin" }}
           - name: team-{{ $teamId }}
             group: team-{{ $teamId }}
             mountpath: oidc/
           {{- end }}
-          {{- end }}
-          - name: team-admin
-            group: team-admin
+          - name: admin
+            group: admin
             mountpath: oidc/
         secrets:
           - path: secret
@@ -244,7 +247,6 @@ resources:
         # See https://www.vaultproject.io/docs/secrets/kv/index.html for more information.
         startupSecrets:
         {{- range $teamId, $team := $tc }}
-          {{- if ne $teamId "admin" }}
           {{- if eq $teamId "demo" }}
           - type: kv
             path: secret/data/teams/team-{{ $teamId }}/mysecret-generic
@@ -258,12 +260,6 @@ resources:
               data:
                 HELLO: "Welcome {{ $teamId }} team"
         {{- end }}
-        {{- end }}
-          - type: kv
-            path: secret/data/teams/team-admin/otomi-welcome
-            data:
-              data:
-                HELLO: "Welcome admin team"
 
       {{- if and (hasKey $seal "kmsKeyId") (hasKey $kms "gcpckms")  }}
       credentialsConfig:


### PR DESCRIPTION
This PR fixes redkubes/otomi-core#837, as adding an additional group-policy assignment, allowing the `otomi-admin` user to access all teams' secrets.

This approach has been chosen, diverting from the suggestion in the ticket (adding the `otomi-admin` user to `team-admin`), in order to have an implementation logic somewhat similar to other apps (e.g. ArgoCD). The single superuser and the admin team `team-admin` are also there kept as separate concepts.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
