### PR TITLE
fix: broken links in otomi CLI

### DIFF
--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -344,7 +344,7 @@ export const bootstrap = async (
   const originalValues = await deps.processValues()
   // exit early if `isCli` and `ENV_DIR` were empty, and let the user provide valid values first:
   if (!originalValues) {
-    d.log('A new values repo has been created. For next steps follow otomi.io/docs.')
+    d.log('A new values repo has been created. For next steps follow documentation at https://otomi.io')
     return
   }
   const finalValues = (await deps.hfValues()) as Record<string, any>

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -99,7 +99,7 @@ export const commit = async (firstTime = false): Promise<void> => {
     #
     #  To start using Otomi, go to https://otomi.${values.cluster.domainSuffix} and sign in to the web console
     #  with username "${credentials.adminUsername}" and password "${credentials.adminPassword}".
-    #  Then activate Drone. For more information see: https://otomi.io/docs/installation/activation/
+    #  Then activate Drone. For more information see: https://otomi.io
     #
     ########################################################################################################################################`
     d.info(message)


### PR DESCRIPTION
We just ask user to visit otomi.io instead of providing specific links, because they often become invalid.  
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
