### PR TITLE
fix: upgrade only relevant versions

### DIFF
--- a/src/cmd/upgrade.test.ts
+++ b/src/cmd/upgrade.test.ts
@@ -1,0 +1,16 @@
+import * as upgrade from './upgrade'
+
+describe('semverCompare', () => {
+  it('should indicate version to be higher', () => {
+    const inputData = [
+      { version: '0.1.1' },
+      { version: '1.1.2' },
+      { version: '1.1.4' },
+      { version: '2.1.1' },
+      { version: 'dev' },
+    ]
+    const expectedData = [{ version: '1.1.4' }, { version: '2.1.1' }, { version: 'dev' }]
+
+    expect(upgrade.filterUpgrades('1.1.3', inputData)).toEqual(expectedData)
+  })
+})

--- a/src/cmd/upgrade.test.ts
+++ b/src/cmd/upgrade.test.ts
@@ -1,7 +1,7 @@
 import * as upgrade from './upgrade'
 
-describe('semverCompare', () => {
-  it('should indicate version to be higher', () => {
+describe('filterUpgrades', () => {
+  it('should filter out lower versions', () => {
     const inputData = [
       { version: '0.1.1' },
       { version: '1.1.2' },

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -37,7 +37,7 @@ export type Upgrades = Array<Upgrade>
 
 // select upgrades after semver version, and always select upgrade with version "dev" for dev purposes
 function filterUpgrades(version: string, upgrades: Upgrades): Upgrades {
-  return upgrades.filter((c) => c.version === 'dev' || semverCompare(version, c.version))
+  return upgrades.filter((c) => c.version === 'dev' || semverCompare(version, c.version) === 1)
 }
 
 async function execute(d: typeof console, dryRun: boolean, operations: string[], values: Record<string, any>) {

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -36,8 +36,8 @@ interface Upgrade {
 export type Upgrades = Array<Upgrade>
 
 // select upgrades after semver version, and always select upgrade with version "dev" for dev purposes
-function filterUpgrades(version: string, upgrades: Upgrades): Upgrades {
-  return upgrades.filter((c) => c.version === 'dev' || semverCompare(version, c.version) === 1)
+export function filterUpgrades(version: string, upgrades: Upgrades): Upgrades {
+  return upgrades.filter((c) => c.version === 'dev' || semverCompare(version, c.version) === -1)
 }
 
 async function execute(d: typeof console, dryRun: boolean, operations: string[], values: Record<string, any>) {

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -22,3 +22,15 @@ describe('Flatten objects', () => {
     expect(flattened).toEqual(expectingFlattenedObject)
   })
 })
+
+describe('semverCompare', () => {
+  it('should indicate version to be higher', () => {
+    expect(utils.semverCompare('1.1.3', '0.1.1')).toEqual(1)
+  })
+  it('should indicate version to be equal', () => {
+    expect(utils.semverCompare('0.1.1', '0.1.1')).toEqual(0)
+  })
+  it('should indicate version to be lower', () => {
+    expect(utils.semverCompare('0.1.1', '1.1.3')).toEqual(-1)
+  })
+})


### PR DESCRIPTION
I noticed that all upgrade scripts are applied always during the apply step.

This PR fixes filtering out the not relevant upgrade versions.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
