### PR TITLE
feat: make Jaeger shared

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -196,7 +196,7 @@ adminApps:
         auth: true
   - name: keycloak
     tags: [auth, sso]
-    isShared: true
+    # isShared: true
     ownHost: true
     ingress:
       - namespace: keycloak

--- a/core.yaml
+++ b/core.yaml
@@ -186,6 +186,7 @@ adminApps:
   - name: jaeger
     tags: [ingress, telemetry, observability]
     deps: [istio]
+    isShared: true
     ingress:
       - svc: jaeger-operator-jaeger-query
         port: 16686


### PR DESCRIPTION
This PR will enable Jaeger to be shared and made available for teams and remove Keycloak as a team app.
