### PR TITLE
fix: do not redeploy drone on secret.yaml change

### DIFF
--- a/charts/drone/templates/deployment-agent.yaml
+++ b/charts/drone/templates/deployment-agent.yaml
@@ -19,7 +19,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- with .Values.agent.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/drone/templates/deployment-server.yaml
+++ b/charts/drone/templates/deployment-server.yaml
@@ -21,7 +21,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.metrics.prometheus.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"


### PR DESCRIPTION
fixes #950

This PR removes annotations that may cause drone pipeline not being able to finalise the deployment job due to self-update deadlock.

Before Otomi upgrade, an operator needs to remove deprecated annotations from drone server and agent deployments. 

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
