### PR TITLE
test: simplify cluster name

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Set k8s cluster name
         run: |
           # Cluster name must be no longer than 63 characters
-          echo DIGITALOCEAN_CLUSTER_NAME=i-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}-${{ github.event.pull_request.head.sha || github.sha }} >> $GITHUB_ENV
+          echo DIGITALOCEAN_CLUSTER_NAME=i-${{ github.run_id }} >> $GITHUB_ENV
       - name: Determine exact k8s version
         run: |
           echo DIGITALOCEAN_K8S_VERSION=`doctl kubernetes options versions -o json | jq -re 'map(select(.kubernetes_version | startswith("${{ matrix.kubernetes_version }}"))) | .[0] | .slug'` >> $GITHUB_ENV


### PR DESCRIPTION
Example 
cluster name instead of `i-3280617043-161-1-0-361b86c3808e4c501e95cb19439de6b125e2afa8`
will be called `i-3280617043`
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
