### PR TITLE
fix: missing appinfo, titles added

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -1,5 +1,39 @@
 appsInfo:
+  alertmanager:
+    title: Alertmanager
+    appVersion: 0.24.0
+    repo: https://github.com/prometheus/alertmanager
+    maintainers: Prometheus Community
+    relatedLinks:
+      - https://otomi.io/docs/apps/alertmanager
+      - https://prometheus.io/docs/alerting/latest/alertmanager]
+    license: Apache 2.0
+    about: Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of de-duplicating, grouping, and routing them to the correct receiver integration such as email, PagerDuty, or OpsGenie. Alertmanager also takes care of silencing and inhibition of alerts.
+    integration: Alertmanager can be activated to send alerts to configured receivers. It is configured by Otomi to use the global values found under settings/alerts. A team can override global settings to send alerts to their own endpoints.
+  argocd:
+    title: ArgoCD
+    appVersion: 1.4.25
+    repo: https://github.com/argoproj/argo-helm
+    maintainers: Argo Project
+    relatedLinks:
+      - https://otomi.io/docs/apps/argocd
+      - https://argo-cd.readthedocs.io
+    license: Apache 2.0
+    about: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
+    integration: Argo CD is configured by Otomi to use the SSO provided by keycloak, and maps otomi groups to Argo CD roles. The otomi-admin role is made super admin within Argo CD. The team-admin role has access to Argo CD and is admin of all team projects. Members of team roles are only allowed to administer their own projects. All Teams will automatically get access to a Git repo, and Argo CD is configured to listen to this repo. All a team has to do is to fill their repo with intended state, commit, and automation takes care of the rest.
+  cert-manager:
+    title: CertManager
+    appVersion: 1.8.0
+    repo: https://github.com/cert-manager/cert-manager
+    maintainers: The Linux Foundation
+    relatedLinks:
+      - https://otomi.io/docs/apps/certmanager
+      - https://cert-manager.io/
+    license: Apache 2.0
+    about: Cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates. It can issue certificates from a variety of supported sources, including Let's Encrypt, HashiCorp Vault, and Venafi as well as private PKI, and it ensures certificates remain valid and up to date, attempting to renew certificates at an appropriate time before expiry.
+    integration: Cert-manager is used by Otomi to automatically create and rotate TLS certificates for service endpoints. You may bring your own CA, or let Otomi create one for you (default). It is recommended to use Let's Encrypt for production certificates. Setting cert-manager to use Let's Encrypt requires DNS availability of the requesting domains, and forces Otomi to install external-dns. Because a lot of DNS settings are used by other Otomi contexts, most DNS configuration is found under settings/dns.
   drone:
+    title: Drone
     appVersion: 2.7.3
     repo: https://github.com/harness/drone
     maintainers: Harness
@@ -10,6 +44,7 @@ appsInfo:
     about: Drone is a continuous delivery system built on container technology. Drone uses a simple YAML build file, to define and execute build pipelines inside Docker containers.
     integration: Otomi uses Drone to deploy changes to the configuration (values) repository. Drone is installed and configured by default. When no external source control is configured (default), Otomi will use Gitea as Drone's git hosting dependency. Teams can use Drone for other purposes if desired, with the limitation that it can't be configured for multiple git services.
   external-dns:
+    title: External DNS
     appVersion: 0.10.2
     repo: https://github.com/kubernetes-sigs/external-dns
     maintainers: Kubernetes SIGs
@@ -20,6 +55,7 @@ appsInfo:
     about: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
     integration: ExternalDNS is used by Otomi to make public service domains accessible by registering them with Otomi's load balancer CNAME or IP address. When ExternalDNS is not enabled (default), then Otomi will rely on nip.io to create host names for all services.
   gatekeeper:
+    title: Gatekeeper
     appVersion: 3.8.1
     repo: https://github.com/open-policy-agent/gatekeeper
     maintainers: Open Policy Agent
@@ -30,6 +66,7 @@ appsInfo:
     about: Kubernetes allows decoupling policy decisions from the inner workings of the API Server by means of admission controller webhooks, which are executed whenever a resource is created, updated or deleted. Gatekeeper is a validating (mutating TBA) webhook that enforces CRD-based policies executed by Open Policy Agent.
     integration: OPA/Gatekeeper can be enabled for policy enforcement. The Otomi configuration repository holds a policies.yaml file with sane default policy presets. A selection of usable policies for Otomi are used by Conftest as well for static analysis of manifests generated by Otomi. YAML Resources are verified against defined .rego policy rules, using the defined preset parameters as their constraint value. When enabled, policies can be turned on/off in the Otomi web UI.
   gitea:
