### PR TITLE
fix: get files for encryption / decryption 

### DIFF
--- a/src/common/crypt.test.ts
+++ b/src/common/crypt.test.ts
@@ -3,32 +3,33 @@ import * as crypt from './crypt'
 describe('Crypt', () => {
   it('Should provied correct list of files to be encrypted', () => {
     const allFileNames = [
-      'secrets.a.yaml',
-      'secrets.a.yaml.dec',
-      'secrets.b.yaml.dec',
-      'secrets.c.yaml',
-      'x/y/secrets.z.yaml.dec',
-      'a.yaml',
-      'b.yaml',
-      'd.yaml',
+      'env/secrets.a.yaml',
+      'env/secrets.a.yaml.dec',
+      'env/secrets.b.yaml.dec',
+      'env/secrets.c.yaml',
+      'env/x/y/secrets.z.yaml.dec',
+      'env/teams/external-secrets.admin.yaml',
+      'env/a.yaml',
+      'env/b.yaml',
+      'env/d.yaml',
     ]
     const r = crypt.getAllSecretFiles(allFileNames, true, '.dec')
     expect(r.sort()).toEqual(
-      ['secrets.a.yaml.dec', 'secrets.b.yaml.dec', 'secrets.c.yaml', 'x/y/secrets.z.yaml.dec'].sort(),
+      ['env/secrets.a.yaml.dec', 'env/secrets.b.yaml.dec', 'env/secrets.c.yaml', 'env/x/y/secrets.z.yaml.dec'].sort(),
     )
   })
   it('should be flattened', () => {
     const allFileNames = [
-      'secrets.a.yaml',
-      'secrets.a.yaml.dec',
-      'secrets.b.yaml.dec',
-      'secrets.c.yaml',
-      'x/y/secrets.z.yaml',
-      'a.yaml',
-      'b.yaml',
-      'd.yaml',
+      'env/secrets.a.yaml',
+      'env/secrets.a.yaml.dec',
+      'env/secrets.b.yaml.dec',
+      'env/secrets.c.yaml',
+      'env/x/y/secrets.z.yaml',
+      'env/a.yaml',
+      'env/b.yaml',
+      'secrets.d.yaml',
     ]
     const r = crypt.getAllSecretFiles(allFileNames, false, '.dec')
-    expect(r.sort()).toEqual(['secrets.a.yaml', 'secrets.c.yaml', 'x/y/secrets.z.yaml'].sort())
+    expect(r.sort()).toEqual(['env/secrets.a.yaml', 'env/secrets.c.yaml', 'env/x/y/secrets.z.yaml'].sort())
   })
 })

--- a/src/common/crypt.test.ts
+++ b/src/common/crypt.test.ts
@@ -1,0 +1,30 @@
+import * as crypt from './crypt'
+
+describe('Crypt', () => {
+  it('Should provied correct list of files to be encrypted', () => {
+    const allFileNames = [
+      'secrets.a.yaml',
+      'secrets.a.yaml.dec',
+      'secrets.b.yaml.dec',
+      'secrets.c.yaml',
+      'a.yaml',
+      'b.yaml',
+      'd.yaml',
+    ]
+    const r = crypt.getAllSecretFiles(allFileNames, true, '.dec')
+    expect(r.sort()).toEqual(['secrets.a.yaml.dec', 'secrets.b.yaml.dec', 'secrets.c.yaml'].sort())
+  })
+  it('should be flattened', () => {
+    const allFileNames = [
+      'secrets.a.yaml',
+      'secrets.a.yaml.dec',
+      'secrets.b.yaml.dec',
+      'secrets.c.yaml',
+      'a.yaml',
+      'b.yaml',
+      'd.yaml',
+    ]
+    const r = crypt.getAllSecretFiles(allFileNames, false, '.dec')
+    expect(r.sort()).toEqual(['secrets.a.yaml', 'secrets.c.yaml'].sort())
+  })
+})

