### PR TITLE
fix: do not enable external-secrets by default

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -37,7 +37,7 @@ environments:
           external-dns:
             logLevel: info
           external-secrets:
-            enabled: true
+            enabled: false
             logLevel: info
             pollingInterval: 60000
           gatekeeper:


### PR DESCRIPTION
We noticed that the external-secrets is installed by default, which is not inline with our design.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
