### PR TITLE
fix: encrypt brand new secrets files

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -39,10 +39,13 @@ app.get('/prepare', async (req: Request, res: Response) => {
   const { envDir } = req.query as QueryParams
   try {
     d.log('Request to prepare values repo')
+    await bootstrapSops(envDir)
+    // Encrypt ensures that a brand new secret file is encrypted
+    await encrypt(envDir)
+    // Decrypt ensures that a brand new secret file is decrypted to .dec file, so the validateValues can tak it into account
+    await decrypt(envDir)
     await validateValues(envDir)
     await genDrone(envDir)
-    await bootstrapSops(envDir)
-    await encrypt(envDir)
     res.status(200).send('ok')
   } catch (error) {
     const err = `${error}`

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,9 +40,9 @@ app.get('/prepare', async (req: Request, res: Response) => {
   try {
     d.log('Request to prepare values repo')
     await bootstrapSops(envDir)
-    // Encrypt ensures that a brand new secret file is encrypted
+    // Encrypt ensures that a brand new secret file is encrypted in place
     await encrypt(envDir)
-    // Decrypt ensures that a brand new secret file is decrypted to .dec file, so the validateValues can tak it into account
+    // Decrypt ensures that a brand new encrypted secret file is decrypted to the .dec file
     await decrypt(envDir)
     await validateValues(envDir)
     await genDrone(envDir)

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
+api: encrypt-new-secret-files
 console: main
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
fixes #975

depends-on https://github.com/redkubes/otomi-api/pull/355

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
