### PR TITLE
fix: chart version placeholder conformed with semver

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           tag=${GITHUB_REF##*/}
           sed --in-place "s/APP_VERSION_PLACEHOLDER/$tag/g" chart/otomi/Chart.yaml
-          sed --in-place "s/CHART_PATCH_PLACEHOLDER/0/g" chart/otomi/Chart.yaml
+          sed --in-place "s/0-chart-patch-placeholder/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/${{ inputs.install_profile }}.yaml
           cat << EOF > values-temp.yaml
           imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,12 +131,12 @@ jobs:
           chart_patch_version=${chart_version##*.}
           new_patch_version=$(($chart_patch_version+1))
           # check if major or minor part of version changed (patch number is automated so left out of equation)
-          this_version=$(cat chart/otomi/Chart.yaml | yq r - 'version' | sed "s/CHART_PATCH_PLACEHOLDER/$chart_patch_version/g")
+          this_version=$(cat chart/otomi/Chart.yaml | yq r - 'version' | sed "s/0-chart-patch-placeholder/$chart_patch_version/g")
           # if any of those changed then reset the patch version
           [ "$this_version" != "$chart_version" ] && new_patch_version=1
           release_tag=v$(cat package.json | jq -r '.version')
           sed --in-place "s/APP_VERSION_PLACEHOLDER/$release_tag/g" chart/otomi/Chart.yaml
-          sed --in-place "s/CHART_PATCH_PLACEHOLDER/$new_patch_version/g" chart/otomi/Chart.yaml
+          sed --in-place "s/0-chart-patch-placeholder/$new_patch_version/g" chart/otomi/Chart.yaml
           sed --in-place "s/APP_VERSION_PLACEHOLDER/$release_tag/g" chart/otomi/values.yaml
           # copy readme from repo into the charts and add tpl/chart-values.md
           cp README.md chart/otomi/

--- a/chart/otomi/Chart.yaml
+++ b/chart/otomi/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for installing otomi in Kubernetes
 home: https://otomi.io/
 icon: https://otomi.io/img/otomi-logo.svg
 type: application
-version: 0.5.CHART_PATCH_PLACEHOLDER
+version: 0.5.0-chart-patch-placeholder
 appVersion: APP_VERSION_PLACEHOLDER
 keywords:
   - otomi


### PR DESCRIPTION
Users trying to install otomi 
```
helm install otomi chart/otomi --dry-run --values <path>
```
,where `chart/otomi ` is a directory in `otomi-core`, experience the following error:
```
Error: INSTALLATION FAILED: validation: chart.metadata.version "0.5.CHART_PATCH_PLACEHOLDER" is invalid
```

This change enables helm chart installation without need of changing the value of `chart.metadata.version`
## Checklist

- [x] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [x] Helm releases are meeting otomi's baseline security policies, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
