### PR TITLE
fix: do not allow additional properites at dns provider

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2465,6 +2465,7 @@ properties:
         oneOf:
           - title: AWS
             description: Uses credentials when either a pair of id+key or a secret name is provided. Assumes node role otherwise.
+            additionalProperties: false
             properties:
               aws:
                 properties:
@@ -2490,18 +2491,21 @@ properties:
             required:
               - aws
           - title: Azure
+            additionalProperties: false
             properties:
               azure:
                 $ref: '#/definitions/azure/definitions/dns'
             required:
               - azure
           - title: Azure Private
+            additionalProperties: false
             properties:
               azure-private-dns:
                 $ref: '#/definitions/azure/definitions/dns'
             required:
               - azure-private-dns
           - title: Google
+            additionalProperties: false
             properties:
               google:
                 properties:
@@ -2514,6 +2518,7 @@ properties:
             required:
               - google
           - title: Digital Ocean
+            additionalProperties: false
             properties:
               digitalocean:
                 properties:
@@ -2525,6 +2530,7 @@ properties:
             required:
               - digitalocean
           - title: CloudFlare
+            additionalProperties: false
             properties:
               cloudflare:
                 properties:
@@ -2552,6 +2558,7 @@ properties:
             required:
               - cloudflare
           - title: Other
+            additionalProperties: false
             properties:
               other:
                 description: This option requires configuration for both external-dns as well as cert-manager. No schema validation is available so provide correct data.


### PR DESCRIPTION
The schema did not complain about incorrect dns values. E.g.:

```
dns:
    provider:
        azure:
            aadClientId: 00-aadClientId
            resourceGroup: external-dns
            subscriptionId: 00-subscriptionId
            tenantId: 00-tenantId
       domainFilters:
          - otomi.cloud
 ```
 which is incorrect, because the `domainFilters` is not in the right scope. Should be:
 ```
dns:
    provider:
        azure:
            aadClientId: 00-aadClientId
            resourceGroup: external-dns
            subscriptionId: 00-subscriptionId
            tenantId: 00-tenantId
    domainFilters:
      - otomi.cloud
 ```
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
