### PR TITLE
test: workflows select image registry [ci skip]

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,7 +192,13 @@ jobs:
           sed --in-place "s/CONTEXT_PLACEHOLDER/${{ env.DIGITALOCEAN_CLUSTER_CONTEXT }}/g" tests/integration/${{ inputs.install_profile }}.yaml
           sed --in-place "s/K8S_VERSION_PLACEHOLDER/${k8sVersion:0:4}/g" tests/integration/${{ inputs.install_profile }}.yaml
           sed --in-place "s/OTOMI_VERSION_PLACEHOLDER/${GITHUB_REF##*/}/g" tests/integration/${{ inputs.install_profile }}.yaml
-          cat << EOF > values-temp.yaml
+          touch values-container-registry.yaml
+
+          # If a pipeline installs Otomi from the semver tag then pull container image from DockerHub
+          [[ ${GITHUB_REF##*/} =~ ^v[0-9].+$ ]] && exit 0
+
+          # Pull image from cache registry
+          cat << EOF > values-container-registry.yaml
           imageName: "${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }}"
           imagePullSecretNames:
             - reg-otomi-github
@@ -213,7 +219,7 @@ jobs:
           # Sometimes the DO cluster is having hiccups while scaling up nodes, thus we need keep the timeout high.
           helm install --wait --wait-for-jobs --timeout 90m0s otomi chart/otomi \
           --values tests/integration/${{ inputs.install_profile }}.yaml \
-          --values values-temp.yaml \
+          --values values-container-registry.yaml \
           --values values.yaml \
           $domainSuffix
       - name: Gather k8s events on failure


### PR DESCRIPTION
The pipeline by default provides GitHub credentials to pull images from the GitHub cache registry, which is good for testing with unofficial container image tags. However the GiHub cache repo does not contain images that has been release long time ago.

This PR checks if requested image tag is semver compatible (a simplified regex). If so then the Otomi installation job will pull container image from DockerHub.
