### PR TITLE
fix: missing secret for cert-manager

### DIFF
--- a/tests/fixtures/env/apps/cert-manager.yaml
+++ b/tests/fixtures/env/apps/cert-manager.yaml
@@ -1,3 +1,4 @@
 apps:
     cert-manager:
-        issuer: custom-ca
+        issuer: letsencrypt
+        email: test@test.local

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -18,8 +18,8 @@ resources:
       secret: "{{ $p.google.serviceAccountKey | b64enc }}"
       {{- else if or (hasKey $p "azure") }}
       secret: "{{ $p.azure.aadClientSecret | b64enc }}"
-      {{- else if hasKey $p "aws" }}
-      secret: "{{ $p.aws.secretAccessKey | b64enc }}"
+      {{- else if ($p | get "$p.aws.credentials.secretKey" nil) }}
+      secret: "{{ $p.aws.credentials.secretKey | b64enc }}"
       {{- else if hasKey $p "digitalocean" }}
       secret: "{{ $p.digitalocean.apiToken | b64enc }}"
       {{- else if hasKey $p "cloudflare" }}

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -16,7 +16,7 @@ resources:
     data:
       {{- if hasKey $p "google" }}
       secret: "{{ $p.google.serviceAccountKey | b64enc }}"
-      {{- else if or (hasKey $p "azure") (hasKey $p "azure-private-dns" ) }}
+      {{- else if or (hasKey $p "azure") }}
       secret: "{{ $p.azure.aadClientSecret | b64enc }}"
       {{- else if hasKey $p "aws" }}
       secret: "{{ $p.aws.secretAccessKey | b64enc }}"

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -16,6 +16,8 @@ resources:
     data:
       {{- if hasKey $p "google" }}
       secret: "{{ $p.google.serviceAccountKey | b64enc }}"
+      {{- else if or (hasKey $p "azure-private-dns") }}
+      secret: "{{ $p.azure-private-dns.aadClientSecret | b64enc }}"
       {{- else if or (hasKey $p "azure") }}
       secret: "{{ $p.azure.aadClientSecret | b64enc }}"
       {{- else if ($p | get "$p.aws.credentials.secretKey" nil) }}
@@ -63,6 +65,21 @@ resources:
                 {{- end }}
               {{- end }}
               {{- with $p | get "azure" nil }}
+              azureDNS:
+                resourceGroupName: {{ .resourceGroup }}
+                subscriptionID: {{ .subscriptionId }}
+                {{- if hasKey . "aadClientId" }}
+                tenantID: {{ .tenantId }}
+                clientID: {{ .aadClientId }}
+                {{- end }}
+                {{- with . | get "hostedZoneName" nil }}
+                hostedZoneName: {{ . }}
+                {{- end }}
+                clientSecretSecretRef:
+                  key: secret
+                  name: external-dns
+              {{- end }}
+              {{- with $p | get "azure-private-dns" nil }}
               azureDNS:
                 resourceGroupName: {{ .resourceGroup }}
                 subscriptionID: {{ .subscriptionId }}

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -7,6 +7,25 @@
 {{- $issuerName := ternary (printf "%s-%s" $cm.issuer ($cm | get "stage" "")) $cm.issuer (eq $cm.issuer "letsencrypt") }}
 {{- $doms := tpl (readFile "../../helmfile.d/snippets/domains.gotmpl") $v | fromYaml }}
 resources:
+
+{{- if $v.otomi.hasExternalDNS }}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "external-dns"
+    data:
+      {{- if hasKey $p "google" }}
+      secret: "{{ $p.google.serviceAccountKey | b64enc }}"
+      {{- else if or (hasKey $p "azure") (hasKey $p "azure-private-dns" ) }}
+      secret: "{{ $p.azure.aadClientSecret | b64enc }}"
+      {{- else if hasKey $p "aws" }}
+      secret: "{{ $p.aws.secretAccessKey | b64enc }}"
+      {{- else if hasKey $p "digitalocean" }}
+      secret: "{{ $p.digitalocean.apiToken | b64enc }}"
+      {{- else if hasKey $p "cloudflare" }}
+      secret: "{{ $p.cloudflare.apiToken | b64enc }}"
+      {{- end }}
+{{- end }}
   - apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
@@ -33,9 +52,9 @@ resources:
                 {{- with . | get "credentials.accessKey" nil }}
                 accessKeyID: {{ . }}
                 {{- end }}
-                {{- if or (. | get "credentials.secretKey" nil) (. | get "secretName" nil) }}
+                {{- if . | get "credentials.secretKey" nil }}
                 secretAccessKeySecretRef:
-                  key: "credentials"
+                  key: secret
                   name: external-dns
                 {{- end }}
                 region: {{ .region }}
@@ -54,46 +73,33 @@ resources:
                 {{- with . | get "hostedZoneName" nil }}
                 hostedZoneName: {{ . }}
                 {{- end }}
-                {{- if or (. | get "aadClientSecret" nil) (. | get "secretName" nil) }}
                 clientSecretSecretRef:
-                  key: azure.json
+                  key: secret
                   name: external-dns
-                {{- end }}
               {{- end }}
               {{- with $p | get "cloudflare" nil }}
               cloudflare:
-                {{- if or (. | get "apiToken" nil) (. | get "apiSecret" nil) (. | get "secretName" nil) }}
-                  {{- with . | get "apiToken" nil }}
+                {{- with . | get "apiToken" nil }}
                 apiTokenSecretRef:
-                  key: cloudflare_api_token
-                  {{- end }}
-                  {{- with . | get "apiSecret" nil }}
-                apiKeySecretRef:
-                  key: cloudflare_api_key
-                  {{- end }}
-                  name: external-dns
-                {{- else }}
-                  {}
                 {{- end }}
+                {{- with . | get "apiSecret" nil }}
+                apiKeySecretRef:
+                {{- end }}
+                  key: secret
+                  name: external-dns
               {{- end }}
               {{- with $p | get "digitalocean" nil }}
               digitalocean:
-                {{- if or (. | get "apiToken" nil) (. | get "secretName" nil) }}
                 tokenSecretRef:
-                  key: digitalocean_api_token
+                  key: secret
                   name: external-dns
-                {{- else }}
-                  {}
-                {{- end }}
               {{- end }}
               {{- with $p | get "google" nil }}
               cloudDNS:
                 project: {{ .project }}
-                {{- if or (. | get "serviceAccountKey" nil) (. | get "secretName" nil) }}
                 serviceAccountSecretRef:
-                  key: credentials.json
+                  key: secret
                   name: external-dns
-                {{- end }}
               {{- end }}
               {{- with $p | get "other" nil }}
               {{- toYaml . | get "cert-manager" nindent 14 }}

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -17,7 +17,7 @@ resources:
       {{- if hasKey $p "google" }}
       secret: "{{ $p.google.serviceAccountKey | b64enc }}"
       {{- else if or (hasKey $p "azure-private-dns") }}
-      secret: "{{ $p.azure-private-dns.aadClientSecret | b64enc }}"
+      secret: "{{ $p | get "azure-private-dns.aadClientSecret" | b64enc }}"
       {{- else if or (hasKey $p "azure") }}
       secret: "{{ $p.azure.aadClientSecret | b64enc }}"
       {{- else if ($p | get "$p.aws.credentials.secretKey" nil) }}


### PR DESCRIPTION
The ClusterIssuer was referencing a secret that did not exist in cert-manager namespace.
This issue was happening if dns configuration together with cert-manager lets encrypt issuer were provided via values.


## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
