### PR TITLE
feat: raw values for ingress-nginx chart

### DIFF
--- a/helmfile.d/helmfile-02.init.yaml
+++ b/helmfile.d/helmfile-02.init.yaml
@@ -60,6 +60,7 @@ releases:
     chart: ../charts/ingress-nginx
     values:
       - ../values/ingress-nginx/ingress-nginx.gotmpl
+      - ./snippets/ingress-nginx-raw.gotmpl
     <<: *upgrade
 {{- end }}
   - name: operator-lifecycle-manager

--- a/helmfile.d/snippets/ingress-nginx-raw.gotmpl
+++ b/helmfile.d/snippets/ingress-nginx-raw.gotmpl
@@ -1,0 +1,5 @@
+{{- /*
+Since the release name does not match ingress-nginx chart name, we cannot use common.gotmpl
+*/ -}}
+{{- $rawValues := .Values | get "apps.ingress-nginx._rawValues" nil }}
+{{- with $rawValues }}{{ toYaml . }}{{ end }}

--- a/tests/fixtures/env/apps/ingress-nginx.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx.yaml
@@ -1,5 +1,12 @@
 apps:
     ingress-nginx:
+        _rawValues:
+            controller:
+                config:
+                    modsecurity-snippet: |
+                        SecRuleRemoveById 911100
+        modsecurity:
+            enabled: true
         maxBodySize: 1024m
         resources:
             limits:


### PR DESCRIPTION
Since introduction of ingress classes feature the `_rawValues` were not populated to the chart values.
This PR allows users to set `_rawValues` that applies to all `ingress-nginx-<name>` releases.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
