### PR TITLE
test: allow developers to create k8s cluster and install Otomi via GitHub pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,11 @@ on:
         required: true
         default: ams3
         type: string
+      cluster_persistence:
+        options:
+          - preserve
+          - destroy
+        default: destroy
 
 env:
   CACHE_REGISTRY: ghcr.io
@@ -149,7 +154,9 @@ jobs:
           kubectl logs jobs/otomi --tail 150
       - name: Remove the test cluster
         if: always()
-        run: doctl kubernetes cluster delete ${{ env.DIGITALOCEAN_CLUSTER_NAME }} -f --dangerous
+        run: |
+          [[ "${{ inputs.cluster_persistence }}" == "preserve" ]] && echo "The cluster ${{ env.DIGITALOCEAN_CLUSTER_NAME }} will NOT be destroyed!!" && exit 0
+          doctl kubernetes cluster delete ${{ env.DIGITALOCEAN_CLUSTER_NAME }} -f --dangerous
       - name: Slack Notification
         if: always()
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,6 +34,9 @@ on:
         default: ams3
         type: string
       cluster_persistence:
+        type: choice
+        description: Should a cluster be destroyed on pipeline finish
+        required: true
         options:
           - preserve
           - destroy

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,12 @@ on:
         required: true
         default: ams3
         type: string
+      cluster_persistence:
+        type: string
+        description: Should a cluster be destroyed on pipeline finish
+        required: true
+        default: destroy
+
   workflow_dispatch:
     inputs:
       kubernetes_versions:


### PR DESCRIPTION
Allow developers to create k8s cluster and install Otomi via GitHub pipeline.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
