### PR TITLE
fix: gitea postgres pv size

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -173,6 +173,8 @@ postgresql:
   persistence:
     {{- if eq $v.cluster.provider "vultr" }}
     size: 10Gi
+    {{- else }}
+    size: 1Gi
     {{- end }}
   global:
     postgresql:


### PR DESCRIPTION
This fixes the issue where the pv size for Gitea Postgress was not set in case the provider is not vultr.
