### PR TITLE
chore(release): 0.16.20

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 !^/charts/team-ns/*.{yaml | md}
 /helmfile*/
 *.sh
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.16.20](https://github.com/redkubes/otomi-core/compare/v0.16.19...v0.16.20) (2022-12-05)
+
+
+### Features
+
+* add a flag to disable monitoring stack for a specific team ([#946](https://github.com/redkubes/otomi-core/issues/946)) ([550295e](https://github.com/redkubes/otomi-core/commit/550295ec3f383057bd3b3adbbc7094bb0ed4c55c))
+* add Jaeger to shared apps and ensure Keycloak in not a shared app([#944](https://github.com/redkubes/otomi-core/issues/944)) ([ebccd43](https://github.com/redkubes/otomi-core/commit/ebccd4315930c42fb1bfee382eff69db8dc58704))
+* add minio ap  ([#957](https://github.com/redkubes/otomi-core/issues/957)) ([ec5322e](https://github.com/redkubes/otomi-core/commit/ec5322e6d75416bec9624419b3138a142ce2ec7b))
+* less promiscuous validate-template output ([#955](https://github.com/redkubes/otomi-core/issues/955)) ([9d96a00](https://github.com/redkubes/otomi-core/commit/9d96a0022b3ac0a5180ed6cca04c6c61d6fa9a18))
+* prometheus remote write ([#959](https://github.com/redkubes/otomi-core/issues/959)) ([3f81389](https://github.com/redkubes/otomi-core/commit/3f81389ffe78f8dc41f3ea60530e82901335f3b3))
+
+
+### Bug Fixes
+
+* do not enable gatekeeper when otomi.nodeSelector is empty ([#958](https://github.com/redkubes/otomi-core/issues/958)) ([bfe5287](https://github.com/redkubes/otomi-core/commit/bfe5287182f4a8998fa1bcec5006ba05ab716133))
+* do not redeploy drone on secret.yaml change ([19126dc](https://github.com/redkubes/otomi-core/commit/19126dc503d32b6568d3d322e90ad4052a32bcee)), closes [#950](https://github.com/redkubes/otomi-core/issues/950)
+* migrate values shall preserve teamConfig property ([#949](https://github.com/redkubes/otomi-core/issues/949)) ([2ea76fb](https://github.com/redkubes/otomi-core/commit/2ea76fbd75ec3666d2fa1d068132fe74b55ed1bf))
+* prometheus resources ([#956](https://github.com/redkubes/otomi-core/issues/956)) ([ca862d2](https://github.com/redkubes/otomi-core/commit/ca862d2ae17455703697236cf15b9018a808686c))
+
+
+### Tests
+
+* add minio to test scenario [ci skip] ([#961](https://github.com/redkubes/otomi-core/issues/961)) ([8ac6a21](https://github.com/redkubes/otomi-core/commit/8ac6a21f69f5c4f6d021330f5d2c4d25dda62b17))
+* digital ocean does not support k8s 1.22 anymore [ci skip] ([#951](https://github.com/redkubes/otomi-core/issues/951)) ([2372722](https://github.com/redkubes/otomi-core/commit/237272258035f95870661c597d8ae7d9725d9192))
+* workflows select image registry [ci skip] ([#948](https://github.com/redkubes/otomi-core/issues/948)) ([b780e5c](https://github.com/redkubes/otomi-core/commit/b780e5c43db6d8b04ac6b243aa7f75e77ef9b939))
+
+
+### Others
+
+* versions ([13f64af](https://github.com/redkubes/otomi-core/commit/13f64af3feeb9bf30506ca81fd66e26e1a692adb))
+
 ### [0.16.19](https://github.com/redkubes/otomi-core/compare/v0.16.18...v0.16.19) (2022-11-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 * add a flag to disable monitoring stack for a specific team ([#946](https://github.com/redkubes/otomi-core/issues/946)) ([550295e](https://github.com/redkubes/otomi-core/commit/550295ec3f383057bd3b3adbbc7094bb0ed4c55c))
-* add Jaeger to shared apps and ensure Keycloak in not a shared app([#944](https://github.com/redkubes/otomi-core/issues/944)) ([ebccd43](https://github.com/redkubes/otomi-core/commit/ebccd4315930c42fb1bfee382eff69db8dc58704))
-* add minio ap  ([#957](https://github.com/redkubes/otomi-core/issues/957)) ([ec5322e](https://github.com/redkubes/otomi-core/commit/ec5322e6d75416bec9624419b3138a142ce2ec7b))
-* less promiscuous validate-template output ([#955](https://github.com/redkubes/otomi-core/issues/955)) ([9d96a00](https://github.com/redkubes/otomi-core/commit/9d96a0022b3ac0a5180ed6cca04c6c61d6fa9a18))
-* prometheus remote write ([#959](https://github.com/redkubes/otomi-core/issues/959)) ([3f81389](https://github.com/redkubes/otomi-core/commit/3f81389ffe78f8dc41f3ea60530e82901335f3b3))
-* new code editor based on Monaco (otomi-console)
+* add Jaeger to shared apps ([#944](https://github.com/redkubes/otomi-core/issues/944)) ([ebccd43](https://github.com/redkubes/otomi-core/commit/ebccd4315930c42fb1bfee382eff69db8dc58704))
+* remove Keycloak from shared apps ([#944](https://github.com/redkubes/otomi-core/issues/944)) ([ebccd43](https://github.com/redkubes/otomi-core/commit/ebccd4315930c42fb1bfee382eff69db8dc58704))
+* add minio core app ([#957](https://github.com/redkubes/otomi-core/issues/957)) ([ec5322e](https://github.com/redkubes/otomi-core/commit/ec5322e6d75416bec9624419b3138a142ce2ec7b))
+* less promiscuous otomi validate-template output ([#955](https://github.com/redkubes/otomi-core/issues/955)) ([9d96a00](https://github.com/redkubes/otomi-core/commit/9d96a0022b3ac0a5180ed6cca04c6c61d6fa9a18))
+* allow to define prometheus remote write ([#959](https://github.com/redkubes/otomi-core/issues/959)) ([3f81389](https://github.com/redkubes/otomi-core/commit/3f81389ffe78f8dc41f3ea60530e82901335f3b3))
+* introduce new code editor based on Monaco (otomi-console)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. See [standa
 * add minio ap  ([#957](https://github.com/redkubes/otomi-core/issues/957)) ([ec5322e](https://github.com/redkubes/otomi-core/commit/ec5322e6d75416bec9624419b3138a142ce2ec7b))
 * less promiscuous validate-template output ([#955](https://github.com/redkubes/otomi-core/issues/955)) ([9d96a00](https://github.com/redkubes/otomi-core/commit/9d96a0022b3ac0a5180ed6cca04c6c61d6fa9a18))
 * prometheus remote write ([#959](https://github.com/redkubes/otomi-core/issues/959)) ([3f81389](https://github.com/redkubes/otomi-core/commit/3f81389ffe78f8dc41f3ea60530e82901335f3b3))
+* new code editor based on Monaco (otomi-console)
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otomi-core",
-  "version": "0.16.19",
+  "version": "0.16.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "otomi-core",
-      "version": "0.16.19",
+      "version": "0.16.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -157,5 +157,5 @@
     }
   },
   "type": "commonjs",
-  "version": "0.16.19"
+  "version": "0.16.20"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.17
+api: 0.5.18-rc1
 console: 0.5.20
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
-console: main
+api: 0.5.17
+console: 0.5.20
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.18-rc1
+api: 0.5.18
 console: 0.5.20
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