+    title: Gitea
     appVersion: 1.15.8
     repo: https://github.com/go-gitea/gitea
     maintainers: Gitea
@@ -40,6 +77,7 @@ appsInfo:
     about: Gitea is a painless self-hosted Git service. It is similar to GitHub, Bitbucket, and GitLab. Gitea is a fork of Gogs. See the Gitea Announcement blog post to read about the justification for a fork.
     integration: Otomi uses Gitea as its default repository for otomi configuration (values). Gitea can also be used by Teams to provide application code repositories. Access to Gitea is provided by the OIDC integration in Otomi. Members of the otomi-admin and team-admin group can seamlessly sign in to Gitea. When Argo CD is enabled, Otomi will automatically create a Gitops repository for each Team in Gitea.
   grafana:
+    title: Grafana
     appVersion: 9.0.1
     repo: https://github.com/grafana/grafana
     maintainers: Grafana Labs
@@ -50,6 +88,7 @@ appsInfo:
     about: Grafana allows you to query, visualize, alert on and understand your metrics no matter where they are stored. Create, explore, and share dashboards with your team and foster a data-driven culture.
     integration: Otomi uses Grafana to visualize Prometheus metrics and Loki logs. Team members are automatically given the Editor role, while admins are also given the Admin role. It is possible to make configuration changes directly in Grafana, but only to non-conflicting settings. Data sources are preconfigured and must not be edited as changes will be gone when Grafana is redeployed.
   harbor:
+    title: Harbor
     appVersion: 2.3.0
     repo: https://github.com/goharbor/harbor
     maintainers: Project Harbor
@@ -60,6 +99,7 @@ appsInfo:
     about: Harbor is an open source trusted cloud native registry project that stores, signs, and scans content. Harbor extends the open source Docker Distribution by adding the functionalities usually required by users such as security, identity and management. Having a registry closer to the build and run environment can improve the image transfer efficiency. Harbor supports replication of images between registries, and also offers advanced security features such as user management, access control and activity auditing.
     integration: Harbor can be enabled to provide each team with a private registry. Harbor has been made user and tenant aware. Otomi runs automated tasks that take care of creating a project in Harbor for each team, creating a bot-account for each team, and creating a Kubernetes pull secret in the team namespace to enable pulling of images out of the local registry.
   httpbin:
+    title: HTTPbin
     appVersion: 0.1.0
     repo: https://github.com/postmanlabs/httpbin
     maintainers: Postman Inc.
@@ -69,6 +109,7 @@ appsInfo:
     about: HTTP Request & Response Service
     integration: Httpbin is by default available for developers to use.
   ingress-nginx:
+    title: Ingress-NGINX
     appVersion: 1.1.2
     repo: https://github.com/kubernetes/ingress-nginx
     maintainers: NGINX
@@ -77,6 +118,7 @@ appsInfo:
     about: ingress-nginx is an Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.
     integration: Otomi integrated ingress-nginx into an advanced ingress architecture.
   istio:
+    title: Istio
     appVersion: 1.10.1
     repo: https://github.com/istio/istio
     maintainers: Istio
@@ -86,6 +128,7 @@ appsInfo:
     about: Istio is an open platform for providing a uniform way to integrate microservices, manage traffic flow across microservices, enforce policies and aggregate telemetry data. Istio's control plane provides an abstraction layer over the underlying cluster management platform.
     integration: Otomi has security best practices built in, and is designed for intrusion. Istio is used by Otomi as a service mesh to deliver mTLS enforcement for all traffic that is deemed compromisable, egress control to force teams to choose explicit egress endpoints, and advanced routing capabilities such as weight based load balancing (A/B or blue/green testing). Istio is part of the core of Otomi and can not be disabled.
   jaeger:
+    title: Jaeger
     appVersion: 1.25.0
     repo: https://github.com/jaegertracing/jaeger
     maintainers: CNCF
@@ -95,6 +138,7 @@ appsInfo:
     about: Jaeger is a distributed tracing platform. It can be used for monitoring microservices-based distributed systems. As on-the-ground microservice practitioners are quickly realizing, the majority of operational problems that arise when moving to a distributed architecture are ultimately grounded in networking and observability. It is simply an orders of magnitude larger problem to network and debug a set of intertwined distributed services versus a single monolithic application.
     integration: Jaeger can be activated to gain tracing insights on its network traffic. It runs in anonymous mode and each authenticated user is given the same authorization, allowing them to see everything.
   keycloak:
