### PR TITLE
fix: azure vault unseal

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2292,11 +2292,14 @@ properties:
                       client_secret:
                         type: string
                         x-secret: ''
+                      key_name:
+                        $ref: '#/definitions/wordCharacterPattern'
                     required:
                       - vault_name
                       - tenant_id
                       - client_id
                       - client_secret
+                      - key_name
                 required:
                   - azurekeyvault
           storage:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2238,8 +2238,8 @@ properties:
           seal:
             description: |
               Use a KMS to encrypt and decrypt the master key.\n
-              WARNING - enabling this feature will delete the unseal key from the cluster without pushing to external kms!\n
-              You must first copy the keys from the "vault-unseal-keys" secret, and import them to your KMS.
+              WARNING - You must first copy the keys from the "vault-unseal-keys" secret, and import them to your KMS.\n
+              (enabling this feature will delete the unseal key from the cluster without pushing to external kms!)
             nullable: true
             type: object
             oneOf:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2237,9 +2237,8 @@ properties:
             $ref: '#/definitions/logLevel'
           seal:
             description: |
-              Use a KMS to encrypt and decrypt the master key.
-
-              WARNING - ENABLING THIS FEATURE WILL DELETE THE UNSEAL KEY FROM THE CLUSTER WITHOUT PUSHING TO EXTERNAL KMS!
+              Use a KMS to encrypt and decrypt the master key.\n
+              WARNING - enabling this feature will delete the unseal key from the cluster without pushing to external kms!\n
               You must first copy the keys from the "vault-unseal-keys" secret, and import them to your KMS.
             nullable: true
             type: object

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2238,6 +2238,7 @@ properties:
           seal:
             description: |
               Use a KMS to encrypt and decrypt the master key.
+
               WARNING - ENABLING THIS FEATURE WILL DELETE THE UNSEAL KEY FROM THE CLUSTER WITHOUT PUSHING TO EXTERNAL KMS!
               You must first copy the keys from the "vault-unseal-keys" secret, and import them to your KMS.
             nullable: true

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2236,7 +2236,10 @@ properties:
           logLevel:
             $ref: '#/definitions/logLevel'
           seal:
-            description: Use a KMS to encrypt and decrypt the master key
+            description: |
+              Use a KMS to encrypt and decrypt the master key.
+              WARNING - ENABLING THIS FEATURE WILL DELETE THE UNSEAL KEY FROM THE CLUSTER WITHOUT PUSHING TO EXTERNAL KMS!
+              You must first copy the keys from the "vault-unseal-keys" secret, and import them to your KMS.
             nullable: true
             type: object
             oneOf:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.11
+api: azure-vault-unseal
 console: 0.5.15
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: azure-vault-unseal
+api: 0.5.11
 console: 0.5.15
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
This is a fix for #845 

Tested and it works but one thing to be VERY careful about is that when you add an external provider for storing unseal secrets, that it will delete the kubernetes secret containing the keys **without** pushing them to keyvault, so you absolutely need to take a backup of that key before enabling this configuration.

I have included a warning in the field description in the values schema to help people avoid losing their keys (in both Core and API).

[Respective PR in API](https://github.com/redkubes/otomi-api/pull/316)
