### PR TITLE
test: integration tests and tests on demand with optional settings for dns kms and oidc

### DIFF
--- a/.github/workflows/integration-on-schedule-dns.yml
+++ b/.github/workflows/integration-on-schedule-dns.yml
@@ -1,4 +1,4 @@
-name: Integration test on schedule (minimal)
+name: Scheduled - minimal with DNS, KMS and Letsencrypt
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:

--- a/.github/workflows/integration-on-schedule-dns.yml
+++ b/.github/workflows/integration-on-schedule-dns.yml
@@ -1,0 +1,19 @@
+name: Integration test on schedule (minimal)
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  start-integration-test-minimal-dns:
+    name: Start integration test (minimal)
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+    with:
+      install_profile: minimal
+      cluster_region: ams3
+      kubernetes_versions: "['1.23']"
+      dns: az_dns
+      kms: az_kms
+      oidc: keycloak
+      certificate: letsencrypt_staging

--- a/.github/workflows/integration-on-schedule-full.yml
+++ b/.github/workflows/integration-on-schedule-full.yml
@@ -1,4 +1,4 @@
-name: Integration test on schedule (full)
+name: Scheduled - full with nip.io
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:

--- a/.github/workflows/integration-on-schedule-minimal.yml
+++ b/.github/workflows/integration-on-schedule-minimal.yml
@@ -1,4 +1,4 @@
-name: Integration test on schedule (minimal)
+name: Scheduled - minimal with nip.io
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,38 @@ on:
           - preserve
           - destroy
         default: destroy
-
+      dns:
+        type: choice
+        description: Select DNS provider
+        required: true
+        options:
+          - nip_io
+          - az_dns
+        default: nip_io
+      kms:
+        type: choice
+        description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
+        required: true
+        options:
+          - no_kms
+          - az_kms
+        default: az_kms
+      oidc:
+        type: choice
+        description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
+        required: true
+        options:
+          - no_oidc
+          - az_oidc
+        default: no_oidc
+      certificate:
+        type: choice
+        description: Select certificate issuer
+        required: true
+        options:
+          - gen_custom_ca
+          - letsencrypt_staging
+        default: gen_custom_ca
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: redkubes/otomi-core
@@ -153,7 +184,23 @@ jobs:
             - reg-otomi-github
           EOF
       - name: Otomi install
-        run: helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi --values tests/integration/${{ inputs.install_profile }}.yaml --values values-temp.yaml
+        env:
+          AZ_DNS: ${{ secrets.AZ_DNS }}
+          AZ_KMS: ${{ secrets.AZ_KMS }}
+          AZ_OIDC: ${{ secrets.AZ_OIDC }}
+          LETSENCRYPT_STAGING: ${{ secrets.LETSENCRYPT_STAGING }}
+        run: |
+          domainSuffix=''
+          touch values.yaml
+          [[ '${{ inputs.dns }}' == 'az_dns' ]] && echo "$AZ_DNS" >> values.yaml && domainSuffix=' --set cluster.domainSuffix=tst-${{ github.run_id }}.aks.redkubes.net'
+          [[ '${{ inputs.kms }}' == 'az_kms' ]] && echo "$AZ_KMS" >> values.yaml
+          [[ '${{ inputs.oidc }}' == 'az_oidc' ]] && echo "$AZ_OIDC" >> values.yaml
+          [[ '${{ inputs.cert }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
+          helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi \
+          --values tests/integration/${{ inputs.install_profile }}.yaml \
+          --values values-temp.yaml \
+          --values values.yaml \
+          $domainSuffix
       - name: Gather k8s events on failure
         if: failure()
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,23 @@ on:
         description: Should a cluster be destroyed on pipeline finish
         required: false
         default: destroy
-
+      dns:
+        type: string
+        description: Select DNS provider
+        default: nip_io
+      kms:
+        type: string
+        description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
+        default: az_kms
+      oidc:
+        type: string
+        description: Should Otomi use external OIDC
+        default: keycloak
+      certificate:
+        type: string
+        description: Select certificate issuer
+        required: true
+        default: gen_custom_ca
   workflow_dispatch:
     inputs:
       kubernetes_versions:
@@ -73,9 +89,9 @@ on:
         description: Should Otomi encrypt secrets in values repo (DNS or KMS is used).
         required: true
         options:
-          - no_oidc
+          - keycloak
           - az_oidc
-        default: no_oidc
+        default: keycloak
       certificate:
         type: choice
         description: Select certificate issuer
@@ -195,7 +211,7 @@ jobs:
           [[ '${{ inputs.dns }}' == 'az_dns' ]] && echo "$AZ_DNS" >> values.yaml && domainSuffix=' --set cluster.domainSuffix=tst-${{ github.run_id }}.aks.redkubes.net'
           [[ '${{ inputs.kms }}' == 'az_kms' ]] && echo "$AZ_KMS" >> values.yaml
           [[ '${{ inputs.oidc }}' == 'az_oidc' ]] && echo "$AZ_OIDC" >> values.yaml
-          [[ '${{ inputs.cert }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
+          [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
           helm install --wait --wait-for-jobs --timeout 40m0s otomi chart/otomi \
           --values tests/integration/${{ inputs.install_profile }}.yaml \
           --values values-temp.yaml \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,7 +70,7 @@ on:
         default: az_kms
       oidc:
         type: choice
-        description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
+        description: Should Otomi encrypt secrets in values repo (DNS or KMS is used).
         required: true
         options:
           - no_oidc

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -9,7 +9,7 @@ azure:
         clientSecret: somesecretvalue
 dns:
     provider:
-        azure:
+        azure-private-dns:
             aadClientSecret: 00-aadClientSecret
 home:
     email:

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -24,7 +24,7 @@ dns:
     domainFilters:
         - otomi.cloud
     provider:
-        azure:
+        azure-private-dns:
             aadClientId: 00-aadClientId
             resourceGroup: external-dns
             subscriptionId: 00-subscriptionId

--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -7,6 +7,7 @@ cluster:
 otomi:
   isMultitenant: true
   version: 'OTOMI_VERSION_PLACEHOLDER'
+  adminPassword: welcomeotomi
 apps:
   alertmanager:
     enabled: true

--- a/tests/integration/minimal.yaml
+++ b/tests/integration/minimal.yaml
@@ -6,3 +6,4 @@ cluster:
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
   version: 'OTOMI_VERSION_PLACEHOLDER'
+  adminPassword: welcomeotomi


### PR DESCRIPTION
This PR enables users to schedule on demand Otomi deployment with customisable deployment scenarios like in the picture below. The deployment workflow ensures unique cluster.domianSuffix.

<img width="387" alt="image" src="https://user-images.githubusercontent.com/17126497/196254579-29250c45-3209-4376-9cea-1c37f6a54f7d.png">

Moreover this PR implements scheduled test to ensure deployment with DNS is successful (see `.github/workflows/integration-on-schedule-dns.yml` file)

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
