### PR TITLE
Fix/loki

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -101,7 +101,7 @@ releases:
               editable: false
               type: loki
               access: proxy
-              url: http://loki.monitoring:3101
+              url: http://loki.monitoring:3100
               basicAuth: true
               basicAuthUser: {{ $teamId }}
               basicAuthPassword: {{ $team.password }}

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -102,9 +102,11 @@ releases:
               type: loki
               access: proxy
               url: http://loki.monitoring:3100
-              # basicAuth: true
-              # basicAuthUser: {{ $teamId }}
-              # basicAuthPassword: {{ $team.password }}
+{{/*
+              basicAuth: true
+              basicAuthUser: {{ $teamId }}
+              basicAuthPassword: {{ $team.password }}
+*/}}
     {{- if ($team | get "azureMonitor" ($v | get "azure.monitor" nil)) }}
             - {{- tpl (readFile "../helmfile.d/snippets/azure-monitor.gotmpl") ($team | get "azureMonitor" ($v | get "azure.monitor")) | toString | nindent 14 }}
     {{- end }}

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -101,7 +101,7 @@ releases:
               editable: false
               type: loki
               access: proxy
-              url: http://loki.monitoring:11811
+              url: http://loki.monitoring:3101
               basicAuth: true
               basicAuthUser: {{ $teamId }}
               basicAuthPassword: {{ $team.password }}

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -102,9 +102,9 @@ releases:
               type: loki
               access: proxy
               url: http://loki.monitoring:3100
-              basicAuth: true
-              basicAuthUser: {{ $teamId }}
-              basicAuthPassword: {{ $team.password }}
+              # basicAuth: true
+              # basicAuthUser: {{ $teamId }}
+              # basicAuthPassword: {{ $team.password }}
     {{- if ($team | get "azureMonitor" ($v | get "azure.monitor" nil)) }}
             - {{- tpl (readFile "../helmfile.d/snippets/azure-monitor.gotmpl") ($team | get "azureMonitor" ($v | get "azure.monitor")) | toString | nindent 14 }}
     {{- end }}

--- a/values/loki/auth-config.gotmpl
+++ b/values/loki/auth-config.gotmpl
@@ -1,9 +1,9 @@
 users:
   - username: admins
     password: {{ .adminPassword }}
-    orgId: admins
+    orgid: admins
   {{- range $id, $team := .teams }}
   - username: {{ $id }}
     password: {{ $team | get "password" "XXXX" }}
-    orgId: {{ $id }}
+    orgid: {{ $id }}
   {{- end }}

--- a/values/loki/loki-raw.gotmpl
+++ b/values/loki/loki-raw.gotmpl
@@ -1,7 +1,8 @@
 {{- $v := .Values }}
 {{- $l := $v.apps | get "loki" }}
 {{- if $v.otomi.isMultitenant }}
-resources:
+resources: []
+{{/*
   - apiVersion: v1
     kind: Secret
     metadata:
@@ -10,4 +11,5 @@ resources:
       name: reverse-proxy-auth-config
     data:
       authn.yaml: {{ tpl (readFile "auth-config.gotmpl") (dict "adminPassword" $l.adminPassword "teams" $v.teamConfig) | b64enc }}
+*/}}
 {{- end }}

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -91,14 +91,15 @@ promtail:
 extraContainers:
 {{- if $v.otomi.isMultitenant }}
 - name: reverse-proxy
-  image: angelbarrera92/basic-auth-reverse-proxy:dev
+  image: k8spin/loki-multi-tenant-proxy:v1.0.0
   args:
     - "serve"
-    - "--upstream=http://localhost:3100"
+    - "--port=3101"
+    - "--loki-server=http://localhost:3100"
     - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
   ports:
     - name: http
-      containerPort: 11811
+      containerPort: 3101
       protocol: TCP
   resources:
     limits:
@@ -123,7 +124,7 @@ extraVolumeMounts: []
 
 extraPorts:
 {{- if $v.otomi.isMultitenant }}
-- port: 11811
+- port: 3101
   protocol: TCP
   name: http
   targetPort: http

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -14,7 +14,7 @@ tracing:
   jaegerAgentHost:
 
 config:
-  auth_enabled: {{ $v.otomi.isMultitenant }}
+  # auth_enabled: {{ $v.otomi.isMultitenant }}
   limits_config:
     reject_old_samples_max_age: {{ $l | get "retention.duration" "24h" }}
   schema_config:
@@ -89,46 +89,46 @@ promtail:
   serviceName: promtail
 
 extraContainers:
-{{- if $v.otomi.isMultitenant }}
-- name: reverse-proxy
-  image: k8spin/loki-multi-tenant-proxy:v1.0.0
-  args:
-    - "serve"
-    - "--port=3101"
-    - "--loki-server=http://localhost:3100"
-    - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
-  ports:
-    - name: http
-      containerPort: 3101
-      protocol: TCP
-  resources:
-    limits:
-      cpu: 250m
-      memory: 200Mi
-    requests:
-      cpu: 50m
-      memory: 40Mi
-  volumeMounts:
-    - name: reverse-proxy-auth-config
-      mountPath: /etc/reverse-proxy-conf
-{{- end }}
+# {{- if $v.otomi.isMultitenant }}
+# - name: reverse-proxy
+#   image: k8spin/loki-multi-tenant-proxy:v1.0.0
+#   args:
+#     - "run"
+#     - "--port=3101"
+#     - "--loki-server=http://localhost:3100"
+#     - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
+#   ports:
+#     - name: http
+#       containerPort: 3101
+#       protocol: TCP
+#   resources:
+#     limits:
+#       cpu: 250m
+#       memory: 200Mi
+#     requests:
+#       cpu: 50m
+#       memory: 40Mi
+#   volumeMounts:
+#     - name: reverse-proxy-auth-config
+#       mountPath: /etc/reverse-proxy-conf
+# {{- end }}
 
 extraVolumes:
-{{- if $v.otomi.isMultitenant }}
-- name: reverse-proxy-auth-config
-  secret:
-    secretName: reverse-proxy-auth-config
-{{- end }}
+# {{- if $v.otomi.isMultitenant }}
+# - name: reverse-proxy-auth-config
+#   secret:
+#     secretName: reverse-proxy-auth-config
+# {{- end }}
 
 extraVolumeMounts: []
 
-extraPorts:
-{{- if $v.otomi.isMultitenant }}
-- port: 3101
-  protocol: TCP
-  name: http
-  targetPort: http
-{{- end }}
+# extraPorts:
+# {{- if $v.otomi.isMultitenant }}
+# - port: 3101
+#   protocol: TCP
+#   name: http
+#   targetPort: http
+# {{- end }}
 
 serviceMonitor:
   enabled: true
@@ -140,9 +140,9 @@ extraArgs:
 
 podAnnotations:
   sidecar.istio.io/inject: "false"
-  {{- if $v.otomi.isMultitenant }}
-  checksum/teams: {{ $teamNames | sha256sum }}
-  {{- end }}  
+  # {{- if $v.otomi.isMultitenant }}
+  # checksum/teams: {{ $teamNames | sha256sum }}
+  # {{- end }}  
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}
 image:

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -14,7 +14,9 @@ tracing:
   jaegerAgentHost:
 
 config:
-  # auth_enabled: {{ $v.otomi.isMultitenant }}
+{{/*
+  auth_enabled: {{ $v.otomi.isMultitenant }}
+*/}}
   limits_config:
     reject_old_samples_max_age: {{ $l | get "retention.duration" "24h" }}
   schema_config:
@@ -88,47 +90,52 @@ fullnameOverride: loki
 promtail:
   serviceName: promtail
 
+{{/*
 extraContainers:
-# {{- if $v.otomi.isMultitenant }}
-# - name: reverse-proxy
-#   image: k8spin/loki-multi-tenant-proxy:v1.0.0
-#   args:
-#     - "run"
-#     - "--port=3101"
-#     - "--loki-server=http://localhost:3100"
-#     - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
-#   ports:
-#     - name: http
-#       containerPort: 3101
-#       protocol: TCP
-#   resources:
-#     limits:
-#       cpu: 250m
-#       memory: 200Mi
-#     requests:
-#       cpu: 50m
-#       memory: 40Mi
-#   volumeMounts:
-#     - name: reverse-proxy-auth-config
-#       mountPath: /etc/reverse-proxy-conf
-# {{- end }}
+{{- if $v.otomi.isMultitenant }}
+- name: reverse-proxy
+  image: k8spin/loki-multi-tenant-proxy:v1.0.0
+  args:
+    - "run"
+    - "--port=3101"
+    - "--loki-server=http://localhost:3100"
+    - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
+  ports:
+    - name: http
+      containerPort: 3101
+      protocol: TCP
+  resources:
+    limits:
+      cpu: 250m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 40Mi
+  volumeMounts:
+    - name: reverse-proxy-auth-config
+      mountPath: /etc/reverse-proxy-conf
+{{- end }}
+*/}}
 
+{{/*
 extraVolumes:
-# {{- if $v.otomi.isMultitenant }}
-# - name: reverse-proxy-auth-config
-#   secret:
-#     secretName: reverse-proxy-auth-config
-# {{- end }}
-
+{{- if $v.otomi.isMultitenant }}
+- name: reverse-proxy-auth-config
+  secret:
+    secretName: reverse-proxy-auth-config
+{{- end }}=
 extraVolumeMounts: []
+*/}}
 
-# extraPorts:
-# {{- if $v.otomi.isMultitenant }}
-# - port: 3101
-#   protocol: TCP
-#   name: http
-#   targetPort: http
-# {{- end }}
+{{/*
+extraPorts:
+{{- if $v.otomi.isMultitenant }}
+- port: 3101
+  protocol: TCP
+  name: http
+  targetPort: http
+{{- end }}
+*/}}
 
 serviceMonitor:
   enabled: true

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -206,14 +206,14 @@ grafana:
       editable: false
       type: loki
       access: proxy
