### PR TITLE
fix: prometheus, vault, harbor schemas and values

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -143,6 +143,13 @@ environments:
             enabled: false
           vault:
             enabled: false
+            resources:
+              limits:
+                cpu: "1000m"
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 256Mi
           velero:
             enabled: false
             logLevel: info

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1647,8 +1647,8 @@ properties:
                       - aws
                       - azure
                       - gcs
-                      - file
-                    default: file
+                      - filesystem
+                    default: filesystem
           registry:
             properties:
               secret:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -127,12 +127,17 @@ definitions:
         type: integer
         default: 1
   autoscalingEnabled:
-    allOf:
-      - properties:
-          enabled:
-            default: true
-            type: boolean
-      - $ref: '#/definitions/autoscaling'
+    additionalProperties: false
+    properties:
+      enabled:
+        default: true
+        type: boolean
+      maxReplicas:
+        type: integer
+        default: 10
+      minReplicas:
+        type: integer
+        default: 1
   aws:
     definitions:
       accessKey:

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -69,7 +69,7 @@ prometheus:
       annotations:
         sidecar.istio.io/inject: "true"
     resources:
-      {{- with $p | get "resources" nil }}
+      {{- with $p | get "prometheus.resources" nil }}
         {{- toYaml . | nindent 6 }}
       {{- else }}
       requests:

--- a/values/vault-operator/vault-operator-raw.gotmpl
+++ b/values/vault-operator/vault-operator-raw.gotmpl
@@ -29,17 +29,8 @@ resources:
         # psp-allowed-users vault needs to run as root because it cuses chwon and IPC_LOCK
         policy.otomi.io/ignore: banned-image-tags,psp-capabilities,psp-allowed-users
       resources:
-        vault:
-          {{- with $vt | get "resources" nil }}
-            {{- toYaml . | nindent 6 }}
-          {{- else }}
-          limits:
-            cpu: "1"
-            memory: 512Mi
-          requests:
-            cpu: 500m
-            memory: 256Mi
-          {{- end }}
+        vault: {{ toYaml $vt.resources | nindent 10 }}
+
       vaultPodSpec:
         securityContext:
           runAsNonRoot: false


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
