### PR TITLE
feat: add a flag to disable monitoring stack for a specific team

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -111,7 +111,7 @@ releases:
     {{- end }}
     {{- if has "msteams" ($team | get "alerts.receivers" list) }}
   - name: prometheus-msteams-{{ $teamId }}
-    installed: {{ $team.monitoringStack.enabled }}
+    installed: {{ $team | get "monitoringStack.enabled" true }}
     namespace: team-{{ $teamId }}
     chart: ../charts/prometheus-msteams
     labels:

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -30,7 +30,7 @@ releases:
   {{- $appsDomain := printf "apps.%s" $domain }}
   {{- $grafanaDomain := printf "grafana.%s" $domain }}
   {{- $azure := $team | get "azure" dict }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $tc.monitoringStack.enabled }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $team.monitoringStack.enabled }}
   - name: prometheus-{{ $teamId }}
     installed: true
     namespace: team-{{ $teamId }}
@@ -164,7 +164,7 @@ releases:
       - {{- omit $team "apps" | toYaml | nindent 8 }}
         teamId: {{ $teamId }}
       - services: {{- concat $coreTeamServices $teamServices | toYaml | nindent 10 }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $tc.monitoringStack.enabled (gt (len $teamServices) 0) }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $team.monitoringStack.enabled (gt (len $teamServices) 0) }}
       - name: blackbox
         svc: prometheus-blackbox-exporter
         port: 9115

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -30,7 +30,7 @@ releases:
   {{- $appsDomain := printf "apps.%s" $domain }}
   {{- $grafanaDomain := printf "grafana.%s" $domain }}
   {{- $azure := $team | get "azure" dict }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $tc.monitoringStack.enabled }}
   - name: prometheus-{{ $teamId }}
     installed: true
     namespace: team-{{ $teamId }}
@@ -164,7 +164,7 @@ releases:
       - {{- omit $team "apps" | toYaml | nindent 8 }}
         teamId: {{ $teamId }}
       - services: {{- concat $coreTeamServices $teamServices | toYaml | nindent 10 }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant (gt (len $teamServices) 0) }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $tc.monitoringStack.enabled (gt (len $teamServices) 0) }}
       - name: blackbox
         svc: prometheus-blackbox-exporter
         port: 9115

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -30,9 +30,9 @@ releases:
   {{- $appsDomain := printf "apps.%s" $domain }}
   {{- $grafanaDomain := printf "grafana.%s" $domain }}
   {{- $azure := $team | get "azure" dict }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $team.monitoringStack.enabled }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant }}
   - name: prometheus-{{ $teamId }}
-    installed: true
+    installed: {{ $team.monitoringStack.enabled }}
     namespace: team-{{ $teamId }}
     chart: ../charts/kube-prometheus-stack
     labels:
@@ -59,7 +59,7 @@ releases:
         commonLabels:
           prometheus: team-{{ $teamId }}
         prometheus:
-          enabled: true
+          enabled: {{ $team.monitoringStack.enabled }}
           namespaceOverride: null # team-{{ $teamId }}
           prometheusSpec:
             externalUrl: https://{{ $appsDomain }}/prometheus
@@ -111,7 +111,7 @@ releases:
     {{- end }}
     {{- if has "msteams" ($team | get "alerts.receivers" list) }}
   - name: prometheus-msteams-{{ $teamId }}
-    installed: true
+    installed: {{ $team.monitoringStack.enabled }}
     namespace: team-{{ $teamId }}
     chart: ../charts/prometheus-msteams
     labels:
@@ -130,7 +130,7 @@ releases:
           - low_priority_channel: {{ $team | get "msteams.lowPrio" }}
     {{- end }}
   - name: grafana-dashboards-{{ $teamId }}
-    installed: true
+    installed: {{ $team.monitoringStack.enabled }}
     namespace: team-{{ $teamId }}
     chart: ../charts/grafana-dashboards
     labels:
@@ -164,7 +164,7 @@ releases:
       - {{- omit $team "apps" | toYaml | nindent 8 }}
         teamId: {{ $teamId }}
       - services: {{- concat $coreTeamServices $teamServices | toYaml | nindent 10 }}
-  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant $team.monitoringStack.enabled (gt (len $teamServices) 0) }}
+  {{- if and $a.prometheus.enabled $v.otomi.isMultitenant (gt (len $teamServices) 0) }}
       - name: blackbox
         svc: prometheus-blackbox-exporter
         port: 9115

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -32,7 +32,7 @@ releases:
   {{- $azure := $team | get "azure" dict }}
   {{- if and $a.prometheus.enabled $v.otomi.isMultitenant }}
   - name: prometheus-{{ $teamId }}
-    installed: {{ $team.monitoringStack.enabled }}
+    installed: {{ $team | get "monitoringStack.enabled" true }}
     namespace: team-{{ $teamId }}
     chart: ../charts/kube-prometheus-stack
     labels:
@@ -59,7 +59,7 @@ releases:
         commonLabels:
           prometheus: team-{{ $teamId }}
         prometheus:
-          enabled: {{ $team.monitoringStack.enabled }}
+          enabled: {{ $team | get "monitoringStack.enabled" true }}
           namespaceOverride: null # team-{{ $teamId }}
           prometheusSpec:
             externalUrl: https://{{ $appsDomain }}/prometheus
@@ -130,7 +130,7 @@ releases:
           - low_priority_channel: {{ $team | get "msteams.lowPrio" }}
     {{- end }}
   - name: grafana-dashboards-{{ $teamId }}
-    installed: {{ $team.monitoringStack.enabled }}
+    installed: {{ $team | get "monitoringStack.enabled" true }}
     namespace: team-{{ $teamId }}
     chart: ../charts/grafana-dashboards
     labels:

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -6,8 +6,8 @@ teamConfig:
             receivers:
                 - email
         id: demo
-        monitoringStack:
-            enabled: true
+        # monitoringStack:
+        #     enabled: false
         networkPolicy:
             egressPublic: true
             ingressPrivate: true

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -6,6 +6,8 @@ teamConfig:
             receivers:
                 - email
         id: demo
+        monitoringStack:
+            enabled: true
         networkPolicy:
             egressPublic: true
             ingressPrivate: true

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1111,6 +1111,11 @@ definitions:
         items:
           $ref: '#/definitions/service'
         type: array
+      monitoringStack:
+        properties:
+          enabled:
+            type: boolean
+            default: true
       networkPolicy:
         ingressPrivate:
           title: Enable filtering of ingress traffic inside the cluster

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -1,3 +1,5 @@
+{{- $teamId := .Release.Labels.team }}
+
 kubeApiServer:
   enabled: false
 coreDns:
@@ -61,6 +63,13 @@ prometheus:
       requests:
         cpu: 100m
         memory: 128Mi
+    {{- range $selType := list "podMonitor" "probe" "rule" "serviceMonitor" }}
+    {{ $selType }}NamespaceSelector: 
+      - team-{{ $teamId }}
+    {{ $selType }}Selector:
+      matchLabels:
+        prometheus: team-{{ $teamId }}
+    {{- end }}
 additionalPrometheusRules: null
 grafana:
   defaultDashboardsEnabled: false

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: teammon
+api: main
 console: main
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
+api: teammon
 console: main
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
This PR brings:

- The option to disable the monitoring stack (grafana, prometheus) for a specific team when otomi is running in multi-tenant mode
