### PR TITLE
chore: adjust GITHUB_TOKEN permissions for jobs in github actions

### DIFF
--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -22,6 +22,8 @@ env:
 jobs:
   require-integration-test:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - run: |
           gh api \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,6 +90,8 @@ jobs:
   integration:
     needs: create-integration-test-cluster
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Install doctl
         uses: digitalocean/action-doctl@v2


### PR DESCRIPTION
Approved PRs from forked repos cannot run integration tests. See example: https://github.com/redkubes/otomi-core/runs/7605917091?check_suite_focus=true

It is because the default permissions for `statuses` is read for forked repos:
Read: `https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

Permissions can be adjusted per job: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
