### PR TITLE
fix: admin services should not be excluded from team-ns-admin

### DIFF
--- a/helmfile.d/helmfile-15.ingress-core.yaml
+++ b/helmfile.d/helmfile-15.ingress-core.yaml
@@ -27,6 +27,7 @@ bases:
 {{- $svc := merge $s (dict "ingressClassName" $ingressClass ) }}
 {{- $services = append $services $svc }}
 {{- end }}
+{{- $services = concat $services ($tca | get "services" list) }}
 
 releases:
   - name: team-ns-admin

--- a/tests/fixtures/env/teams/services.admin.yaml
+++ b/tests/fixtures/env/teams/services.admin.yaml
@@ -1,3 +1,13 @@
 teamConfig:
     admin:
-        services: []
+        services:
+            - auth: true
+              domain: hello.team-admin.demo.eks.otomi.cloud
+              id: cb5149c4-8ea5-4c5a-be04-a37258658bd0
+              name: hello-admin
+              networkPolicy:
+                  ingressPrivate:
+                      mode: AllowAll
+              ownHost: true
+              port: 80
+              type: public


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
