### PR TITLE
Fix: certman resources

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1263,6 +1263,8 @@ properties:
               - production
               - staging
             default: production
+          resources:
+            $ref: '#/definitions/resources'
         oneOf:
           - properties:
               issuer:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1241,6 +1241,8 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
+          resources:
+            $ref: '#/definitions/resources'
           customRootCA:
             x-secret: ''
             type: string
@@ -1263,8 +1265,6 @@ properties:
               - production
               - staging
             default: production
-          resources:
-            $ref: '#/definitions/resources'
         oneOf:
           - properties:
               issuer:

--- a/values/cert-manager/cert-manager.gotmpl
+++ b/values/cert-manager/cert-manager.gotmpl
@@ -33,12 +33,16 @@ startupapicheck:
 installCRDs: true
 
 resources:
+  {{- with $cm | get "resources" nil }}
+    {{- toYaml . | nindent 2 }}
+  {{- else }}
   requests:
     cpu: 50m
     memory: 64Mi
   limits:
     cpu: 200m
     memory: 384Mi
+  {{- end }}
 
 cainjector:
   resources:


### PR DESCRIPTION
Adds the ability to configure resource quotas for certmanager

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
