### PR TITLE
feat: more dns providers, including 'other'

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,6 +7,6 @@ npm run lint
 if ! git diff HEAD main --quiet; then
   # if values files have BOTH been modified, then we know migrate is safe
   if test $(git diff origin/main --name-only | awk 'xor(/values-schema.yaml/,/values-changes.yaml/)' | wc -l) = 2; then
-    npm run migrate-values -- -ni
+    npm run migrate-values
   fi
 fi

--- a/.values/env/secrets.teams.yaml
+++ b/.values/env/secrets.teams.yaml
@@ -1,1 +1,0 @@
-teamConfig: {}

--- a/.values/env/settings.yaml
+++ b/.values/env/settings.yaml
@@ -1,1 +1,1 @@
-version: 4
+version: 5

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -138,7 +138,7 @@
       "request": "launch",
       "runtimeExecutable": "node",
       "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
-      "args": ["src/otomi.ts", "--", "template", "-l", "name=external-dns", "-k", "1.22"],
+      "args": ["src/otomi.ts", "--", "template", "-l", "name=external-dns"],
       "cwd": "${workspaceRoot}",
       "internalConsoleOptions": "openOnSessionStart",
       "skipFiles": ["<node_internals>/**", "node_modules/**"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,7 +50,7 @@
   "sops.enabled": false,
   "todohighlight.include": ["**/*.ts", "**/*.tsx", "**/*.html", "**/*.css", "**/*.scss", "**/*.gotmpl", "**/*.yaml"],
   "yaml.schemas": {
-    ".vscode/values-schema.yaml": "**/env/*.yaml",
+    ".vscode/values-schema.yaml": "**/env/**/*.yaml",
     "https://json-schema.org/draft-07/schema": "values-schema.yaml"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.16.14](https://github.com/redkubes/otomi-core/compare/v0.16.13...v0.16.14) (2022-08-24)
+
+
+### Features
+
+* add OVHcloud provider ([#878](https://github.com/redkubes/otomi-core/issues/878)) ([563d084](https://github.com/redkubes/otomi-core/commit/563d08489b64603d3d87dee238a8ff6bbc348cc2))
+* add vultr provider ([#877](https://github.com/redkubes/otomi-core/issues/877)) ([0f1cb03](https://github.com/redkubes/otomi-core/commit/0f1cb0381df86665831eaa3d5cff2fd9c3b05cc1))
+* app descriptions in core ([#881](https://github.com/redkubes/otomi-core/issues/881)) ([f72ebd6](https://github.com/redkubes/otomi-core/commit/f72ebd683814ccdeb00f20ed1785ab912189e0c6))
+* load apps.yaml and provided it to otomi-api ([c8b02c9](https://github.com/redkubes/otomi-core/commit/c8b02c99de2a8818f0da14c598f771c1c33a1f0b))
+* move apps info to separate file ([285c963](https://github.com/redkubes/otomi-core/commit/285c9638ad0100d506127686bf64734aee66347f))
+* move apps info to separate object ([2d7891e](https://github.com/redkubes/otomi-core/commit/2d7891e1efa3c64d8932b0979b7aaaa93f020267))
+* schema and related logic grooming ([#879](https://github.com/redkubes/otomi-core/issues/879)) ([9f04eb3](https://github.com/redkubes/otomi-core/commit/9f04eb35960c06377fc759b592ab1ccfa5afb4f4)), closes [redkubes/unassigned-issues#442](https://github.com/redkubes/unassigned-issues/issues/442)
+* new info tab showing the version of the app, the repo and other usefull information in Otomi Console (Platform/Apps)
+* direct navigation to applications and settings in Otomi Console (Platform/Apps and Teams/Apps)
+
+### Bug Fixes
+
+* broken link in otomi CLI ([#875](https://github.com/redkubes/otomi-core/issues/875)) ([c2ce8f9](https://github.com/redkubes/otomi-core/commit/c2ce8f9f63f9e3fb588ec0ac1d409210ee1d7010))
+* gitea postgres pv size ([#887](https://github.com/redkubes/otomi-core/issues/887)) ([cd08008](https://github.com/redkubes/otomi-core/commit/cd08008b0a74034a7cb0b15d3a9209e255e25b3d))
+* missing appinfo, titles added ([#883](https://github.com/redkubes/otomi-core/issues/883)) ([99f4e76](https://github.com/redkubes/otomi-core/commit/99f4e768a1cec98c2e6077f457aced3da74adab9))
+
+
+### Docs
+
+* describe creating values repo ([#874](https://github.com/redkubes/otomi-core/issues/874)) ([bdd6022](https://github.com/redkubes/otomi-core/commit/bdd6022021476f9773aa0452d822d62e05aa0d51))
+* using otomi cli in dev mode ([#872](https://github.com/redkubes/otomi-core/issues/872)) ([4ae9ac0](https://github.com/redkubes/otomi-core/commit/4ae9ac0bb578f4e16f84794d73934c55626f4c37))
+
+
+### Others
+
+* bump otomi versions and fix docs ([#885](https://github.com/redkubes/otomi-core/issues/885)) ([8dc91a9](https://github.com/redkubes/otomi-core/commit/8dc91a9f76956973bece098da505c81e8367e060))
+
 ### [0.16.13](https://github.com/redkubes/otomi-core/compare/v0.16.12...v0.16.13) (2022-08-11)
 
 

--- a/adr/2022-08-26-other-dns-provider.md
+++ b/adr/2022-08-26-other-dns-provider.md
@@ -1,0 +1,11 @@
+# Other DNS provider
+
+Maurice:
+
+**Background:**
+
+We collect one set of configuration for DNS, which is following the schema of the `external-dns` chart. That same config is mapped onto the cert-manager chart.
+
+**Change introduced:**
+
+Since `cert-manager` charts only has a limited set of providers, but `external-dns` chart has lots, we now also offer an extra provider option `other`. This option asks for a provider name and a yaml blob for `external-dns`, and a yaml blob for `cert-manager` that will be used for the `cluster-issuer`'s `dns01` section.

--- a/adr/index.md
+++ b/adr/index.md
@@ -16,6 +16,7 @@ This log lists the architectural decisions for otomi-core.
 * [ADR-2022-05-17](2022-05-17-destroy-upon-uninstall.md) - Extra flags to accomodate destroy upon uninstall
 * [ADR-2022-06-07](2022-06-07-ingress-classes.md) - Ingress classes
 * [ADR-2022-07-02](2022-07-02-node-affinity.md) - Node affinity
+* [ADR-2022-08-26](2022-08-26-other-dns-provider.md) - Other DNS provider
 
 <!-- adrlogstop -->
 

--- a/chart/otomi/values.yaml
+++ b/chart/otomi/values.yaml
@@ -47,34 +47,25 @@ otomi: {}
   ## By default the image tag is set to .Chart.AppVersion
   # version: main
 
-apps:
-  cert-manager:
+## Optional configuration
+# apps:
+#   cert-manager:
     ## Set issuer 
     ## Use a custom-ca (for BYO CA or auto-generated CA) or letsencrypt. 
     ## When using letsencrypt, also fill in 'dns'.
-    issuer: custom-ca
+    # issuer: custom-ca
     ## Set when using BYO CA. 
     ## If not filled in, a CA will be auto generated
     # customRootCA:
     # customRootCAKey:
-
     ## Set when issuer is letsencrypt
     # email: ''
     # stage: staging # defaults to 'production' when commented out
 
-  external-dns:
-    ## List one or more domains that the credentials under dns give access to
-    domainFilters:
-      - ''
-    ## if your dns credentials give authorization to manage everything on a root domain (i.e. *.example.com)
-    ## you can limit the scope to a list of zones that only operate on a subdomain (i.e. test.example.com):
-    # zoneIdFilters:
-    #   - ''
-    
-## Optional configuration
-
 ## External dns zone configuration
 # dns:
+#   domainFilters: []
+#   zoneIdFilters: []
 #   provider:
 #     # provide one of the following below: aws|azure|google
 #     aws:

--- a/charts/external-dns/Chart.lock
+++ b/charts/external-dns/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.3
-digest: sha256:710e8247ae70ea63a2fb2fde4320511ff28c7b5c7a738861427f104a7718bdf4
-generated: "2021-12-13T15:39:42.319653929Z"
+  version: 2.0.1
+digest: sha256:46553c7194313fd9ce2e1e86422eef4dab3defb450e20c692f865924eacb8fb1
+generated: "2022-08-23T21:17:43.285411696Z"

--- a/charts/external-dns/Chart.yaml
+++ b/charts/external-dns/Chart.yaml
@@ -1,13 +1,13 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 0.10.2
+appVersion: 0.12.2
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
   tags:
   - bitnami-common
-  version: 1.x.x
+  version: 2.x.x
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers
   with information about exposed Kubernetes services to make them discoverable.
 home: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
@@ -17,11 +17,11 @@ keywords:
 - network
 - dns
 maintainers:
-- email: containers@bitnami.com
-  name: Bitnami
+- name: Bitnami
+  url: https://github.com/bitnami/charts
 name: external-dns
 sources:
 - https://github.com/kubernetes-sigs/external-dns
-- https://github.com/bitnami/bitnami-docker-external-dns
+- https://github.com/bitnami/containers/tree/main/bitnami/external-dns
 - https://github.com/kubernetes-sigs/external-dns
-version: 6.0.2
+version: 6.8.1

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -1,7 +1,13 @@
-# external-dns
+<!--- app-name: ExternalDNS -->
 
-[ExternalDNS](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+# ExternalDNS packaged by Bitnami
 
+ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+
+[Overview of ExternalDNS](https://github.com/kubernetes-incubator/external-dns)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+                           
 ## TL;DR
 
 ```console
@@ -11,14 +17,14 @@ $ helm install my-release bitnami/external-dns
 
 ## Introduction
 
-This chart bootstraps a [ExternalDNS](https://github.com/bitnami/bitnami-docker-external-dns) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [ExternalDNS](https://github.com/bitnami/containers/tree/main/bitnami/external-dns) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
 ## Prerequisites
 
 - Kubernetes 1.19+
-- Helm 3.1.0
+- Helm 3.2.0+
 
 ## Installing the Chart
 
@@ -54,15 +60,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                                                                  | Value           |
-| ------------------- | -------------------------------------------------------------------------------------------- | --------------- |
-| `nameOverride`      | String to partially override external-dns.fullname template (will maintain the release name) | `""`            |
-| `fullnameOverride`  | String to fully override external-dns.fullname template                                      | `""`            |
-| `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
-| `commonLabels`      | Labels to add to all deployed objects                                                        | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects                                                   | `{}`            |
-| `extraDeploy`       | Array of extra objects to deploy with the release (evaluated as a template).                 | `[]`            |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`            |
+| Name                    | Description                                                                                  | Value           |
+| ----------------------- | -------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`          | String to partially override external-dns.fullname template (will maintain the release name) | `""`            |
+| `fullnameOverride`      | String to fully override external-dns.fullname template                                      | `""`            |
+| `clusterDomain`         | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `commonLabels`          | Labels to add to all deployed objects                                                        | `{}`            |
+| `commonAnnotations`     | Annotations to add to all deployed objects                                                   | `{}`            |
+| `extraDeploy`           | Array of extra objects to deploy with the release (evaluated as a template).                 | `[]`            |
+| `kubeVersion`           | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`            |
+| `watchReleaseNamespace` | Watch only namepsace used for the release                                                    | `false`         |
+
 
 ### external-dns parameters
 
@@ -70,7 +78,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`                              | ExternalDNS image registry                                                                                                                                                   | `docker.io`               |
 | `image.repository`                            | ExternalDNS image repository                                                                                                                                                 | `bitnami/external-dns`    |
-| `image.tag`                                   | ExternalDNS Image tag (immutable tags are recommended)                                                                                                                       | `0.10.1-debian-10-r33`    |
+| `image.tag`                                   | ExternalDNS Image tag (immutable tags are recommended)                                                                                                                       | `0.12.2-debian-11-r5`     |
+| `image.digest`                                | ExternalDNS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                                  | `""`                      |
 | `image.pullPolicy`                            | ExternalDNS image pull policy                                                                                                                                                | `IfNotPresent`            |
 | `image.pullSecrets`                           | ExternalDNS image pull secrets                                                                                                                                               | `[]`                      |
 | `hostAliases`                                 | Deployment pod host aliases                                                                                                                                                  | `[]`                      |
@@ -105,6 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `aws.roleArn`                                 | Specify role ARN to the external-dns daemon                                                                                                                                  | `""`                      |
 | `aws.apiRetries`                              | Maximum number of retries for AWS API calls before giving up                                                                                                                 | `3`                       |
 | `aws.batchChangeSize`                         | When using the AWS provider, set the maximum number of changes that will be applied in each batch                                                                            | `1000`                    |
+| `aws.zonesCacheDuration`                      | If the list of Route53 zones managed by ExternalDNS doesn't change frequently, cache it by setting a TTL                                                                     | `0`                       |
 | `aws.zoneTags`                                | When using the AWS provider, filter for zones with these tags                                                                                                                | `[]`                      |
 | `aws.preferCNAME`                             | When using the AWS provider, replaces Alias records with CNAME (options: true, false)                                                                                        | `""`                      |
 | `aws.evaluateTargetHealth`                    | When using the AWS provider, sets the evaluate target health flag (options: true, false)                                                                                     | `""`                      |
@@ -148,7 +158,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `google.serviceAccountSecret`                 | When using the Google provider, specify the existing secret which contains credentials.json (optional)                                                                       | `""`                      |
 | `google.serviceAccountSecretKey`              | When using the Google provider with an existing secret, specify the key name (optional)                                                                                      | `credentials.json`        |
 | `google.serviceAccountKey`                    | When using the Google provider, specify the service account key JSON file. In this case a new secret will be created holding this service account (optional)                 | `""`                      |
-| `google.zoneVisibility`                       | When using the Google provider, fiter for zones of a specific visibility (private or public)                 | `""`                      |
+| `google.zoneVisibility`                       | When using the Google provider, fiter for zones of a specific visibility (private or public)                                                                                 | `""`                      |
 | `hetzner.token`                               | When using the Hetzner provider, specify your token here. (required when `hetzner.secretName` is not provided. In this case a new secret will be created holding the token.) | `""`                      |
 | `hetzner.secretName`                          | When using the Hetzner provider, specify the existing secret which contains your token. Disables the usage of `hetzner.token` (optional)                                     | `""`                      |
 | `hetzner.secretKey`                           | When using the Hetzner provider with an existing secret, specify the key name (optional)                                                                                     | `hetzner_token`           |
@@ -167,6 +177,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `linode.apiToken`                             | When using the Linode provider, `LINODE_TOKEN` to set (optional)                                                                                                             | `""`                      |
 | `linode.secretName`                           | Use an existing secret with key "linode_api_token" defined.                                                                                                                  | `""`                      |
 | `ns1.minTTL`                                  | When using the ns1 provider, specify minimal TTL, as an integer, for records                                                                                                 | `10`                      |
+| `ns1.apiKey`                                  | When using the ns1 provider, specify the API key to use                                                                                                                      | `""`                      |
+| `ns1.secretName`                              | Use an existing secret with key "ns1-api-key" defined.                                                                                                                       | `""`                      |
+| `oci.region`                                  | When using the OCI provider, specify the region, where your zone is located in.                                                                                              | `""`                      |
+| `oci.tenancyOCID`                             | When using the OCI provider, specify your Tenancy OCID                                                                                                                       | `""`                      |
+| `oci.userOCID`                                | When using the OCI provider, specify your User OCID                                                                                                                          | `""`                      |
+| `oci.compartmentOCID`                         | When using the OCI provider, specify your Compartment OCID where your DNS Zone is located in.                                                                                | `""`                      |
+| `oci.privateKey`                              | When using the OCI provider, paste in your RSA private key file for the Oracle API                                                                                           | `""`                      |
+| `oci.privateKeyFingerprint`                   | When using the OCI provider, put in the fingerprint of your privateKey                                                                                                       | `""`                      |
+| `oci.privateKeyPassphrase`                    | When using the OCI provider and your privateKey has a passphrase, put it in here. (optional)                                                                                 | `""`                      |
+| `oci.secretName`                              | When using the OCI provider, it's the name of the secret containing `oci.yaml` file.                                                                                         | `""`                      |
 | `ovh.consumerKey`                             | When using the OVH provider, specify the existing consumer key. (required when provider=ovh and `ovh.secretName` is not provided.)                                           | `""`                      |
 | `ovh.applicationKey`                          | When using the OVH provider with an existing application, specify the application key. (required when provider=ovh and `ovh.secretName` is not provided.)                    | `""`                      |
 | `ovh.applicationSecret`                       | When using the OVH provider with an existing application, specify the application secret. (required when provider=ovh and `ovh.secretName` is not provided.)                 | `""`                      |
@@ -251,14 +271,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.extraPorts`                          | Extra ports to expose in the service (normally used with the `sidecar` value)                                                                                                | `[]`                      |
 | `service.annotations`                         | Annotations to add to service                                                                                                                                                | `{}`                      |
 | `service.labels`                              | Provide any additional labels which may be required.                                                                                                                         | `{}`                      |
+| `service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                                                                         | `None`                    |
+| `service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                                                                                                  | `{}`                      |
 | `serviceAccount.create`                       | Determine whether a Service Account should be created or it should reuse a exiting one.                                                                                      | `true`                    |
 | `serviceAccount.name`                         | ServiceAccount to use. A name is generated using the external-dns.fullname template if it is not set                                                                         | `""`                      |
 | `serviceAccount.annotations`                  | Additional Service Account annotations                                                                                                                                       | `{}`                      |
 | `serviceAccount.automountServiceAccountToken` | Automount API credentials for a service account.                                                                                                                             | `true`                    |
+| `serviceAccount.labels`                       | Additional labels to be included on the service account                                                                                                                      | `{}`                      |
 | `rbac.create`                                 | Whether to create & use RBAC resources or not                                                                                                                                | `true`                    |
 | `rbac.clusterRole`                            | Whether to create Cluster Role. When set to false creates a Role in `namespace`                                                                                              | `true`                    |
 | `rbac.apiVersion`                             | Version of the RBAC API                                                                                                                                                      | `v1`                      |
-| `rbac.pspEnabled`                             | PodSecurityPolicy                                                                                                                                                            | `false`                   |
+| `rbac.pspEnabled`                             | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later                                  | `false`                   |
 | `containerSecurityContext`                    | Security context for the container                                                                                                                                           | `{}`                      |
 | `podSecurityContext.enabled`                  | Enable pod security context                                                                                                                                                  | `true`                    |
 | `podSecurityContext.fsGroup`                  | Group ID for the container                                                                                                                                                   | `1001`                    |
@@ -277,7 +300,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                                                                           | `5`                       |
 | `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                                                                         | `6`                       |
 | `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                                                                         | `1`                       |
-| `startupProbe.enabled`                        | Enable startupProbe                                                                                                                                                          | `true`                    |
+| `startupProbe.enabled`                        | Enable startupProbe                                                                                                                                                          | `false`                   |
 | `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                                                                       | `5`                       |
 | `startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                                                                              | `10`                      |
 | `startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                                                                             | `5`                       |
@@ -299,7 +322,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.metricRelabelings`    | Specify Metric Relabelings to add to the scrape endpoint                                                                                                                     | `[]`                      |
 | `metrics.serviceMonitor.relabelings`          | Prometheus relabeling rules                                                                                                                                                  | `[]`                      |
 | `metrics.serviceMonitor.honorLabels`          | Specify honorLabels parameter to add the scrape endpoint                                                                                                                     | `false`                   |
-| `metrics.serviceMonitor.additionalLabels`     | Used to pass Labels that are required by the installed Prometheus Operator                                                                                                   | `{}`                      |
+| `metrics.serviceMonitor.labels`               | Used to pass Labels that are required by the installed Prometheus Operator                                                                                                   | `{}`                      |
 | `metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.                                                                                            | `""`                      |
 
 
@@ -362,7 +385,7 @@ $ helm install my-release \
 
 ## Troubleshooting
 
-Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 ## Upgrading
 
 ### To 6.0.0
@@ -435,3 +458,19 @@ Other mayor changes included in this major version are:
   - `aws.credentialsPath` -> `aws.credentials.mountPath`
   - `designate.customCA.directory` -> `designate.customCA.mountPath`
 - Support to Prometheus metrics is added.
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/external-dns/charts/common/Chart.yaml
+++ b/charts/external-dns/charts/common/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.10.0
+appVersion: 2.0.1
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
@@ -13,11 +13,11 @@ keywords:
 - function
 - bitnami
 maintainers:
-- email: containers@bitnami.com
-  name: Bitnami
+- name: Bitnami
+  url: https://github.com/bitnami/charts
 name: common
 sources:
 - https://github.com/bitnami/charts
 - https://www.bitnami.com/
 type: library
-version: 1.10.3
+version: 2.0.1

--- a/charts/external-dns/charts/common/README.md
+++ b/charts/external-dns/charts/common/README.md
@@ -7,7 +7,7 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 ```yaml
 dependencies:
   - name: common
-    version: 0.x.x
+    version: 1.x.x
     repository: https://charts.bitnami.com/bitnami
 ```
 
@@ -28,12 +28,12 @@ data:
 
 This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
 ## Prerequisites
 
-- Kubernetes 1.12+
-- Helm 3.1.0
+- Kubernetes 1.19+
+- Helm 3.2.0+
 
 ## Parameters
 
@@ -43,10 +43,10 @@ The following table lists the helpers available in the library which are scoped 
 
 | Helper identifier             | Description                                          | Expected Input                                 |
 |-------------------------------|------------------------------------------------------|------------------------------------------------|
-| `common.affinities.node.soft` | Return a soft nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
-| `common.affinities.node.hard` | Return a hard nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
-| `common.affinities.pod.soft`  | Return a soft podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
-| `common.affinities.pod.hard`  | Return a hard podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
+| `common.affinities.nodes.soft` | Return a soft nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
+| `common.affinities.nodes.hard` | Return a hard nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
+| `common.affinities.pods.soft`  | Return a soft podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
+| `common.affinities.pods.hard`  | Return a hard podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
 
 ### Capabilities
 
@@ -61,6 +61,8 @@ The following table lists the helpers available in the library which are scoped 
 | `common.capabilities.crd.apiVersion`           | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
 | `common.capabilities.policy.apiVersion`        | Return the appropriate apiVersion for podsecuritypolicy.                                       | `.` Chart context |
 | `common.capabilities.networkPolicy.apiVersion` | Return the appropriate apiVersion for networkpolicy.                                           | `.` Chart context |
+| `common.capabilities.apiService.apiVersion`    | Return the appropriate apiVersion for APIService.                                              | `.` Chart context |
+| `common.capabilities.hpa.apiVersion`           | Return the appropriate apiVersion for Horizontal Pod Autoscaler                                | `.` Chart context |
 | `common.capabilities.supportsHelmVersion`      | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
 
 ### Errors
@@ -79,26 +81,29 @@ The following table lists the helpers available in the library which are scoped 
 
 ### Ingress
 
-| Helper identifier                         | Description                                                          | Expected Input                                                                                                                                                                   |
-|-------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
-| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                     | `.` Chart context                                                                                                                                                                |
-| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported             | `.` Chart context                                                                                                                                                                |
+| Helper identifier                         | Description                                                                                                       | Expected Input                                                                                                                                                                   |
+|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version                                              | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
+| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                                                                  | `.` Chart context                                                                                                                                                                |
+| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported                                                          | `.` Chart context                                                                                                                                                                |
+| `common.ingress.certManagerRequest`       | Prints "true" if required cert-manager annotations for TLS signed certificates are set in the Ingress annotations | `dict "annotations" .Values.path.to.the.ingress.annotations`                                                                                                                     |
 
 ### Labels
 
-| Helper identifier           | Description                                          | Expected Input    |
-|-----------------------------|------------------------------------------------------|-------------------|
-| `common.labels.standard`    | Return Kubernetes standard labels                    | `.` Chart context |
-| `common.labels.matchLabels` | Return the proper Docker Image Registry Secret Names | `.` Chart context |
+| Helper identifier           | Description                                                                 | Expected Input    |
+|-----------------------------|-----------------------------------------------------------------------------|-------------------|
+| `common.labels.standard`    | Return Kubernetes standard labels                                           | `.` Chart context |
+| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector` | `.` Chart context |
 
 ### Names
 
-| Helper identifier       | Description                                                | Expected Input   |
-|-------------------------|------------------------------------------------------------|-------------------|
-| `common.names.name`     | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context |
-| `common.names.fullname` | Create a default fully qualified app name.                 | `.` Chart context |
-| `common.names.chart`    | Chart name plus version                                    | `.` Chart context |
+| Helper identifier                 | Description                                                           | Expected Input    |
+|-----------------------------------|-----------------------------------------------------------------------|-------------------|
+| `common.names.name`               | Expand the name of the chart or use `.Values.nameOverride`            | `.` Chart context |
+| `common.names.fullname`           | Create a default fully qualified app name.                            | `.` Chart context |
+| `common.names.namespace`          | Allow the release namespace to be overridden                          | `.` Chart context |
+| `common.names.fullname.namespace` | Create a fully qualified app name adding the installation's namespace | `.` Chart context |
+| `common.names.chart`              | Chart name plus version                                               | `.` Chart context |
 
 ### Secrets
 
@@ -137,8 +142,9 @@ The following table lists the helpers available in the library which are scoped 
 | `common.validations.values.single.empty`         | Validate a value must not be empty.                                                                                           | `dict "valueKey" "path.to.value" "secret" "secret.name" "field" "my-password" "subchart" "subchart" "context" $` secret, field and subchart are optional. In case they are given, the helper will generate a how to get instruction. See [ValidateValue](#validatevalue) |
 | `common.validations.values.multiple.empty`       | Validate a multiple values must not be empty. It returns a shared error for all the values.                                   | `dict "required" (list $validateValueConf00 $validateValueConf01) "context" $`. See [ValidateValue](#validatevalue)                                                                                                                                                      |
 | `common.validations.values.mariadb.passwords`    | This helper will ensure required password for MariaDB are not empty. It returns a shared error for all the values.            | `dict "secret" "mariadb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mariadb chart and the helper.                                                                                      |
+| `common.validations.values.mysql.passwords`      | This helper will ensure required password for MySQL are not empty. It returns a shared error for all the values.              | `dict "secret" "mysql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mysql chart and the helper.                                                                                      |
 | `common.validations.values.postgresql.passwords` | This helper will ensure required password for PostgreSQL are not empty. It returns a shared error for all the values.         | `dict "secret" "postgresql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use postgresql chart and the helper.                                                                                |
-| `common.validations.values.redis.passwords`      | This helper will ensure required password for Redis&trade; are not empty. It returns a shared error for all the values. | `dict "secret" "redis-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use redis chart and the helper.                                                                                          |
+| `common.validations.values.redis.passwords`      | This helper will ensure required password for Redis&reg; are not empty. It returns a shared error for all the values. | `dict "secret" "redis-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use redis chart and the helper.                                                                                          |
 | `common.validations.values.cassandra.passwords`  | This helper will ensure required password for Cassandra are not empty. It returns a shared error for all the values.          | `dict "secret" "cassandra-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use cassandra chart and the helper.                                                                                  |
 | `common.validations.values.mongodb.passwords`    | This helper will ensure required password for MongoDB&reg; are not empty. It returns a shared error for all the values.            | `dict "secret" "mongodb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mongodb chart and the helper.                                                                                      |
 
@@ -296,11 +302,11 @@ If we force those values to be empty we will see some alerts
 $ helm install test mychart --set path.to.value00="",path.to.value01=""
     'path.to.value00' must not be empty, please add '--set path.to.value00=$PASSWORD_00' to the command. To get the current value:
 
-        export PASSWORD_00=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-00}" | base64 --decode)
+        export PASSWORD_00=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-00}" | base64 -d)
 
     'path.to.value01' must not be empty, please add '--set path.to.value01=$PASSWORD_01' to the command. To get the current value:
 
-        export PASSWORD_01=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-01}" | base64 --decode)
+        export PASSWORD_01=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-01}" | base64 -d)
 ```
 
 ## Upgrading
@@ -326,3 +332,19 @@ $ helm install test mychart --set path.to.value00="",path.to.value01=""
 - https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
 - https://helm.sh/docs/topics/v2_v3_migration/
 - https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/external-dns/charts/common/templates/_affinities.tpl
+++ b/charts/external-dns/charts/common/templates/_affinities.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Return a soft nodeAffinity definition 
+Return a soft nodeAffinity definition
 {{ include "common.affinities.nodes.soft" (dict "key" "FOO" "values" (list "BAR" "BAZ")) -}}
 */}}
 {{- define "common.affinities.nodes.soft" -}}
@@ -63,7 +63,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
           {{ $key }}: {{ $value | quote }}
           {{- end }}
       namespaces:
-        - {{ .context.Release.Namespace | quote }}
+        - {{ include "common.names.namespace" .context | quote }}
       topologyKey: kubernetes.io/hostname
     weight: 1
 {{- end -}}
@@ -85,7 +85,7 @@ requiredDuringSchedulingIgnoredDuringExecution:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     namespaces:
-      - {{ .context.Release.Namespace | quote }}
+      - {{ include "common.names.namespace" .context | quote }}
     topologyKey: kubernetes.io/hostname
 {{- end -}}
 

--- a/charts/external-dns/charts/common/templates/_capabilities.tpl
+++ b/charts/external-dns/charts/common/templates/_capabilities.tpl
@@ -116,6 +116,32 @@ Return the appropriate apiVersion for CRDs.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for APIService.
+*/}}
+{{- define "common.capabilities.apiService.apiVersion" -}}
+{{- if semverCompare "<1.10-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiregistration.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiregistration.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Horizontal Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.hpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns true if the used Helm version is 3.3+.
 A way to check the used Helm version was not introduced until version 3.3.0 with .Capabilities.HelmVersion, which contains an additional "{}}"  structure.
 This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVersion }} because checking for the key HelmVersion in <3.3 results in a "interface not found" error.

--- a/charts/external-dns/charts/common/templates/_images.tpl
+++ b/charts/external-dns/charts/common/templates/_images.tpl
@@ -6,17 +6,18 @@ Return the proper image name
 {{- define "common.images.image" -}}
 {{- $registryName := .imageRoot.registry -}}
 {{- $repositoryName := .imageRoot.repository -}}
-{{- $tag := .imageRoot.tag | toString -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
 {{- if .global }}
     {{- if .global.imageRegistry }}
      {{- $registryName = .global.imageRegistry -}}
     {{- end -}}
 {{- end -}}
-{{- if $registryName }}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- else -}}
-{{- printf "%s:%s" $repositoryName $tag -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
 {{- end -}}
+{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
 {{- end -}}
 
 {{/*

--- a/charts/external-dns/charts/common/templates/_ingress.tpl
+++ b/charts/external-dns/charts/common/templates/_ingress.tpl
@@ -53,3 +53,16 @@ Usage:
 {{- print "true" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if cert-manager required annotations for TLS signed
+certificates are set in the Ingress annotations
+Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+Usage:
+{{ include "common.ingress.certManagerRequest" ( dict "annotations" .Values.path.to.the.ingress.annotations ) }}
+*/}}
+{{- define "common.ingress.certManagerRequest" -}}
+{{ if or (hasKey .annotations "cert-manager.io/cluster-issuer") (hasKey .annotations "cert-manager.io/issuer") }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/external-dns/charts/common/templates/_names.tpl
+++ b/charts/external-dns/charts/common/templates/_names.tpl
@@ -50,3 +50,21 @@ Usage:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "common.names.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name adding the installation's namespace.
+*/}}
+{{- define "common.names.fullname.namespace" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) (include "common.names.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/external-dns/charts/common/templates/_secrets.tpl
+++ b/charts/external-dns/charts/common/templates/_secrets.tpl
@@ -72,6 +72,15 @@ Params:
   - strong - Boolean - Optional - Whether to add symbols to the generated random password.
   - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
   - context - Context - Required - Parent context.
+
+The order in which this function returns a secret password:
+  1. Already existing 'Secret' resource
+     (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
+  2. Password provided via the values.yaml
+     (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
+  3. Randomly generated secret password
+     (A new random secret password with the length specified in the 'length' parameter will be generated and returned)
+
 */}}
 {{- define "common.secrets.passwords.manage" -}}
 
@@ -81,10 +90,12 @@ Params:
 {{- $passwordLength := default 10 .length }}
 {{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
 {{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
-{{- $secret := (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
-{{- if $secret }}
-  {{- if index $secret.data .key }}
-  {{- $password = index $secret.data .key }}
+{{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data }}
+{{- if $secretData }}
+  {{- if hasKey $secretData .key }}
+    {{- $password = index $secretData .key }}
+  {{- else }}
+    {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- end -}}
 {{- else if $providedPasswordValue }}
   {{- $password = $providedPasswordValue | toString | b64enc | quote }}
@@ -98,7 +109,7 @@ Params:
   {{- $requiredPasswordError := include "common.validations.values.single.empty" $requiredPassword -}}
   {{- $passwordValidationErrors := list $requiredPasswordError -}}
   {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $.context) -}}
-  
+
   {{- if .strong }}
     {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
     {{- $password = randAscii $passwordLength }}

--- a/charts/external-dns/charts/common/templates/_utils.tpl
+++ b/charts/external-dns/charts/common/templates/_utils.tpl
@@ -6,7 +6,7 @@ Usage:
 */}}
 {{- define "common.utils.secret.getvalue" -}}
 {{- $varname := include "common.utils.fieldToEnvVar" . -}}
-export {{ $varname }}=$(kubectl get secret --namespace {{ .context.Release.Namespace | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 --decode)
+export {{ $varname }}=$(kubectl get secret --namespace {{ .context.Release.Namespace | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 -d)
 {{- end -}}
 
 {{/*

--- a/charts/external-dns/charts/common/templates/validations/_mongodb.tpl
+++ b/charts/external-dns/charts/common/templates/validations/_mongodb.tpl
@@ -97,7 +97,7 @@ Auxiliary function to get the right value for architecture
 Usage:
 {{ include "common.mongodb.values.architecture" (dict "subchart" "true" "context" $) }}
 Params:
-  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
 */}}
 {{- define "common.mongodb.values.architecture" -}}
   {{- if .subchart -}}

--- a/charts/external-dns/charts/common/templates/validations/_mysql.tpl
+++ b/charts/external-dns/charts/common/templates/validations/_mysql.tpl
@@ -1,0 +1,103 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate MySQL required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.mysql.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where MySQL values are stored, e.g: "mysql-passwords-secret"
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.mysql.passwords" -}}
+  {{- $existingSecret := include "common.mysql.values.auth.existingSecret" . -}}
+  {{- $enabled := include "common.mysql.values.enabled" . -}}
+  {{- $architecture := include "common.mysql.values.architecture" . -}}
+  {{- $authPrefix := include "common.mysql.values.key.auth" . -}}
+  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
+  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
+  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
+  {{- $valueKeyReplicationPassword := printf "%s.replicationPassword" $authPrefix -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mysql-root-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+    {{- if not (empty $valueUsername) -}}
+        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mysql-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+    {{- end -}}
+
+    {{- if (eq $architecture "replication") -}}
+        {{- $requiredReplicationPassword := dict "valueKey" $valueKeyReplicationPassword "secret" .secret "field" "mysql-replication-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mysql.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mysql.
+
+Usage:
+{{ include "common.mysql.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mysql.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mysql.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mysql.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mysql.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.key.auth" -}}
+  {{- if .subchart -}}
+    mysql.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}

--- a/charts/external-dns/charts/common/templates/validations/_redis.tpl
+++ b/charts/external-dns/charts/common/templates/validations/_redis.tpl
@@ -1,7 +1,7 @@
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate Redis&trade; required passwords are not empty.
+Validate Redis&reg; required passwords are not empty.
 
 Usage:
 {{ include "common.validations.values.redis.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}

--- a/charts/external-dns/templates/_helpers.tpl
+++ b/charts/external-dns/templates/_helpers.tpl
@@ -134,6 +134,8 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "linode") .Values.linode.apiToken (not .Values.linode.secretName) -}}
     {{- true -}}
+{{- else if and (eq .Values.provider "oci") .Values.oci.privateKeyFingerprint (not .Values.oci.secretName) -}}
+    {{- true -}}
 {{- else if and (eq .Values.provider "rfc2136") (or .Values.rfc2136.tsigSecret (and .Values.rfc2136.kerberosUsername .Values.rfc2136.kerberosPassword)) (not .Values.rfc2136.secretName) -}}
     {{- true -}}
 {{- else if and (eq .Values.provider "pdns") .Values.pdns.apiKey (not .Values.pdns.secretName) -}}
@@ -145,6 +147,8 @@ Return true if a secret object should be created
 {{- else if and (eq .Values.provider "scaleway") .Values.scaleway.scwAccessKey -}}
     {{- true -}}
 {{- else if and (eq .Values.provider "vinyldns") (or .Values.vinyldns.secretKey .Values.vinyldns.accessKey) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "ns1") .Values.ns1.apiKey (not .Values.ns1.secretName) -}}
     {{- true -}}
 {{- else -}}
 {{- end -}}
@@ -162,7 +166,6 @@ Return true if a configmap object should be created
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Return the name of the Secret used to store the passwords
 */}}
@@ -179,10 +182,12 @@ Return the name of the Secret used to store the passwords
 {{- .Values.digitalocean.secretName }}
 {{- else if and (eq .Values.provider "google") .Values.google.serviceAccountSecret }}
 {{- .Values.google.serviceAccountSecret }}
-{{- else if and (eq .Values.provider "hetzner") .Values.hetzner.secretName -}}
-{{- .Values.hetzner.secretName -}}
+{{- else if and (eq .Values.provider "hetzner") .Values.hetzner.secretName }}
+{{- .Values.hetzner.secretName }}
 {{- else if and (eq .Values.provider "linode") .Values.linode.secretName }}
 {{- .Values.linode.secretName }}
+{{- else if and (eq .Values.provider "oci") .Values.oci.secretName }}
+{{- .Values.oci.secretName }}
 {{- else if and (eq .Values.provider "ovh") .Values.ovh.secretName }}
 {{- .Values.ovh.secretName }}
 {{- else if and (eq .Values.provider "pdns") .Values.pdns.secretName }}
@@ -191,6 +196,8 @@ Return the name of the Secret used to store the passwords
 {{- .Values.infoblox.secretName }}
 {{- else if and (eq .Values.provider "rfc2136") .Values.rfc2136.secretName }}
 {{- .Values.rfc2136.secretName }}
+{{- else if and (eq .Values.provider "ns1") .Values.ns1.secretName }}
+{{- .Values.ns1.secretName }}
 {{- else -}}
 {{- template "external-dns.fullname" . }}
 {{- end -}}
@@ -200,16 +207,16 @@ Return the name of the Secret used to store the passwords
 {
   {{- if .Values.alibabacloud.regionId }}
   "regionId": "{{ .Values.alibabacloud.regionId }}",
-  {{- end}}
+  {{- end }}
   {{- if .Values.alibabacloud.vpcId }}
   "vpcId": "{{ .Values.alibabacloud.vpcId }}",
-  {{- end}}
+  {{- end }}
   {{- if .Values.alibabacloud.accessKeyId }}
   "accessKeyId": "{{ .Values.alibabacloud.accessKeyId }}",
-  {{- end}}
+  {{- end }}
   {{- if .Values.alibabacloud.accessKeySecret }}
   "accessKeySecret": "{{ .Values.alibabacloud.accessKeySecret }}"
-  {{- end}}
+  {{- end }}
 }
 {{ end }}
 
@@ -228,9 +235,13 @@ region = {{ .Values.aws.region }}
 {
   {{- if .Values.azure.cloud }}
   "cloud": "{{ .Values.azure.cloud }}",
-  {{- end}}
+  {{- end }}
+  {{- if .Values.azure.tenantId }}
   "tenantId": "{{ .Values.azure.tenantId }}",
+  {{- end }}
+  {{- if .Values.azure.subscriptionId }}
   "subscriptionId": "{{ .Values.azure.subscriptionId }}",
+  {{- end }}
   "resourceGroup": "{{ .Values.azure.resourceGroup }}",
   {{- if not .Values.azure.useManagedIdentityExtension }}
   "aadClientId": "{{ .Values.azure.aadClientId }}",
@@ -243,6 +254,19 @@ region = {{ .Values.aws.region }}
   "useManagedIdentityExtension": true
   {{- end }}
 }
+{{ end }}
+{{- define "external-dns.oci-credentials" -}}
+auth:
+  region: {{ .Values.oci.region }}
+  tenancy: {{ .Values.oci.tenancyOCID }}
+  user: {{ .Values.oci.userOCID }}
+  key: {{ toYaml .Values.oci.privateKey | indent 4 }}
+  fingerprint: {{ .Values.oci.privateKeyFingerprint }}
+  # Omit if there is not a password for the key
+  {{- if .Values.oci.privateKeyPassphrase }}
+  passphrase: {{ .Values.oci.privateKeyPassphrase }}
+  {{- end }}
+compartment: {{ .Values.oci.compartmentOCID }}
 {{ end }}
 
 {{/*
@@ -259,9 +283,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.pdns.apiKey" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.resourceGroupWithoutTenantId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.resourceGroupWithoutSubscriptionId" .) -}}
-{{- $messages := append $messages (include "external-dns.validateValues.azure.tenantIdWithoutResourceGroup" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.tenantIdWithoutSubscriptionId" .) -}}
-{{- $messages := append $messages (include "external-dns.validateValues.azure.subscriptionIdWithoutResourceGroup" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.subscriptionIdWithoutTenantId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientSecret" .) -}}
@@ -278,6 +300,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.userAssignedIdentityIDWithoutUseManagedIdentityExtension" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.account" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.apiKey" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.ns1.apiKey" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.linode.apiToken" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.ovh.consumerKey" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.ovh.applicationKey" .) -}}
@@ -417,18 +440,6 @@ external-dns: azure.resourceGroup
 
 {{/*
 Validate values of Azure DNS:
-- must provide the Azure Tenant ID when provider is "azure" and secretName is not set and resourceGroup is set
-*/}}
-{{- define "external-dns.validateValues.azure.tenantIdWithoutResourceGroup" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.tenantId) (not .Values.azure.secretName) .Values.azure.resourceGroup -}}
-external-dns: azure.tenantId
-    You must provide the Azure Tenant ID when provider="azure" and resourceGroup is set.
-    Please set the tenantId parameter (--set azure.tenantId="xxxx")
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate values of Azure DNS:
 - must provide the Azure Tenant ID when provider is "azure" and secretName is not set and subscriptionId is set
 */}}
 {{- define "external-dns.validateValues.azure.tenantIdWithoutSubscriptionId" -}}
@@ -436,18 +447,6 @@ Validate values of Azure DNS:
 external-dns: azure.tenantId
     You must provide the Azure Tenant ID when provider="azure" and subscriptionId is set.
     Please set the tenantId parameter (--set azure.tenantId="xxxx")
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate values of Azure DNS:
-- must provide the Azure Subscription ID when provider is "azure" and secretName is not set and resourceGroup is set
-*/}}
-{{- define "external-dns.validateValues.azure.subscriptionIdWithoutResourceGroup" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.subscriptionId) (not .Values.azure.secretName) .Values.azure.resourceGroup -}}
-external-dns: azure.subscriptionId
-    You must provide the Azure Subscription ID when provider="azure" and resourceGroup is set.
-    Please set the subscriptionId parameter (--set azure.subscriptionId="xxxx")
 {{- end -}}
 {{- end -}}
 
@@ -671,6 +670,19 @@ external-dns: linode.apiToken
 
 {{/*
 Validate values of External DNS:
+- must provide the NS1 API key when provider is "ns1"
+*/}}
+{{- define "external-dns.validateValues.ns1.apiKey" -}}
+{{- if and (eq .Values.provider "ns1") (not .Values.ns1.apiKey) (not .Values.ns1.secretName) -}}
+external-dns: ns1.apiKey
+    You must provide the NS1 API key when provider="ns1".
+    Please set the token parameter (--set ns1.apiKey="xxxx")
+    or specify a secret that contains an API key. (--set ns1.secretName="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
 - must provide the OVH consumer key when provider is "ovh"
 */}}
 {{- define "external-dns.validateValues.ovh.consumerKey" -}}
@@ -782,6 +794,8 @@ Return the ExternalDNS namespace to be used
 {{- define "external-dns.namespace" -}}
 {{- if and .Values.rbac.create (not .Values.rbac.clusterRole) -}}
     {{ default .Release.Namespace .Values.namespace }}
+{{- else if .Values.watchReleaseNamespace -}}
+    {{ .Release.namespace }}
 {{- else -}}
     {{ .Values.namespace }}
 {{- end -}}

--- a/charts/external-dns/templates/clusterrole.yaml
+++ b/charts/external-dns/templates/clusterrole.yaml
@@ -1,9 +1,16 @@
 {{- if and .Values.rbac.create .Values.rbac.clusterRole }}
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRole
 metadata:
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/charts/external-dns/templates/clusterrolebinding.yaml
+++ b/charts/external-dns/templates/clusterrolebinding.yaml
@@ -1,15 +1,22 @@
 {{- if and .Values.rbac.create .Values.rbac.clusterRole }}
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/external-dns/templates/configmap.yaml
+++ b/charts/external-dns/templates/configmap.yaml
@@ -3,8 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
 {{- if .Values.designate.customCA.enabled }}
   {{ .Values.designate.customCA.filename }}: |

--- a/charts/external-dns/templates/deployment.yaml
+++ b/charts/external-dns/templates/deployment.yaml
@@ -2,8 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ coalesce .Values.replicas .Values.replicaCount }}
   {{- if .Values.updateStrategy }}
@@ -179,6 +185,9 @@ spec:
             - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
             {{- end }}
             {{- end }}
+            {{- if .Values.aws.zonesCacheDuration }}
+            - --aws-zones-cache-duration={{ .Values.aws.zonesCacheDuration }}
+            {{- end }}
             {{- range .Values.aws.zoneTags }}
             - --aws-zone-tags={{ . }}
             {{- end }}
@@ -335,14 +344,14 @@ spec:
             - name: OPENSTACK_CA_FILE
               value: {{ .Values.designate.customCAHostPath }}
             {{- end }}
-            {{- if .Values.designate.username}}
+            {{- if .Values.designate.username }}
             - name: OS_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: {{ template "external-dns.secretName" . }}
                   key: designate_username
             {{- end }}
-            {{- if .Values.designate.password}}
+            {{- if .Values.designate.password }}
             - name: OS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -531,6 +540,16 @@ spec:
               {{- if .Values.extraEnvVars }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
               {{- end }}
+            {{- if eq .Values.provider "ns1" }}
+            # NS1 environment variables
+            {{- if or (.Values.ns1.apiKey) (.Values.ns1.secretName) }}
+            - name: NS1_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: ns1-api-key
+            {{- end }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -609,7 +628,7 @@ spec:
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
               mountPath: /etc/kubernetes/
-              {{- else if not .Values.azure.useManagedIdentityExtension }}
+              {{- else }}
               mountPath: /etc/kubernetes/azure.json
               {{- end }}
               readOnly: true
@@ -625,10 +644,14 @@ spec:
             - name: google-service-account
               mountPath: /etc/secrets/service-account/
             {{- end }}
+            {{- if eq .Values.provider "oci" }}
+            - name: oci-config-file
+              mountPath: /etc/kubernetes/
+            {{- end }}
             {{- if eq .Values.provider "designate" }}
             # Designate mountPath(s)
             {{- if and (.Values.designate.customCAHostPath) (.Values.designate.customCA.enabled) }}
-            {{- fail "designate.customCAHostPath cannot be specified with designate.customCA.enabled set to true"}}
+            {{- fail "designate.customCAHostPath cannot be specified with designate.customCA.enabled set to true" }}
             {{- else if .Values.designate.customCA.enabled }}
             - name: designate-custom-ca
               mountPath: {{ .Values.designate.customCA.mountPath }}
@@ -643,7 +666,7 @@ spec:
             - name: krb5config
               mountPath: /etc/krb5.conf
               subPath: krb5.conf
-            {{- end}}
+            {{- end }}
             {{- if (eq .Values.provider "transip") }}
             # TransIP mountPath(s)
             - name: transip-api-key
@@ -676,11 +699,19 @@ spec:
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
           secret:
             secretName: {{ template "external-dns.secretName" . }}
-          {{- else if not .Values.azure.useManagedIdentityExtension }}
+          {{- else if .Values.azure.useManagedIdentityExtension }}
+          secret:
+            secretName: {{ template "external-dns.fullname" . }}
+          {{- else }}
           hostPath:
             path: /etc/kubernetes/azure.json
             type: File
           {{- end }}
+        {{- end }}
+        {{- if (eq .Values.provider "oci")}}
+        - name: oci-config-file
+          secret:
+            secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
         {{- if and (eq .Values.provider "coredns") (.Values.coredns.etcdTLS.enabled) }}
         # CoreDNS volume(s)

--- a/charts/external-dns/templates/pdb.yaml
+++ b/charts/external-dns/templates/pdb.yaml
@@ -1,10 +1,16 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{ include "external-dns.matchLabels" . | nindent 6 }}

--- a/charts/external-dns/templates/psp-clusterrole.yaml
+++ b/charts/external-dns/templates/psp-clusterrole.yaml
@@ -3,12 +3,19 @@
 kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ template "external-dns.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - {{ template "external-dns.fullname" . }}
+  - {{ template "common.names.fullname.namespace" . }}
 {{- end }}

--- a/charts/external-dns/templates/psp-clusterrolebinding.yaml
+++ b/charts/external-dns/templates/psp-clusterrolebinding.yaml
@@ -3,14 +3,21 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "external-dns.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "external-dns.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/external-dns/templates/psp.yaml
+++ b/charts/external-dns/templates/psp.yaml
@@ -3,8 +3,15 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/charts/external-dns/templates/role.yaml
+++ b/charts/external-dns/templates/role.yaml
@@ -1,10 +1,16 @@
 {{- if and .Values.rbac.create (not .Values.rbac.clusterRole) }}
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: Role
 metadata:
   name: {{ template "external-dns.fullname" . }}
   namespace: {{ template "external-dns.namespace" . }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -59,11 +65,11 @@ rules:
     verbs:
       - patch
       - update
-  - apiGroups: 
+  - apiGroups:
       - projectcontour.io
     resources:
       - httpproxies
-    verbs: 
+    verbs:
       - get
       - watch
       - list

--- a/charts/external-dns/templates/rolebindings.yaml
+++ b/charts/external-dns/templates/rolebindings.yaml
@@ -1,10 +1,16 @@
 {{- if and .Values.rbac.create (not .Values.rbac.clusterRole) }}
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: RoleBinding
 metadata:
   name: {{ template "external-dns.fullname" . }}
   namespace: {{ template "external-dns.namespace" . }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "external-dns.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/charts/external-dns/templates/secret.yaml
+++ b/charts/external-dns/templates/secret.yaml
@@ -3,11 +3,18 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
-  {{- if .Values.secretAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.secretAnnotations "context" $) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.secretAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.secretAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   {{- if eq .Values.provider "alibabacloud" }}
@@ -53,6 +60,9 @@ data:
   {{- if eq .Values.provider "linode" }}
   linode_api_token: {{ .Values.linode.apiToken | b64enc | quote }}
   {{- end }}
+  {{- if eq .Values.provider "oci" }}
+  oci.yaml: {{ include "external-dns.oci-credentials" . | b64enc | quote }}
+  {{- end }}
   {{- if eq .Values.provider "pdns" }}
   pdns_api_key: {{ .Values.pdns.apiKey | b64enc | quote }}
   {{- end }}
@@ -77,5 +87,8 @@ data:
   {{- if eq .Values.provider "vinyldns" }}
   vinyldns-access-key: {{ .Values.vinyldns.accessKey | b64enc | quote }}
   vinyldns-secret-key: {{ .Values.vinyldns.secretKey | b64enc | quote }}
+  {{- end }}
+  {{- if eq .Values.provider "ns1" }}
+  ns1-api-key: {{ .Values.ns1.apiKey | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/external-dns/templates/service.yaml
+++ b/charts/external-dns/templates/service.yaml
@@ -3,16 +3,20 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
   {{- if .Values.service.labels -}}
   {{ toYaml .Values.service.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.service.annotations }}
   annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.service.clusterIP }}
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
@@ -21,11 +25,17 @@ spec:
   {{- if .Values.service.externalIPs }}
   externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
-  {{- if .Values.service.loadBalancerIP }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http
@@ -39,5 +49,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{ include "external-dns.matchLabels" . | nindent 4 }}
-  type: {{ .Values.service.type }}
 {{- end }}

--- a/charts/external-dns/templates/serviceaccount.yaml
+++ b/charts/external-dns/templates/serviceaccount.yaml
@@ -1,12 +1,22 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "external-dns.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
-  {{- if .Values.serviceAccount.annotations }}
-  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/external-dns/templates/servicemonitor.yaml
+++ b/charts/external-dns/templates/servicemonitor.yaml
@@ -3,12 +3,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  {{- with .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/charts/external-dns/templates/tls-secret.yaml
+++ b/charts/external-dns/templates/tls-secret.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "external-dns.fullname" . }}-crt
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/charts/external-dns/values.yaml
+++ b/charts/external-dns/values.yaml
@@ -41,6 +41,9 @@ extraDeploy: []
 ## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion: ""
+## @param watchReleaseNamespace Watch only namepsace used for the release
+##
+watchReleaseNamespace: false
 
 ## @section external-dns parameters
 ##
@@ -50,13 +53,15 @@ kubeVersion: ""
 ## @param image.registry ExternalDNS image registry
 ## @param image.repository ExternalDNS image repository
 ## @param image.tag ExternalDNS Image tag (immutable tags are recommended)
+## @param image.digest ExternalDNS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy ExternalDNS image pull policy
 ## @param image.pullSecrets ExternalDNS image pull secrets
 ##
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.10.2-debian-10-r0
+  tag: 0.12.2-debian-11-r5
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -97,7 +102,7 @@ sources:
   # - contour-httpproxy
 ## @param provider DNS provider where the DNS records will be created.
 ## Available providers are:
-## - alibabacloud, aws, azure, azure-private-dns, cloudflare, coredns, designate, digitalocean, google, hetzner, infoblox, linode, rfc2136, transip
+## - alibabacloud, aws, azure, azure-private-dns, cloudflare, coredns, designate, digitalocean, google, hetzner, infoblox, linode, rfc2136, transip, oci
 ##
 provider: aws
 ## @param initContainers Attach additional init containers to the pod (evaluated as a template)
@@ -192,6 +197,10 @@ aws:
   ## @param aws.batchChangeSize When using the AWS provider, set the maximum number of changes that will be applied in each batch
   ##
   batchChangeSize: 1000
+  ## @param aws.zonesCacheDuration If the list of Route53 zones managed by ExternalDNS doesn't change frequently, cache it by setting a TTL
+  ## (default 0 - disabled, can be set to time interval like 1m or 1h)
+  ##
+  zonesCacheDuration: 0
   ## @param aws.zoneTags When using the AWS provider, filter for zones with these tags
   ##
   zoneTags: []
@@ -423,11 +432,51 @@ linode:
   ## This ignores linode.apiToken
   ##
   secretName: ""
+
 ## NS1 configuration to be set via arguments/env. variables
-## @param ns1.minTTL When using the ns1 provider, specify minimal TTL, as an integer, for records
 ##
 ns1:
+  ## @param ns1.minTTL When using the ns1 provider, specify minimal TTL, as an integer, for records
+  ##
   minTTL: 10
+  ## @param ns1.apiKey When using the ns1 provider, specify the API key to use
+  ##
+  apiKey: ""
+  ## @param ns1.secretName Use an existing secret with key "ns1-api-key" defined.
+  ## This ignores ns1.apiToken
+  ##
+  secretName: ""
+
+## oci configuration to be set via arguments/env. variables
+##
+oci:
+  ## @param oci.region When using the OCI provider, specify the region, where your zone is located in.
+  ##
+  region: ""
+  ## @param oci.tenancyOCID When using the OCI provider, specify your Tenancy OCID
+  ##
+  tenancyOCID: ""
+  ## @param oci.userOCID When using the OCI provider, specify your User OCID
+  ##
+  userOCID: ""
+  ## @param oci.compartmentOCID When using the OCI provider, specify your Compartment OCID where your DNS Zone is located in.
+  ##
+  compartmentOCID: ""
+  ## @param oci.privateKey [string] When using the OCI provider, paste in your RSA private key file for the Oracle API
+  ##
+  privateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    -----END RSA PRIVATE KEY-----
+  ## @param oci.privateKeyFingerprint When using the OCI provider, put in the fingerprint of your privateKey
+  ##
+  privateKeyFingerprint: ""
+  ## @param oci.privateKeyPassphrase When using the OCI provider and your privateKey has a passphrase, put it in here. (optional)
+  ##
+  privateKeyPassphrase: ""
+  ## @param oci.secretName When using the OCI provider, it's the name of the secret containing `oci.yaml` file.
+  ## Ref: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/oracle.md#deploy-externaldns
+  ##
+  secretName: ""
 ## OVH configuration to be set via arguments/env. variables
 ##
 ovh:
@@ -756,6 +805,17 @@ service:
   ##  kubernetes.io/name: "external-dns"
   ##
   labels: {}
+  ## @param service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+  ## If "ClientIP", consecutive client requests will be directed to the same Pod
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  ##
+  sessionAffinity: None
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
 ## ServiceAccount parameters
 ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
@@ -772,6 +832,9 @@ serviceAccount:
   ## @param serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
   ##
   automountServiceAccountToken: true
+  ## @param serviceAccount.labels [object] Additional labels to be included on the service account
+  ##
+  labels: {}
 ## RBAC parameters
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
@@ -939,10 +1002,11 @@ metrics:
     ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
     ##
     honorLabels: false
-    ## @param metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
+    ## DEPRECATED metrics.serviceMonitor.additionalLabels will be removed in a future release - Please use metrics.serviceMonitor.labels instead
+    ## @param metrics.serviceMonitor.labels Used to pass Labels that are required by the installed Prometheus Operator
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     ##
-    additionalLabels: {}
+    labels: {}
     ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
     ##
     jobLabel: ""

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -28,7 +28,7 @@ environments:
               provider: gitea
               username: otomi-admin
           external-dns:
-            domainFilters: []
+            logLevel: info
           external-secrets:
             logLevel: info
             pollingInterval: 60000
@@ -144,6 +144,9 @@ environments:
           vault:
             enabled: false
         cluster: {}
+        dns:
+          domainFilters: []
+          zoneIdFilters: []
         ingress:
           platformClass:
             className: platform

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otomi-core",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "otomi-core",
-      "version": "0.16.13",
+      "version": "0.16.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "lint:ts": "eslint --ext ts src",
     "lint:ts:fix": "eslint --fix --ext ts src",
     "lint:types": "tsc",
-    "migrate-values": "ENV_DIR=$PWD/.values binzx/otomi migrate && ENV_DIR=$PWD/tests/fixtures binzx/otomi migrate && ENV_DIR=$PWD/tests/kind binzx/otomi migrate",
+    "migrate-values": "ENV_DIR=$PWD/.values binzx/otomi migrate -ni && ENV_DIR=$PWD/tests/fixtures binzx/otomi migrate -ni && ENV_DIR=$PWD/tests/kind binzx/otomi migrate -ni",
     "prepare": "husky install",
     "server": "ts-node-dev --watch 'values-schema.yaml,src/**/*.ts' --inspect=4320 --respawn --transpile-only -r tsconfig-paths/register -r dotenv/config src/server/index.ts",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -160,5 +160,5 @@
     }
   },
   "type": "commonjs",
-  "version": "0.16.13"
+  "version": "0.16.14"
 }

--- a/src/cmd/bootstrap.test.ts
+++ b/src/cmd/bootstrap.test.ts
@@ -80,7 +80,7 @@ describe('Bootstrapping values', () => {
       }),
     )
   })
-  describe('Generating a loose schema', () => {
+  xdescribe('Generating a loose schema', () => {
     const values = { test: 'ok', required: 'remove', nested: { required: 'remove-leaf' } }
     const rootDir = '/bla'
     const targetPath = `${rootDir}/.vscode/values-schema.yaml`
@@ -92,11 +92,11 @@ describe('Bootstrapping values', () => {
         ENV_DIR: '/bla/env',
       }),
       terminal,
-      outputFileSync: jest.fn(),
+      copyFileSync: jest.fn(),
     }
     it('should create a schema without required props', () => {
       generateLooseSchema(deps)
-      expect(deps.outputFileSync).toHaveBeenCalledWith(targetPath, 'test: ok\n')
+      expect(deps.copyFileSync).toHaveBeenCalledWith(targetPath, 'test: ok\n')
     })
   })
   describe('Copying basic files', () => {

--- a/src/cmd/bootstrap.test.ts
+++ b/src/cmd/bootstrap.test.ts
@@ -7,7 +7,6 @@ import {
   bootstrapSops,
   copyBasicFiles,
   createCustomCA,
-  generateLooseSchema,
   getStoredClusterSecrets,
   processValues,
 } from './bootstrap'
@@ -80,25 +79,6 @@ describe('Bootstrapping values', () => {
       }),
     )
   })
-  xdescribe('Generating a loose schema', () => {
-    const values = { test: 'ok', required: 'remove', nested: { required: 'remove-leaf' } }
-    const rootDir = '/bla'
-    const targetPath = `${rootDir}/.vscode/values-schema.yaml`
-    const deps = {
-      isCore: true,
-      rootDir,
-      loadYaml: jest.fn().mockReturnValue(values),
-      env: () => ({
-        ENV_DIR: '/bla/env',
-      }),
-      terminal,
-      copyFileSync: jest.fn(),
-    }
-    it('should create a schema without required props', () => {
-      generateLooseSchema(deps)
-      expect(deps.copyFileSync).toHaveBeenCalledWith(targetPath, 'test: ok\n')
-    })
-  })
   describe('Copying basic files', () => {
     const deps = {
       env: () => ({
@@ -108,7 +88,7 @@ describe('Bootstrapping values', () => {
       copyFile: jest.fn(),
       terminal,
       copy: jest.fn(),
-      generateLooseSchema: jest.fn(),
+      copySchema: jest.fn(),
       existsSync: jest.fn(),
     }
     it('should not throw any exception', async () => {

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -106,8 +106,8 @@ export const bootstrapSops = async (
   }
 }
 
-export const generateLooseSchema = (deps = { terminal, rootDir, env, isCore, loadYaml, copyFileSync }): void => {
-  const d = deps.terminal(`cmd:${cmdName}:generateLooseSchema`)
+export const copySchema = (deps = { terminal, rootDir, env, isCore, loadYaml, copyFileSync }): void => {
+  const d = deps.terminal(`cmd:${cmdName}:copySchema`)
   const { ENV_DIR } = env
   const devOnlyPath = `${deps.rootDir}/.vscode/values-schema.yaml`
   const targetPath = `${ENV_DIR}/.vscode/values-schema.yaml`
@@ -146,7 +146,7 @@ export const getStoredClusterSecrets = async (
 }
 
 export const copyBasicFiles = async (
-  deps = { terminal, env, mkdirSync, copyFile, copy, generateLooseSchema, existsSync },
+  deps = { terminal, env, mkdirSync, copyFile, copy, copySchema, existsSync },
 ): Promise<void> => {
   const d = deps.terminal(`cmd:${cmdName}:copyBasicFiles`)
   const { ENV_DIR } = deps.env
@@ -161,7 +161,7 @@ export const copyBasicFiles = async (
   await deps.copy(`${rootDir}/.values/.vscode`, `${ENV_DIR}/.vscode`, { recursive: true })
   d.info('Copied vscode folder')
 
-  deps.generateLooseSchema()
+  deps.copySchema()
 
   // only copy sample files if a real one is not found
   await Promise.allSettled(

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -1,7 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
-import { copy, outputFileSync } from 'fs-extra'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { copy } from 'fs-extra'
 import { copyFile } from 'fs/promises'
-import { dump } from 'js-yaml'
 import { cloneDeep, get, merge } from 'lodash'
 import { pki } from 'node-forge'
 import { Argv } from 'yargs'
@@ -14,7 +13,7 @@ import { terminal } from '../common/debug'
 import { env, isChart, isCi, isCli } from '../common/envalid'
 import { hfValues } from '../common/hf'
 import { createK8sSecret, getDeploymentState, getK8sSecret, secretId } from '../common/k8s'
-import { getFilename, gucci, isCore, loadYaml, providerMap, removeBlankAttributes, rootDir } from '../common/utils'
+import { getFilename, gucci, isCore, loadYaml, providerMap, rootDir } from '../common/utils'
 import { generateSecrets, getCurrentVersion, getImageTag, writeValues } from '../common/values'
 import { BasicArguments, setParsedArgs } from '../common/yargs'
 import { migrate } from './migrate'
@@ -107,23 +106,25 @@ export const bootstrapSops = async (
   }
 }
 
-export const generateLooseSchema = (deps = { terminal, rootDir, env, isCore, loadYaml, outputFileSync }): void => {
+export const generateLooseSchema = (deps = { terminal, rootDir, env, isCore, loadYaml, copyFileSync }): void => {
   const d = deps.terminal(`cmd:${cmdName}:generateLooseSchema`)
   const { ENV_DIR } = env
   const devOnlyPath = `${deps.rootDir}/.vscode/values-schema.yaml`
   const targetPath = `${ENV_DIR}/.vscode/values-schema.yaml`
   const sourcePath = `${deps.rootDir}/values-schema.yaml`
 
-  const valuesSchema = deps.loadYaml(sourcePath)
-  const trimmedVS = dump(
-    removeBlankAttributes(JSON.parse(JSON.stringify(valuesSchema, (k, v) => (k === 'required' ? undefined : v), 2))),
-  )
-  d.debug('generated values-schema.yaml: ', trimmedVS)
-  deps.outputFileSync(targetPath, trimmedVS)
+  // const valuesSchema = deps.loadYaml(sourcePath)
+  // const trimmedVS = dump(
+  //   removeBlankAttributes(JSON.parse(JSON.stringify(valuesSchema, (k, v) => (k === 'required' ? undefined : v), 2))),
+  // )
+  // d.debug('generated values-schema.yaml: ', trimmedVS)
+  // deps.outputFileSync(targetPath, trimmedVS)
+  deps.copyFileSync(sourcePath, targetPath)
   d.info(`Stored loose YAML schema at: ${targetPath}`)
   if (deps.isCore) {
-    // for validation of .values/env/* files we also generate a loose schema here:
-    deps.outputFileSync(devOnlyPath, trimmedVS)
+    // for validation of .values/env/* files we also generate a schema here:
+    // deps.outputFileSync(devOnlyPath, trimmedVS)
+    deps.copyFileSync(sourcePath, devOnlyPath)
     d.debug(`Stored loose YAML schema for otomi-core devs at: ${devOnlyPath}`)
   }
 }

--- a/src/cmd/validate-values.ts
+++ b/src/cmd/validate-values.ts
@@ -10,7 +10,7 @@ import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from '../com
 
 const cmdName = getFilename(__filename)
 
-const internalPaths: string[] = ['apps', 'k8s', 'services', 'teamConfig.services']
+const internalPaths: string[] = ['k8s', 'services', 'teamConfig.services']
 
 // TODO: Accept json path to validate - on empty, validate all
 export const validateValues = async (): Promise<void> => {

--- a/tests/fixtures/env/apps/external-dns.yaml
+++ b/tests/fixtures/env/apps/external-dns.yaml
@@ -1,6 +1,0 @@
-apps:
-    external-dns:
-        domainFilters:
-            - otomi.cloud
-        zoneIdFilters:
-            - otomi

--- a/tests/fixtures/env/apps/grafana.yaml
+++ b/tests/fixtures/env/apps/grafana.yaml
@@ -1,4 +1,4 @@
 apps:
     grafana:
-        enabled: true
         adminPassword: somesecretvalue
+        enabled: true

--- a/tests/fixtures/env/apps/ingress-nginx.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx.yaml
@@ -1,18 +1,6 @@
 apps:
     ingress-nginx:
         maxBodySize: 1024m
-        private:
-            enabled: true
-            resources:
-                limits:
-                    cpu: 200m
-                    memory: 256Mi
-                requests:
-                    cpu: 100m
-                    memory: 192Mi
-            service:
-                annotations:
-                    private: 'true'
         resources:
             limits:
                 cpu: 200m

--- a/tests/fixtures/env/apps/istio.yaml
+++ b/tests/fixtures/env/apps/istio.yaml
@@ -18,10 +18,6 @@ apps:
         global:
             logging:
                 level: default:warn
-            mtls:
-                enabled: false
-            sds:
-                enabled: true
         resources:
             ingressgateway:
                 limits:

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -11,6 +11,7 @@ dns:
     provider:
         azure:
             aadClientSecret: 00-aadClientSecret
+            # userAssignedIdentityID: 00-userAssignedIdentityID
 home:
     email:
         critical: admins@yourdoma.in

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -11,7 +11,6 @@ dns:
     provider:
         azure:
             aadClientSecret: 00-aadClientSecret
-            # userAssignedIdentityID: 00-userAssignedIdentityID
 home:
     email:
         critical: admins@yourdoma.in

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -27,7 +27,6 @@ dns:
             resourceGroup: external-dns
             subscriptionId: 00-subscriptionId
             tenantId: 00-tenantId
-            # useManagedIdentityExtension: true
 
     domainFilters:
         - otomi.cloud

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -27,6 +27,8 @@ dns:
             resourceGroup: external-dns
             subscriptionId: 00-subscriptionId
             tenantId: 00-tenantId
+            # useManagedIdentityExtension: true
+
     domainFilters:
         - otomi.cloud
     zoneIdFilters:

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -23,10 +23,14 @@ cloud:
 dns:
     provider:
         azure:
-            resourceGroup: external-dns
             aadClientId: 00-aadClientId
-            tenantId: 00-tenantId
+            resourceGroup: external-dns
             subscriptionId: 00-subscriptionId
+            tenantId: 00-tenantId
+    domainFilters:
+        - otomi.cloud
+    zoneIdFilters:
+        - otomi
 home:
     receivers:
         - slack
@@ -36,13 +40,13 @@ home:
 ingress:
     classes:
         - className: private
-          network: private
           loadBalancerSubnet: subnet
+          network: private
         - className: net-a
-          network: public
-          loadBalancerIP: '11.0.0.1'
+          loadBalancerIP: 11.0.0.1
           loadBalancerRG: myrg
-          sourceIpAddressFiltering: '10.0.0.0/24'
+          network: public
+          sourceIpAddressFiltering: 10.0.0.0/24
 kms:
     sops:
         azure:
@@ -61,16 +65,16 @@ otomi:
           name: demo
           provider: aws
     hasCloudLB: false
-    hasExternalIDP: true
     hasExternalDNS: true
+    hasExternalIDP: true
     isHomeMonitored: true
     isMultitenant: true
-    version: main
     nodeSelector:
         otomi: otomi-sys
+    version: main
 smtp:
     auth_username: no-reply@doma.in
     from: no-reply@doma.in
     hello: doma.in
     smarthost: smtp-relay.gmail.com:587
-version: 3
+version: 5

--- a/tests/fixtures/env/teams/apps.demo.yaml
+++ b/tests/fixtures/env/teams/apps.demo.yaml
@@ -1,8 +1,3 @@
 teamConfig:
     demo:
-        apps:
-            drone:
-                shortcuts:
-                    - description: blabla
-                      path: /ok
-                      title: some title
+        apps: []

--- a/tests/fixtures/env/teams/external-secrets.admin.yaml
+++ b/tests/fixtures/env/teams/external-secrets.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        secrets: []

--- a/tests/fixtures/env/teams/jobs.admin.yaml
+++ b/tests/fixtures/env/teams/jobs.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        jobs: []

--- a/tests/fixtures/env/teams/services.admin.yaml
+++ b/tests/fixtures/env/teams/services.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        services: []

--- a/tests/fixtures/env/teams/services.demo.yaml
+++ b/tests/fixtures/env/teams/services.demo.yaml
@@ -141,6 +141,6 @@ teamConfig:
                   ingressPrivate:
                       mode: AllowOnly
               type: cluster
-            - name: service-e
+            - ingressClassName: net-a
+              name: service-e
               type: public
-              ingressClassName: net-a

--- a/tests/kind/env/apps/kiali-operator.yaml
+++ b/tests/kind/env/apps/kiali-operator.yaml
@@ -1,5 +1,5 @@
 apps:
-    kiali:
+    kiali-operator:
         _rawValues:
             cr:
                 spec:
@@ -12,4 +12,3 @@ apps:
                 requests:
                     cpu: 10m
                     memory: 10Mi
-        enabled: true

--- a/tests/kind/env/settings.yaml
+++ b/tests/kind/env/settings.yaml
@@ -5,4 +5,4 @@ otomi:
     isHomeMonitored: false
     isMultitenant: true
     version: main
-version: 3
+version: 5

--- a/tests/kind/env/teams/apps.admin.yaml
+++ b/tests/kind/env/teams/apps.admin.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    admin:
+        apps: []

--- a/tests/kind/env/teams/apps.demo.yaml
+++ b/tests/kind/env/teams/apps.demo.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    demo:
+        apps: []

--- a/tests/kind/env/teams/external-secrets.admin.yaml
+++ b/tests/kind/env/teams/external-secrets.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        secrets: []

--- a/tests/kind/env/teams/jobs.admin.yaml
+++ b/tests/kind/env/teams/jobs.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        jobs: []

--- a/tests/kind/env/teams/services.admin.yaml
+++ b/tests/kind/env/teams/services.admin.yaml
@@ -1,3 +1,3 @@
 teamConfig:
     admin:
-        apps: []
+        services: []

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -35,5 +35,10 @@ changes:
       - otomi.isManaged
   - version: 5
     relocations:
+      - apps.vault.seal.gcpkms.projectId: apps.vault.seal.gcpkms.project
+      - apps.external-dns.domainFilters: dns.domainFilters
+      - apps.external-dns.zoneIdFilters: dns.zoneIdFilters
       - dns.provider.aws.accessKeyID: dns.provider.aws.credentials.accessKey
       - dns.provider.aws.secretAccessKey: dns.provider.aws.credentials.secretKey
+      - dns.provider.google.projectId: dns.provider.google.project
+      - kms.sops.google.projectId: kms.sops.google.project

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -33,3 +33,7 @@ changes:
   - version: 4
     deletions:
       - otomi.isManaged
+  - version: 5
+    relocations:
+      - dns.provider.aws.accessKeyID: dns.provider.aws.credentials.accessKey
+      - dns.provider.aws.secretAccessKey: dns.provider.aws.credentials.secretKey

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -166,8 +166,6 @@ definitions:
         x-secret: ''
       dns:
         properties:
-          environment:
-            $ref: '#/definitions/azure/definitions/environment'
           resourceGroup:
             $ref: '#/definitions/azure/definitions/resourceGroup'
           hostedZoneName:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -186,9 +186,6 @@ definitions:
             type: string
             description: Azure Application Client Secret
             x-secret: ''
-          secretName:
-            type: string
-            description: Existing secret with credentials. Will override credentials provided.
           useManagedIdentityExtension:
             title: Using managed identities?
             type: boolean
@@ -206,18 +203,13 @@ definitions:
         allOf:
           - oneOf:
               - required: [aadClientId, aadClientSecret]
-              - required: [secretName]
-              - not:
-                  anyOf:
-                    - required: [secretName]
-                    - required: [aadClientId]
-                    - required: [aadClientSecret]
-          - oneOf:
               - required: [useManagedIdentityExtension, userAssignedIdentityID]
               - not:
                   anyOf:
-                    - required: [useManagedIdentityExtension, userAssignedIdentityID]
-
+                    - required: [useManagedIdentityExtension]
+                    - required: [userAssignedIdentityID]
+                    - required: [aadClientId]
+                    - required: [aadClientSecret]
       environment:
         title: Azure environment
         description: An Azure environment.
@@ -2400,17 +2392,7 @@ properties:
                         $ref: '#/definitions/aws/definitions/secretKey'
                       accessKey:
                         $ref: '#/definitions/aws/definitions/accessKey'
-                      secretName:
-                        type: string
-                        description: Existing secret with credentials. Will override credentials provided.
-                    oneOf:
-                      - required: [secretKey, accessKey]
-                      - required: [secretName]
-                      - not:
-                          anyOf:
-                            - required: [accessKey]
-                            - required: [secretKey]
-                            - required: [secretName]
+                    required: [secretKey, accessKey]
                   region:
                     $ref: '#/definitions/aws/definitions/region'
                   role:
@@ -2446,17 +2428,7 @@ properties:
                     description: A service account key in json format for managing a DNS zone.
                   project:
                     $ref: '#/definitions/google/definitions/project'
-                  secretName:
-                    type: string
-                    description: Existing secret with credentials. Will override credentials provided.
-                required: [project]
-                oneOf:
-                  - required: [serviceAccountKey]
-                  - required: [secretName]
-                  - not:
-                      anyOf:
-                        - required: [serviceAccountKey]
-                        - required: [secretName]
+                required: [project, serviceAccountKey]
             required:
               - google
           - title: Digital Ocean
@@ -2466,16 +2438,8 @@ properties:
                   apiToken:
                     type: string
                     x-secret: true
-                  secretName:
-                    type: string
-                    description: Existing secret with credentials. Will override credentials provided.
-                oneOf:
-                  - required: [apiToken]
-                  - required: [secretName]
-                  - not:
-                      anyOf:
-                        - required: [apiToken]
-                        - required: [secretName]
+                required:
+                  - apiToken
             required:
               - digitalocean
           - title: CloudFlare
@@ -2492,22 +2456,17 @@ properties:
                   email:
                     $ref: '#/definitions/email'
                     description: Required when Email is set.
-                  secretName:
-                    type: string
-                    description: Existing secret with credentials. Will override credentials provided.
                   proxied:
                     type: boolean
                     x-default: true
                 oneOf:
                   - required: [apiToken]
                   - required: [apiSecret, email]
-                  - required: [secretName]
                   - not:
                       anyOf:
                         - required: [apiToken]
                         - required: [apiSecret]
                         - required: [email]
-                        - required: [secretName]
             required:
               - cloudflare
           - title: Other

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -203,14 +203,15 @@ definitions:
           - tenantId
           - subscriptionId
           - resourceGroup
-        anyOf:
+        allOf:
           - oneOf:
               - required: [aadClientId, aadClientSecret]
               - required: [secretName]
               - not:
                   anyOf:
-                    - required: [aadClientId, aadClientSecret]
                     - required: [secretName]
+                    - required: [aadClientId]
+                    - required: [aadClientSecret]
           - oneOf:
               - required: [useManagedIdentityExtension, userAssignedIdentityID]
               - not:
@@ -392,7 +393,6 @@ definitions:
   email:
     pattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     type: string
-    # nullable: true
   env:
     additionalProperties: false
     examples:
@@ -1265,7 +1265,7 @@ properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
           customRootCA:
-            x-secret: '' # made secret to let it be added to k8s secret for chart install
+            x-secret: ''
             type: string
             description: CA that is used to create and verify self-signed certificates. Leave it empty to generate one automatically.
           customRootCAKey:
@@ -1286,25 +1286,22 @@ properties:
               - production
               - staging
             default: production
-        required: [email]
-        # oneOf:
-        #   - properties:
-        #       issuer:
-        #         const: letsencrypt
-        #     required:
-        #       - email
-        #       - issuer
-        #   - properties:
-        #       issuer:
-        #         const: custom-ca
-        #     required:
-        #       - issuer
-        # - properties:
-        #     issuer:
-        #       const: null
-        #   not:
-        #     required:
-        #       - issuer
+        oneOf:
+          - properties:
+              issuer:
+                const: letsencrypt
+            required:
+              - email
+              - issuer
+          - properties:
+              issuer:
+                const: custom-ca
+            required:
+              - issuer
+          - not:
+              anyOf:
+                - required:
+                    - issuer
       cluster-autoscaler:
         additionalProperties: false
         properties:
@@ -1534,6 +1531,8 @@ properties:
                 $ref: '#/definitions/resources'
       gitea:
         properties:
+          _rawValues:
+            $ref: '#/definitions/rawValues'
           enabled:
             type: boolean
           adminPassword:
@@ -1570,6 +1569,9 @@ properties:
           enabled:
             type: boolean
             default: false
+          adminPassword:
+            type: string
+            x-secret: ''
           image:
             $ref: '#/definitions/imageSimple'
           resources:
@@ -1930,6 +1932,9 @@ properties:
           adminPassword:
             type: string
             x-secret: ''
+          theme:
+            type: string
+            default: otomi
           image:
             properties:
               keycloak:
@@ -2403,7 +2408,8 @@ properties:
                       - required: [secretName]
                       - not:
                           anyOf:
-                            - required: [secretKey, accessKey]
+                            - required: [accessKey]
+                            - required: [secretKey]
                             - required: [secretName]
                   region:
                     $ref: '#/definitions/aws/definitions/region'
@@ -2470,10 +2476,8 @@ properties:
                       anyOf:
                         - required: [apiToken]
                         - required: [secretName]
-                type: object
             required:
-              - google
-            type: object
+              - digitalocean
           - title: CloudFlare
             properties:
               cloudflare:
@@ -2496,17 +2500,16 @@ properties:
                     x-default: true
                 oneOf:
                   - required: [apiToken]
-                  - required: [email, apiSecret]
+                  - required: [apiSecret, email]
                   - required: [secretName]
                   - not:
                       anyOf:
                         - required: [apiToken]
-                        - required: [email, apiSecret]
+                        - required: [apiSecret]
+                        - required: [email]
                         - required: [secretName]
-                type: object
             required:
               - cloudflare
-            type: object
           - title: Other
             properties:
               other:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -186,30 +186,12 @@ definitions:
             type: string
             description: Azure Application Client Secret
             x-secret: ''
-          useManagedIdentityExtension:
-            title: Using managed identities?
-            type: boolean
-            description: If you use Azure MSI, this should be set to true
-            default: false
-          userAssignedIdentityID:
-            title: MSI id
-            type: string
-            description: If you use Azure MSI, this is the Client ID of a Azure user-assigned managed identity or resource id. Required for cert-manager.
-            x-secret: ''
         required:
           - tenantId
           - subscriptionId
           - resourceGroup
-        allOf:
-          - oneOf:
-              - required: [aadClientId, aadClientSecret]
-              - required: [useManagedIdentityExtension, userAssignedIdentityID]
-              - not:
-                  anyOf:
-                    - required: [useManagedIdentityExtension]
-                    - required: [userAssignedIdentityID]
-                    - required: [aadClientId]
-                    - required: [aadClientSecret]
+          - aadClientId
+          - aadClientSecret
       environment:
         title: Azure environment
         description: An Azure environment.

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -186,6 +186,9 @@ definitions:
             type: string
             description: Azure Application Client Secret
             x-secret: ''
+          secretName:
+            type: string
+            description: Existing secret with credentials. Will override credentials provided.
           useManagedIdentityExtension:
             title: Using managed identities?
             type: boolean
@@ -200,13 +203,19 @@ definitions:
           - tenantId
           - subscriptionId
           - resourceGroup
-        oneOf:
-          - required:
-              - aadClientId
-              - aadClientSecret
-          - required:
-              - useManagedIdentityExtension
-              - userAssignedIdentityID
+        anyOf:
+          - oneOf:
+              - required: [aadClientId, aadClientSecret]
+              - required: [secretName]
+              - not:
+                  anyOf:
+                    - required: [aadClientId, aadClientSecret]
+                    - required: [secretName]
+          - oneOf:
+              - required: [useManagedIdentityExtension, userAssignedIdentityID]
+              - not:
+                  anyOf:
+                    - required: [useManagedIdentityExtension, userAssignedIdentityID]
 
       environment:
         title: Azure environment
@@ -383,7 +392,7 @@ definitions:
   email:
     pattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     type: string
-    nullable: true
+    # nullable: true
   env:
     additionalProperties: false
     examples:
@@ -408,7 +417,7 @@ definitions:
       accountJson:
         type: string
         x-secret: ''
-      projectId:
+      project:
         $ref: '#/definitions/wordCharacterPattern'
   hostPort:
     pattern: '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]):()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$'
@@ -1255,9 +1264,6 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
-          enabled:
-            type: boolean
-            description: Discarded as derived from otomi flags.
           customRootCA:
             x-secret: '' # made secret to let it be added to k8s secret for chart install
             type: string
@@ -1280,23 +1286,25 @@ properties:
               - production
               - staging
             default: production
-        oneOf:
-          - properties:
-              issuer:
-                const: letsencrypt
-            required:
-              - email
-              - issuer
-          - allOf:
-              - oneOf:
-                  - not:
-                      required:
-                        - issuer
-                  - properties:
-                      issuer:
-                        const: custom-ca
-                    required:
-                      - issuer
+        required: [email]
+        # oneOf:
+        #   - properties:
+        #       issuer:
+        #         const: letsencrypt
+        #     required:
+        #       - email
+        #       - issuer
+        #   - properties:
+        #       issuer:
+        #         const: custom-ca
+        #     required:
+        #       - issuer
+        # - properties:
+        #     issuer:
+        #       const: null
+        #   not:
+        #     required:
+        #       - issuer
       cluster-autoscaler:
         additionalProperties: false
         properties:
@@ -1462,16 +1470,9 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
-          enabled:
-            type: boolean
-            description: Discarded as derived from otomi flags.
-          domainFilters:
-            items:
-              type: string
-            type: array
-          zoneIdFilters:
-            items:
-              type: string
+          logLevel:
+            type: string
+            default: 'info'
       gatekeeper:
         additionalProperties: false
         properties:
@@ -2366,27 +2367,56 @@ properties:
     additionalProperties: false
     properties:
       zones:
-        description: Extra dns zones that the cluster can administer (see dns). Team services can use this to publish their URLs on.
+        description: Extra dns zones that the cluster can administer. Team services can use this to publish their URLs on.
         items:
           $ref: '#/definitions/domain'
+        type: array
+      domainFilters:
+        description: Limit possible target zones by domain suffixes.
+        items:
+          type: string
+        type: array
+      zoneIdFilters:
+        description: Limit possible target zones by zone id.
+        items:
+          type: string
         type: array
       provider:
         description: The DNS provider managing the domains.
         oneOf:
           - title: AWS
+            description: Uses credentials when either a pair of id+key or a secret name is provided. Assumes node role otherwise.
             properties:
               aws:
                 properties:
-                  accessKeyID:
-                    $ref: '#/definitions/aws/definitions/accessKey'
-                  secretAccessKey:
-                    $ref: '#/definitions/aws/definitions/secretKey'
+                  credentials:
+                    properties:
+                      secretKey:
+                        $ref: '#/definitions/aws/definitions/secretKey'
+                      accessKey:
+                        $ref: '#/definitions/aws/definitions/accessKey'
+                      secretName:
+                        type: string
+                        description: Existing secret with credentials. Will override credentials provided.
+                    oneOf:
+                      - required: [secretKey, accessKey]
+                      - required: [secretName]
+                      - not:
+                          anyOf:
+                            - required: [secretKey, accessKey]
+                            - required: [secretName]
                   region:
                     $ref: '#/definitions/aws/definitions/region'
                   role:
                     $ref: '#/definitions/aws/definitions/role'
-                required:
-                  - region
+                required: [region]
+                oneOf:
+                  - required: [credentials]
+                  - required: [role]
+                  - not:
+                      anyOf:
+                        - required: [credentials]
+                        - required: [role]
             required:
               - aws
           - title: Azure
@@ -2409,12 +2439,97 @@ properties:
                     $ref: '#/definitions/google/definitions/accountJson'
                     description: A service account key in json format for managing a DNS zone.
                   project:
-                    $ref: '#/definitions/google/definitions/projectId'
-                required:
-                  - serviceAccountKey
-                  - project
+                    $ref: '#/definitions/google/definitions/project'
+                  secretName:
+                    type: string
+                    description: Existing secret with credentials. Will override credentials provided.
+                required: [project]
+                oneOf:
+                  - required: [serviceAccountKey]
+                  - required: [secretName]
+                  - not:
+                      anyOf:
+                        - required: [serviceAccountKey]
+                        - required: [secretName]
             required:
               - google
+          - title: Digital Ocean
+            properties:
+              digitalocean:
+                properties:
+                  apiToken:
+                    type: string
+                    x-secret: true
+                  secretName:
+                    type: string
+                    description: Existing secret with credentials. Will override credentials provided.
+                oneOf:
+                  - required: [apiToken]
+                  - required: [secretName]
+                  - not:
+                      anyOf:
+                        - required: [apiToken]
+                        - required: [secretName]
+                type: object
+            required:
+              - google
+            type: object
+          - title: CloudFlare
+            properties:
+              cloudflare:
+                properties:
+                  apiToken:
+                    type: string
+                    x-secret: true
+                  apiSecret:
+                    type: string
+                    x-secret: true
+                    description: Required when Email is set.
+                  email:
+                    $ref: '#/definitions/email'
+                    description: Required when Email is set.
+                  secretName:
+                    type: string
+                    description: Existing secret with credentials. Will override credentials provided.
+                  proxied:
+                    type: boolean
+                    x-default: true
+                oneOf:
+                  - required: [apiToken]
+                  - required: [email, apiSecret]
+                  - required: [secretName]
+                  - not:
+                      anyOf:
+                        - required: [apiToken]
+                        - required: [email, apiSecret]
+                        - required: [secretName]
+                type: object
+            required:
+              - cloudflare
+            type: object
+          - title: Other
+            properties:
+              other:
+                description: This option requires configuration for both external-dns as well as cert-manager. No schema validation is available so provide correct data.
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Name of the provider.
+                  external-dns:
+                    title: YAML for external-dns.
+                    type: object
+                    description: 'The provider config as provided here: https://github.com/redkubes/otomi-core/blob/main/charts/external-dns/values.yaml'
+                  cert-manager:
+                    title: YAML for cert-manager.
+                    type: object
+                    description: 'The dns01 config as provided here: https://cert-manager.io/docs/configuration/acme/dns01/'
+                required:
+                  - name
+                  - external-dns
+                  - cert-manager
+            required:
+              - other
       entrypoint:
         $ref: '#/definitions/ipV4Address'
         description: Optional. A public IP address that will override (loadbalancer) ip used for registering hosts. This allows for access to private clusters.
@@ -2482,7 +2597,7 @@ properties:
                   accountJson:
                     $ref: '#/definitions/google/definitions/accountJson'
                   project:
-                    $ref: '#/definitions/google/definitions/projectId'
+                    $ref: '#/definitions/google/definitions/project'
                 required:
                   - keys
                   - accountJson

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -7,21 +7,6 @@
 {{- $issuerName := ternary (printf "%s-%s" $cm.issuer ($cm | get "stage" "")) $cm.issuer (eq $cm.issuer "letsencrypt") }}
 {{- $doms := tpl (readFile "../../helmfile.d/snippets/domains.gotmpl") $v | fromYaml }}
 resources:
-{{- if or ($p | get "azure.aadClientSecret" nil) ($p | get "google.serviceAccountKey" nil) ($p | get "aws.secretAccessKey" nil) }}
-  - apiVersion: v1
-    kind: Secret
-    metadata:
-      name: "dns-secret"
-    data:
-      {{- if hasKey $p "google" }}
-      secret: "{{ $p.google.serviceAccountKey | b64enc }}"
-      {{- else if hasKey $p "azure" }}
-      secret: "{{ $p.azure.aadClientSecret | b64enc }}"
-      {{- else if hasKey $p "aws" }}
-      secret: "{{ $p.aws.secretAccessKey | b64enc }}"
-      {{- end }}
-{{- end }}
-
   - apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
@@ -45,11 +30,13 @@ resources:
             dns01:
               {{- with $p | get "aws" nil }}
               route53:
-                {{- if and (hasKey . "accessKeyID") (hasKey . "secretAccessKey") }}
-                accessKeyID: {{ .accessKeyID }}
+                {{- with . | get "credentials.accessKey" nil }}
+                accessKeyID: {{ . }}
+                {{- end }}
+                {{- if or (. | get "credentials.secretKey" nil) (. | get "secretName" nil) }}
                 secretAccessKeySecretRef:
-                  key: secret
-                  name: "dns-secret"
+                  key: "credentials"
+                  secretName: external-dns
                 {{- end }}
                 region: {{ .region }}
                 {{- with . | get "role" nil }}
@@ -63,9 +50,6 @@ resources:
                 {{- if hasKey . "aadClientId" }}
                 tenantID: {{ .tenantId }}
                 clientID: {{ .aadClientId }}
-                clientSecretSecretRef:
-                  key: secret
-                  name: "dns-secret"
                 {{- end }}
                 {{- if . | get "useManagedIdentityExtension" false }}
                 managedIdentity:
@@ -77,13 +61,49 @@ resources:
                 {{- with . | get "environment" nil }}
                 environment: {{ . }}
                 {{- end }}
+                {{- if or (. | get "aadClientSecret" nil) (. | get "secretName" nil) }}
+                clientSecretSecretRef:
+                  key: azure.json
+                  secretName: external-dns
+                {{- end }}
+              {{- end }}
+              {{- with $p | get "cloudflare" nil }}
+              cloudflare:
+                {{- if or (. | get "apiToken" nil) (. | get "apiSecret" nil) (. | get "secretName" nil) }}
+                  {{- with . | get "apiToken" nil }}
+                apiTokenSecretRef:
+                  key: cloudflare_api_token
+                  {{- end }}
+                  {{- with . | get "apiSecret" nil }}
+                apiKeySecretRef:
+                  key: cloudflare_api_key
+                  {{- end }}
+                  secretName: external-dns
+                {{- else }}
+                  {}
+                {{- end }}
+              {{- end }}
+              {{- with $p | get "digitalocean" nil }}
+              digitalocean:
+                {{- if or (. | get "apiToken" nil) (. | get "secretName" nil) }}
+                tokenSecretRef:
+                  key: digitalocean_api_token
+                  secretName: external-dns
+                {{- else }}
+                  {}
+                {{- end }}
               {{- end }}
               {{- with $p | get "google" nil }}
               cloudDNS:
                 project: {{ .project }}
+                {{- if or (. | get "serviceAccountKey" nil) (. | get "secretName" nil) }}
                 serviceAccountSecretRef:
-                  key: secret
-                  name: "dns-secret"
+                  key: credentials.json
+                  secretName: external-dns
+                {{- end }}
+              {{- end }}
+              {{- with $p | get "other" nil }}
+              {{- toYaml . | get "cert-manager" nindent 14 }}
               {{- end }}
 {{- end }}
 # generate all da certs

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -54,9 +54,6 @@ resources:
                 {{- with . | get "hostedZoneName" nil }}
                 hostedZoneName: {{ . }}
                 {{- end }}
-                {{- with . | get "environment" nil }}
-                environment: {{ . }}
-                {{- end }}
                 {{- if or (. | get "aadClientSecret" nil) (. | get "secretName" nil) }}
                 clientSecretSecretRef:
                   key: azure.json

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -51,10 +51,6 @@ resources:
                 tenantID: {{ .tenantId }}
                 clientID: {{ .aadClientId }}
                 {{- end }}
-                {{- if . | get "useManagedIdentityExtension" false }}
-                managedIdentity:
-                  clientID: {{ .userAssignedIdentityID }}
-                {{- end }}
                 {{- with . | get "hostedZoneName" nil }}
                 hostedZoneName: {{ . }}
                 {{- end }}

--- a/values/external-dns/external-dns.gotmpl
+++ b/values/external-dns/external-dns.gotmpl
@@ -12,13 +12,18 @@ image:
 
 {{- range $provider, $config := $dns.provider }}
 {{- $providerConfigKey := $provider | replace "azure-private-dns" "azure" }}
+{{- if eq $provider "other" }}
+provider: {{ $config.name }}
+{{ $config.name }}: {{- $config | get "external-dns" | toYaml | nindent 2 }}
+{{- else }}
 provider: {{ $provider }}
 {{ $providerConfigKey }}: {{- $config | toYaml | nindent 2 }}
 {{- end }}
-domainFilters: {{ $externalDns | get "domainFilters" | toYaml | nindent 2 }}
-zoneIdFilters: {{ $externalDns | get "zoneIdFilters" list | toYaml | nindent 2 }}
+{{- end }}
+domainFilters: {{ $dns | get "domainFilters" | toYaml | nindent 2 }}
+zoneIdFilters: {{ $dns | get "zoneIdFilters" list | toYaml | nindent 2 }}
 annotationFilter: "externaldns=true"
-logLevel: {{ $externalDns | get "logLevel" "info" }}
+logLevel: {{ $externalDns | get "logLevel" }}
 dryRun: false
 crd:
   create: false

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: other-dns
-console: other-dns
+api: main
+console: main
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.13
-console: 0.5.16
+api: other-dns
+console: other-dns
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
## Checklist

- [x] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
