### PR TITLE
test: digital ocean does not support k8s 1.22 anymore [ci skip]

### DIFF
--- a/.github/workflows/integration-on-schedule-full.yml
+++ b/.github/workflows/integration-on-schedule-full.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       install_profile: full
       cluster_region: ams3
-      kubernetes_versions: "['1.22', '1.23']"
+      kubernetes_versions: "['1.23']"

--- a/.github/workflows/integration-on-schedule-minimal.yml
+++ b/.github/workflows/integration-on-schedule-minimal.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       install_profile: minimal
       cluster_region: ams3
-      kubernetes_versions: "['1.22', '1.23']"
+      kubernetes_versions: "['1.23']"


### PR DESCRIPTION
e.
