### PR TITLE
fix: generating drone pipeline file

### DIFF
--- a/charts/drone/templates/deployment-agent.yaml
+++ b/charts/drone/templates/deployment-agent.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- with .Values.agent.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/drone/templates/deployment-server.yaml
+++ b/charts/drone/templates/deployment-server.yaml
@@ -21,6 +21,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.metrics.prometheus.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"

--- a/charts/drone/templates/deployment-server.yaml
+++ b/charts/drone/templates/deployment-server.yaml
@@ -34,6 +34,8 @@ spec:
         release: "{{ .Release.Name }}"
         component: server
     spec:
+      strategy:
+        type: {{ .Values.server.strategyType }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -63,7 +63,7 @@ export const bootstrapSops = async (
 
   const exists = await deps.pathExists(targetPath)
   // we can just get the values the first time because those are unencrypted
-  const values = exists ? {} : ((await deps.hfValues()) as Record<string, any>)
+  const values = exists ? {} : ((await deps.hfValues(undefined, envDir)) as Record<string, any>)
 
   d.log(`Creating sops file for provider ${provider}`)
   const output = (await deps.gucci(templatePath, obj, true)) as string

--- a/src/cmd/gen-drone.ts
+++ b/src/cmd/gen-drone.ts
@@ -71,7 +71,7 @@ export const genDrone = async (envDir?: string): Promise<void> => {
   const owner = allValues.cluster?.owner
   const cloudProvider = allValues.cluster?.provider
   const globalPullSecret = allValues.otomi?.globalPullSecret
-  const imageTag = await getImageTag()
+  const imageTag = await getImageTag(envDir)
   const pullPolicy = imageTag.startsWith('v') ? 'if-not-exists' : 'always'
   const requestsCpu = allValues.apps.drone.resources?.runner?.requests?.cpu
   const requestsMem = allValues.apps.drone.resources?.runner?.requests?.memory

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -41,10 +41,10 @@ export const getK8sVersion = async (argv?: HelmArguments): Promise<string> => {
  * Find what image tag is defined in configuration for otomi
  * @returns string
  */
-export const getImageTag = async (): Promise<string> => {
+export const getImageTag = async (envDir = env.ENV_DIR): Promise<string> => {
   if (process.env.OTOMI_TAG) return process.env.OTOMI_TAG
-  if (await pathExists(`${env.ENV_DIR}/env/cluster.yaml`)) {
-    const values = await hfValues()
+  if (await pathExists(`${envDir}/env/cluster.yaml`)) {
+    const values = await hfValues(undefined, envDir)
     return values!.otomi!.version
   }
   return `v${pkg.version}`

--- a/values/drone/drone.gotmpl
+++ b/values/drone/drone.gotmpl
@@ -63,7 +63,7 @@ server:
     {{- end }}
     DRONE_WEBHOOK_ENDPOINT: http://otomi-api.otomi/drone
     DRONE_WEBHOOK_SECRET: {{ $d | get "sharedSecret" }}
-
+  strategyType: Recreate
 agent:
   annotations:
     policy.otomi.io/ignore: psp-allowed-users,psp-privileged,psp-host-filesystem,banned-image-tags

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.18
-console: 0.5.20
+api: main
+console: main
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