+    title: Keycloak
     appVersion: 15.0.2
     repo: https://github.com/keycloak/keycloak
     maintainers: Keycloak
@@ -105,6 +149,7 @@ appsInfo:
     about: Keycloak is an Open Source Identity and Access Management solution for modern Applications and Services.
     integration: The SSO login page for Otomi is served by Keycloak. Keycloak is used as an identity broker or provider for all Otomi integrated applications. By default Keycloak is configured as an Identity Broker. Keycloak is part of the core of Otomi and is always enabled.
   kiali:
+    title: Kiali
     appVersion: 1.47.0
     repo: https://github.com/kiali/kiali
     maintainers: Kiali
@@ -114,6 +159,7 @@ appsInfo:
     about: Kiali is a management console for Istio to manage, visualize, validate and troubleshoot the service mesh.
     integration: Kiali can be activated to gain observability insights on its network traffic. Kiali runs in anonymous mode and each authenticated user is given the same authorization, allowing them to see everything.
   knative:
+    title: Knative
     appVersion: dependent on k8s version
     repo: https://github.com/knative/serving
     maintainers: Knative
@@ -124,6 +170,7 @@ appsInfo:
     about: Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers. Serving is easy to get started with and scales to support advanced scenarios.
     integration: Knative serving can be activated to deliver Container-as-a-Service (CaaS) functionality with a scale-to-zero option. It can be compared to Functions-as-a-service (FaaS) but is container oriented, and takes only one manifest to configure an auto scaling service based on a container image of choice. Otomi offers an on-the-fly Knative service deployment, making it very easy to deploy containerized services without the hassle of providing all the supporting resources involved with Helm charts. Istio Virtual Services are used to route traffic coming in for a public domain to its backing Knative Service, allowing it to set a custom domain.
   kubeapps:
+    title: KubeApps
     appVersion: 2.4.3
     repo: https://github.com/vmware-tanzu/kubeapps
     maintainers: VMware Tanzu
@@ -134,6 +181,7 @@ appsInfo:
     about: Kubeapps is an in-cluster web-based application that enables users with a one-time installation to deploy, manage, and upgrade applications on a Kubernetes cluster.
     integration: Kubeapps can be activated to deploy applications from multiple registries. Teams can login to Kubeapps using the generated token that is provided when downloading the KUBECFG.
   kubeclarity:
+    title: KubeClarity
     appVersion: 2.3.0
     repo: https://github.com/openclarity/kubeclarity
     maintainers: OpenClarity
@@ -143,6 +191,7 @@ appsInfo:
     about: KubeClarity is a tool for detection and management of Software Bill Of Materials (SBOM) and vulnerabilities of container images and filesystems. It scans both runtime K8s clusters and CI/CD pipelines for enhanced software supply chain security.
     integration: KubeClarity can be activated to scan running containers and filesystems for vulnerabilities.
   loki:
+    title: Loki
     appVersion: 2.4.1
     repo: https://github.com/grafana/loki
     maintainers: Grafana Labs
@@ -153,6 +202,7 @@ appsInfo:
     about: Loki is a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus. It is designed to be very cost effective and easy to operate. It does not index the contents of the logs, but rather a set of labels for each log stream.
     integration: Loki can be activated to aggregate all the container logs on the platform and store them in a storage endpoint of choice (defaults to PVC). When Otomi is configured in multi-tenancy mode, logs will be split-up between team namespaces and made available for team members only. Otomi shortcuts can be used to provide selections of logs based on interest.
   prometheus:
+    title: Prometheus
     appVersion: 0.57.0
     repo: https://github.com/prometheus/prometheus
     maintainers: Prometheus
@@ -163,6 +213,7 @@ appsInfo:
     about: Prometheus is a systems and service monitoring system. It collects metrics from configured targets at given intervals, evaluates rule expressions, displays the results, and can trigger alerts when specified conditions are observed.
     integration: Prometheus can be activated to aggregate all platform metrics and store them in a storage endpoint of choice (defaults to PVC). When Otomi is configured in multi-tenancy mode, each team will be provided with a dedicated Prometheus instance. This instance can be used to aggregate custom team metrics.
   vault:
+    title: Vault
     appVersion: 1.14.3
     repo: https://github.com/hashicorp/vault
     maintainers: HashiCorp


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
