### PR TITLE
chore(release): 0.16.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.16.18](https://github.com/redkubes/otomi-core/compare/v0.16.17...v0.16.18) (2022-09-30)
+
+
+### Bug Fixes
+
+* do not allow additional properites at dns provider ([#922](https://github.com/redkubes/otomi-core/issues/922)) ([e9383a5](https://github.com/redkubes/otomi-core/commit/e9383a5206ed7d7f417682f00997ba460a4c07f7))
+* missing secret required by certificate issuer ([#923](https://github.com/redkubes/otomi-core/issues/923)) ([cdaa336](https://github.com/redkubes/otomi-core/commit/cdaa336d613e74077e5c191b93995cd21dcaf4b9))
+
+
+### Tests
+
+* add  workflow dispatch options and fix scheduled workflow ([#919](https://github.com/redkubes/otomi-core/issues/919)) ([8165f61](https://github.com/redkubes/otomi-core/commit/8165f61c17fb071d30ec8a17de39c6d020757f32))
+
 ### [0.16.17](https://github.com/redkubes/otomi-core/compare/v0.16.16...v0.16.17) (2022-09-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otomi-core",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "otomi-core",
-      "version": "0.16.17",
+      "version": "0.16.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -160,5 +160,5 @@
     }
   },
   "type": "commonjs",
-  "version": "0.16.17"
+  "version": "0.16.18"
 }


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
