### PR TITLE
feat: otomi cli run as host user

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -240,7 +240,7 @@ helm_config="$HOME/.config/helm"
 if [[ $(uname -s) == "Darwin" ]]; then
   helm_config="$HOME/Library/Preferences/helm"
 else
-  readonly linux_workaround="--user=root:$(id -g)"
+  readonly linux_workaround="65534:65534"
 fi
 
 stack_dir='/home/app/stack'

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -240,7 +240,7 @@ helm_config="$HOME/.config/helm"
 if [[ $(uname -s) == "Darwin" ]]; then
   helm_config="$HOME/Library/Preferences/helm"
 else
-  readonly linux_workaround='--user=root:root'
+  readonly linux_workaround="--user=root:$(id -g)"
 fi
 
 stack_dir='/home/app/stack'

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -240,7 +240,7 @@ helm_config="$HOME/.config/helm"
 if [[ $(uname -s) == "Darwin" ]]; then
   helm_config="$HOME/Library/Preferences/helm"
 else
-  readonly linux_workaround="65534:65534"
+  readonly linux_workaround="--user=65534:65534"
 fi
 
 stack_dir='/home/app/stack'

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -208,6 +208,7 @@ vars=(
   AZURE_TENANT_ID
   CI
   DEBUG
+  DOCKER_RUN_AS
   ENV_DIR
   GCLOUD_SERVICE_KEY
   KUBE_VERSION_OVERRIDE
@@ -240,7 +241,7 @@ helm_config="$HOME/.config/helm"
 if [[ $(uname -s) == "Darwin" ]]; then
   helm_config="$HOME/Library/Preferences/helm"
 else
-  readonly linux_workaround="--user=65534:65534"
+  readonly linux_workaround="--user=${DOCKER_RUN_AS:-'root:root'}"
 fi
 
 stack_dir='/home/app/stack'

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -241,7 +241,8 @@ helm_config="$HOME/.config/helm"
 if [[ $(uname -s) == "Darwin" ]]; then
   helm_config="$HOME/Library/Preferences/helm"
 else
-  readonly linux_workaround="--user=${DOCKER_RUN_AS:-'root:root'}"
+  run_as="$(id -u):$(id -g)"
+  readonly linux_workaround="--user=${DOCKER_RUN_AS:-$run_as}"
 fi
 
 stack_dir='/home/app/stack'


### PR DESCRIPTION
Running Otomi Cli as the root user is a big troublemaker. Otomi mounts ENV_DIR and creates files that are owned by the running user - `root`. Later a user that wants to work with values repo cannot change files from the ENV_DIR. It is extremely cumbersome for any kind of pipeline system which tries to cleanup files after execution as it does it as non-root user.

This PR by default runs docker container with the group and user ID of the host user (in case the host is Linux OS). A user may not exists in the docker container and that is fine as long as the underlining application does not try to read user metadata. That is our case, which I tested while integrating Otomi CLI with the azure DevOps pipeline.

A user may still define any other user IDs by exporting the `DOCKER_RUN_AS` variable.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.