--- a/src/common/crypt.test.ts
+++ b/src/common/crypt.test.ts
@@ -7,12 +7,15 @@ describe('Crypt', () => {
       'secrets.a.yaml.dec',
       'secrets.b.yaml.dec',
       'secrets.c.yaml',
+      'x/y/secrets.z.yaml.dec',
       'a.yaml',
       'b.yaml',
       'd.yaml',
     ]
     const r = crypt.getAllSecretFiles(allFileNames, true, '.dec')
-    expect(r.sort()).toEqual(['secrets.a.yaml.dec', 'secrets.b.yaml.dec', 'secrets.c.yaml'].sort())
+    expect(r.sort()).toEqual(
+      ['secrets.a.yaml.dec', 'secrets.b.yaml.dec', 'secrets.c.yaml', 'x/y/secrets.z.yaml.dec'].sort(),
+    )
   })
   it('should be flattened', () => {
     const allFileNames = [
@@ -20,11 +23,12 @@ describe('Crypt', () => {
       'secrets.a.yaml.dec',
       'secrets.b.yaml.dec',
       'secrets.c.yaml',
+      'x/y/secrets.z.yaml',
       'a.yaml',
       'b.yaml',
       'd.yaml',
     ]
     const r = crypt.getAllSecretFiles(allFileNames, false, '.dec')
-    expect(r.sort()).toEqual(['secrets.a.yaml', 'secrets.c.yaml'].sort())
+    expect(r.sort()).toEqual(['secrets.a.yaml', 'secrets.c.yaml', 'x/y/secrets.z.yaml'].sort())
   })
 })

--- a/src/common/crypt.ts
+++ b/src/common/crypt.ts
@@ -40,7 +40,7 @@ const preCrypt = async (path): Promise<void> => {
   }
 }
 
-export const getAllSecretFiles = (fileNames: Array<string>, encryption: boolean, suffix: string) => {
+export const getAllSecretFiles = (relativePaths: Array<string>, encryption: boolean, suffix: string) => {
   /** Use cases
    * 1. encryption for the first time when .dec does not exists
    * 2. encryption after bootstraping files, so they also do not have .dec
@@ -50,14 +50,14 @@ export const getAllSecretFiles = (fileNames: Array<string>, encryption: boolean,
 
   const d = terminal(`common:crypt:getAllSecretFiles`)
   let filteredFiles: Array<string> = []
-  const encryptedFiles = fileNames.filter((file) => file.endsWith(`.yaml`) && file.startsWith('secrets.'))
+  const encryptedFiles = relativePaths.filter((file) => file.endsWith(`.yaml`) && file.includes('secrets.'))
 
   if (encryption) {
-    const decryptedFiles = fileNames.filter((file) => file.endsWith(suffix) && file.startsWith('secrets.'))
+    const decryptedFiles = relativePaths.filter((file) => file.endsWith(suffix) && file.includes('secrets.'))
 
     filteredFiles = encryptedFiles.map((file) => {
       // If a secret.*.yaml.dec does not exists then return secret.*.yaml
-      if (fileNames.includes(`${file}${suffix}`)) return `${file}${suffix}`
+      if (relativePaths.includes(`${file}${suffix}`)) return `${file}${suffix}`
       return file
     })
     filteredFiles = filteredFiles.concat(decryptedFiles)
@@ -112,8 +112,8 @@ const runOnSecretFiles = async (path: string, crypt: CR, filesArgs: string[] = [
 
   if (files.length === 0) {
     const allFiles = await readdirRecurse(`${path}/env`, { skipHidden: true })
-    const allFileNames = allFiles.map((file) => file.replace(`${path}/`, ''))
-    files = getAllSecretFiles(allFileNames, encryption, suffix)
+    const allRelativePaths = allFiles.map((file) => file.replace(`${path}/`, ''))
+    files = getAllSecretFiles(allRelativePaths, encryption, suffix)
   }
 
   files = files.filter(async (f) => {

--- a/src/common/crypt.ts
+++ b/src/common/crypt.ts
@@ -50,10 +50,10 @@ export const getAllSecretFiles = (relativePaths: Array<string>, encryption: bool
 
   const d = terminal(`common:crypt:getAllSecretFiles`)
   let filteredFiles: Array<string> = []
-  const encryptedFiles = relativePaths.filter((file) => file.endsWith(`.yaml`) && file.includes('secrets.'))
+  const encryptedFiles = relativePaths.filter((file) => file.endsWith(`.yaml`) && file.includes('/secrets.'))
 
   if (encryption) {
-    const decryptedFiles = relativePaths.filter((file) => file.endsWith(suffix) && file.includes('secrets.'))
+    const decryptedFiles = relativePaths.filter((file) => file.endsWith(suffix) && file.includes('/secrets.'))
 
     filteredFiles = encryptedFiles.map((file) => {
       // If a secret.*.yaml.dec does not exists then return secret.*.yaml
@@ -115,7 +115,6 @@ const runOnSecretFiles = async (path: string, crypt: CR, filesArgs: string[] = [
     const allRelativePaths = allFiles.map((file) => file.replace(`${path}/`, ''))
     files = getAllSecretFiles(allRelativePaths, encryption, suffix)
   }
-
   files = files.filter(async (f) => {
     const content = await readFile(f, 'utf-8')
     return !!content


### PR DESCRIPTION
fixes #975

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
