### PR TITLE
ci: otomi version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           doctl kubernetes cluster create ${{ env.DIGITALOCEAN_CLUSTER_NAME }} \
             --tag integration-test \
+            --ha \
             --region ${{ inputs.cluster_region }} \
             --vpc-uuid ${{ env.DIGITALOCEAN_VPC_UUID }} \
             --node-pool "name=int-test-${{ strategy.job-index }}-${{ env.COMMIT_ID }};size=${{ env.DIGITALOCEAN_NODE_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -95,6 +95,7 @@ jobs:
           doctl kubernetes cluster create ${{ env.DIGITALOCEAN_CLUSTER_NAME }} \
             --tag integration-test \
             --ha \
+            --maintenance-window any=03:00 \
             --region ${{ inputs.cluster_region }} \
             --vpc-uuid ${{ env.DIGITALOCEAN_VPC_UUID }} \
             --node-pool "name=int-test-${{ strategy.job-index }}-${{ env.COMMIT_ID }};size=${{ env.DIGITALOCEAN_NODE_SIZE }};tag=integration-test;auto-scale=true;min-nodes=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};max-nodes=5;count=${{ env.DIGITALOCEAN_NODE_POOL_MIN_SIZE }};" \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -124,6 +124,7 @@ jobs:
           sed --in-place "s/0-chart-patch-placeholder/0/g" chart/otomi/Chart.yaml
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/${{ inputs.install_profile }}.yaml
           sed --in-place "s/K8S_VERSION_PLACEHOLDER/${k8sVersion:0:4}/g" tests/integration/${{ inputs.install_profile }}.yaml
+          sed --in-place "s/OTOMI_VERSION_PLACEHOLDER/${GITHUB_REF##*/}/g" tests/integration/${{ inputs.install_profile }}.yaml
           cat << EOF > values-temp.yaml
           imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"
           imagePullSecretNames:

--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -4,6 +4,7 @@ cluster:
   name: 'dev'
   provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
+  version: 'OTOMI_VERSION_PLACEHOLDER'
 otomi:
   isMultitenant: true
 apps:

--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -4,9 +4,9 @@ cluster:
   name: 'dev'
   provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
-  version: 'OTOMI_VERSION_PLACEHOLDER'
 otomi:
   isMultitenant: true
+  version: 'OTOMI_VERSION_PLACEHOLDER'
 apps:
   alertmanager:
     enabled: true

--- a/tests/integration/minimal.yaml
+++ b/tests/integration/minimal.yaml
@@ -4,3 +4,4 @@ cluster:
   name: 'dev'
   provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
+  version: 'OTOMI_VERSION_PLACEHOLDER'


### PR DESCRIPTION
I introduced OTOMI_VERSION_PLACEHOLDER to insure `tools` container from otomi-api pod contains right version of otomi-core.
The `ha` flag is needed as otomi deployment may fail if Kubernetes-api in not in HA mode
The scheduled integration tests are run at midnight, thus it is better to set k8s maintenance-window later.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
