### PR TITLE
fix: values migration

### DIFF
--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -341,7 +341,7 @@ export const bootstrap = async (
   const otomiImage = `otomi/core:${tag}`
   d.log(`Installing artifacts from ${otomiImage}`)
   await deps.copyBasicFiles()
-
+  await deps.migrate()
   const originalValues = await deps.processValues()
   // exit early if `isCli` and `ENV_DIR` were empty, and let the user provide valid values first:
   if (!originalValues) {
@@ -381,7 +381,7 @@ export const bootstrap = async (
       '`otomi.adminPassword` has been generated and is stored in the values repository in `env/secrets.settings.yaml`',
     )
   }
-  await deps.migrate()
+
   if (!hasOtomi) {
     d.log('You can now use the otomi CLI')
   }

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -35,7 +35,9 @@ changes:
       - otomi.isManaged
   - version: 5
     deletions:
-      - istio.autoscaling.ingressgateway-private
+      - apps.istio.autoscaling.ingressgateway-private
+      - apps.istio.global.mtls
+      - apps.istio.global.sds
     relocations:
       - apps.loki.storageType: apps.loki.storage.storageType
       - apps.loki.aws: apps.loki.storage.aws

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2029,6 +2029,8 @@ properties:
       external-secrets:
         additionalProperties: false
         properties:
+          _rawValues:
+            $ref: '#/definitions/rawValues'
           enabled:
             type: boolean
           logLevel:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
