### PR TITLE
feat: split templated manifests into files

### DIFF
--- a/tests/manifests/.gitignore
+++ b/tests/manifests/.gitignore
@@ -1,0 +1,1 @@
+all.yaml

--- a/tests/manifests/Readme.md
+++ b/tests/manifests/Readme.md
@@ -1,0 +1,55 @@
+# slice.sh
+
+The slice.sh script generate all manifests using otomi template and then slice into many files
+
+Run from root of the project
+
+```
+./tests/manifests/slice.sh ./out1
+```
+
+Example output
+
+```
+...
+Creating out5/external-dns/templates/servicemonitor.yaml
+Creating out5/jobs/templates/secret.yaml
+Creating out5/jobs/templates/configmap.yaml
+Creating out5/jobs/templates/job.yaml
+Creating out5/wait-for/templates/serviceaccount.yaml
+Creating out5/wait-for/templates/job.yaml
+Creating out5/hello/templates/serviceaccount.yaml
+Creating out5/hello/templates/service.yaml
+Creating out5/hello/templates/deployment.yaml
+Creating out5/httpbin/templates/service.yaml
+Creating out5/httpbin/templates/deployment.yaml
+Creating out5/kubeapps/templates/apprepository/serviceaccount.yaml
+Creating out5/kubeapps/templates/kubeappsapis/serviceaccount.yaml
+Creating out5/kubeapps/templates/kubeops/serviceaccount.yaml
+Creating out5/kubeapps/charts/postgresql/templates/secrets.yaml
+Creating out5/kubeapps/templates/dashboard/configmap.yaml
+Creating out5/kubeapps/templates/frontend/configmap.yaml
+Creating out5/kubeapps/templates/kubeappsapis/configmap.yaml
+Creating out5/kubeapps/templates/shared/config.yaml
+Creating out5/kubeapps/templates/apprepository/rbac.yaml
+Creating out5/kubeapps/templates/kubeops/rbac.yaml
+Creating out5/kubeapps/charts/postgresql/templates/metrics-svc.yaml
+...
+```
+
+# Comparing outputs
+
+It is possible to perform reqursive diff
+
+```
+diff -qr out1/ out2/
+```
+
+Example output
+
+```
+Files out5/grafana-dashboards/templates/dashboards-json-configmap.yaml and out4/grafana-dashboards/templates/dashboards-json-configmap.yaml differ
+Files out5/harbor/templates/registry/registry-dpl.yaml and out4/harbor/templates/registry/registry-dpl.yaml differ
+Files out5/harbor/templates/registry/registry-secret.yaml and out4/harbor/templates/registry/registry-secret.yaml differ
+Files out5/jobs/templates/job.yaml and out4/jobs/templates/job.yaml differ
+```

--- a/tests/manifests/slice.sh
+++ b/tests/manifests/slice.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Based on https://github.com/helm/helm/issues/4680#issuecomment-613201032
+#
+
+set -eu
+
+if [ -z "${1:-}" ]; then
+  echo "Please provide an output directory"
+  exit 1
+fi
+
+scriptDir="$(dirname -- "$0")"
+manifestsPath="$scriptDir/all.yaml"
+otomi template >"$manifestsPath"
+
+awk -vout="$1" -F": " '
+  $0~/^# Source: / {
+    gsub("\r","",$2)
+    file=out"/"$2;
+    if (!(file in filemap)) {
+      filemap[file] = 1
+      print "Creating "file;
+      system ("mkdir -p $(dirname "file")");
+      print "---" >> file;
+    }
+  }
+  $0!~/^# Source: / {
+    if ($0!~/^---$/) {
+      if (file) {
+        print $0 >> file;
+      }
+    }
+  }' <"$manifestsPath"


### PR DESCRIPTION
Inspired by content of the thread https://github.com/helm/helm/issues/4680

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
