### PR TITLE
fix: otomi-api pod gets stuck during pod initialization

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.14
+api: 0.5.15
 console: 0.5.17
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
