### PR TITLE
fix: vault policies syntax

### DIFF
--- a/values/vault-operator/vault-operator-raw.gotmpl
+++ b/values/vault-operator/vault-operator-raw.gotmpl
@@ -140,35 +140,36 @@ resources:
       # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
       # The repository also contains a lot examples in the deploy/ and operator/deploy directories.
       externalConfig:
+        # The policies below follow HCL syntax. Do not remove quotes!
         policies:
           - name: allow-read-all-secrets
             rules: |
               path "secret/*" {
-                    capabilities = [read, list]
+                    capabilities = ["read", "list"]
               }
           - name: allow-list-all-secrets
             rules: |
               path "secret/*" {
-                    capabilities = [list]
+                    capabilities = ["list"]
               }
           - name: allow_sandbox
             rules: |
               path "secret/data/sandbox/*" {
-                    capabilities = [create, read, update, delete, list]
+                    capabilities = ["create", "read", "update", "delete", "list"]
               }
           {{- range $teamId, $team := $tc }}
           {{- if ne $teamId "admin" }}
           - name: allow-team-{{ $teamId }}
             rules: |
               path "secret/data/teams/team-{{ $teamId }}/*" {
-                    capabilities = [create, update, read, delete, list]
+                    capabilities = ["create", "update", "read", "delete", "list"]
               }
           {{- end }}
           {{- end }}
           - name: allow-all-secrets
             rules: |
               path "secret/*" {
-                    capabilities = [create, update, read, delete, list]
+                    capabilities = ["create", "update", "read", "delete", "list"]
               }
         auth:
           - type: oidc


### PR DESCRIPTION
fixes #860

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
