### PR TITLE
fix: drone update strategy in wrong spec context

### DIFF
--- a/charts/drone/templates/deployment-server.yaml
+++ b/charts/drone/templates/deployment-server.yaml
@@ -17,6 +17,8 @@ spec:
       app: {{ template "drone.name" . }}
       release: "{{ .Release.Name }}"
       component: server
+  strategy:
+    type: {{ .Values.server.strategyType }}
   replicas: 1
   template:
     metadata:
@@ -34,8 +36,6 @@ spec:
         release: "{{ .Release.Name }}"
         component: server
     spec:
-      strategy:
-        type: {{ .Values.server.strategyType }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