-      {{- if $v.otomi.isMultitenant }}
-      url: http://loki.monitoring:3101
-      basicAuth: true
-      basicAuthUser: admins
-      basicAuthPassword: {{ $v.apps.loki.adminPassword }}
-      {{- else }}
+      # {{- if $v.otomi.isMultitenant }}
+      # url: http://loki.monitoring:3101
+      # basicAuth: true
+      # basicAuthUser: admins
+      # basicAuthPassword: {{ $v.apps.loki.adminPassword }}
+      # {{- else }}
       url: http://loki.monitoring:3100
-      {{- end }}
+      # {{- end }}
     {{- if $v | get "azure.monitor" nil }}
     - {{- tpl (readFile "../../helmfile.d/snippets/azure-monitor.gotmpl") $v.azure.monitor | toString | nindent 6 }}
     {{- end }}

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -206,14 +206,17 @@ grafana:
       editable: false
       type: loki
       access: proxy
-      # {{- if $v.otomi.isMultitenant }}
-      # url: http://loki.monitoring:3101
-      # basicAuth: true
-      # basicAuthUser: admins
-      # basicAuthPassword: {{ $v.apps.loki.adminPassword }}
-      # {{- else }}
       url: http://loki.monitoring:3100
-      # {{- end }}
+{{/*
+      {{- if $v.otomi.isMultitenant }}
+      url: http://loki.monitoring:3101
+      basicAuth: true
+      basicAuthUser: admins
+      basicAuthPassword: {{ $v.apps.loki.adminPassword }}
+      {{- else }}
+      url: http://loki.monitoring:3100
+      {{- end }}
+*/}}
     {{- if $v | get "azure.monitor" nil }}
     - {{- tpl (readFile "../../helmfile.d/snippets/azure-monitor.gotmpl") $v.azure.monitor | toString | nindent 6 }}
     {{- end }}

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -207,7 +207,7 @@ grafana:
       type: loki
       access: proxy
       {{- if $v.otomi.isMultitenant }}
-      url: http://loki.monitoring:11811
+      url: http://loki.monitoring:3101
       basicAuth: true
       basicAuthUser: admins
       basicAuthPassword: {{ $v.apps.loki.adminPassword }}

--- a/values/promtail/promtail.gotmpl
+++ b/values/promtail/promtail.gotmpl
@@ -39,22 +39,24 @@ podAnnotations:
 
 pipelineStages:
   - docker: {}
-  # {{- if $v.otomi.isMultitenant }}
-  # - tenant:
-  #     value: admins
-  # - json:
-  #     expressions:
-  #       namespace:
-  # - labels:
-  #     namespace:
-  # {{- range $id, $team := $v.teamConfig }}
-  # - match:
-  #     selector: '{namespace="team-{{ $id }}"}'
-  #     stages:
-  #       - tenant:
-  #           value: {{ $id }}
-  # {{- end }}
-  # {{- end }}
+{{/*
+  {{- if $v.otomi.isMultitenant }}
+  - tenant:
+      value: admins
+  - json:
+      expressions:
+        namespace:
+  - labels:
+      namespace:
+  {{- range $id, $team := $v.teamConfig }}
+  - match:
+      selector: '{namespace="team-{{ $id }}"}'
+      stages:
+        - tenant:
+            value: {{ $id }}
+  {{- end }}
+  {{- end }}
+*/}}
 
 priorityClassName: otomi-critical
 config:

--- a/values/promtail/promtail.gotmpl
+++ b/values/promtail/promtail.gotmpl
@@ -39,22 +39,22 @@ podAnnotations:
 
 pipelineStages:
   - docker: {}
-  {{- if $v.otomi.isMultitenant }}
-  - tenant:
-      value: admins
-  - json:
-      expressions:
-        namespace:
-  - labels:
-      namespace:
-  {{- range $id, $team := $v.teamConfig }}
-  - match:
-      selector: '{namespace="team-{{ $id }}"}'
-      stages:
-        - tenant:
-            value: {{ $id }}
-  {{- end }}
-  {{- end }}
+  # {{- if $v.otomi.isMultitenant }}
+  # - tenant:
+  #     value: admins
+  # - json:
+  #     expressions:
+  #       namespace:
+  # - labels:
+  #     namespace:
+  # {{- range $id, $team := $v.teamConfig }}
+  # - match:
+  #     selector: '{namespace="team-{{ $id }}"}'
+  #     stages:
+  #       - tenant:
+  #           value: {{ $id }}
+  # {{- end }}
+  # {{- end }}
 
 priorityClassName: otomi-critical
 config:


### PR DESCRIPTION
This PR disables the existing Loki multi-tenant setup to make room for a new one. 

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
