### PR TITLE
test: ensure cluster name uniqueness for jobs using matrix strategy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Set k8s cluster name
         run: |
           # Cluster name must be no longer than 63 characters
-          echo DIGITALOCEAN_CLUSTER_NAME=i-${{ github.run_id }} >> $GITHUB_ENV
+          echo DIGITALOCEAN_CLUSTER_NAME=i-${{ github.run_id }}-${{ strategy.job-index } >> $GITHUB_ENV
       - name: Determine exact k8s version
         run: |
           echo DIGITALOCEAN_K8S_VERSION=`doctl kubernetes options versions -o json | jq -re 'map(select(.kubernetes_version | startswith("${{ matrix.kubernetes_version }}"))) | .[0] | .slug'` >> $GITHUB_ENV


### PR DESCRIPTION
Turns out that the `github.run_id` was not enough to ensure cluster name uniqueness.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
