### PR TITLE
fix: rename default vault secret name

### DIFF
--- a/values/vault-operator/vault-operator-raw.gotmpl
+++ b/values/vault-operator/vault-operator-raw.gotmpl
@@ -245,14 +245,14 @@ resources:
                 TARGET: secret demo world
           {{- end }}
           - type: kv
-            path: secret/data/teams/team-{{ $teamId }}/otomi-welcome
+            path: secret/data/teams/team-{{ $teamId }}/.keep-me
             data:
               data:
                 HELLO: Welcome {{ $teamId }} team
         {{- end }}
         {{- end }}
           - type: kv
-            path: secret/data/teams/team-admin/otomi-welcome
+            path: secret/data/teams/team-admin/.keep-me
             data:
               data:
                 HELLO: Welcome admin team


### PR DESCRIPTION
fixes #895

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
