### PR TITLE
fix: harbor schema

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1743,8 +1743,16 @@ properties:
                 default: 0 0 * * *
                 description: Cron-type expression to schedule the backup. Defaults to once a day at 00:00.
                 type: string
-        required:
-          - databasePassword
+        allOf:
+          - anyOf:
+              - not:
+                  properties:
+                    enabled:
+                      const: true
+                  required:
+                    - enabled
+              - required:
+                  - databasePassword
       hello:
         description: Hello world demo chart. When you turn this off you may also have to remove the ingress service.
         properties:
@@ -3155,5 +3163,6 @@ properties:
   version:
     type: integer
     description: DO NOT CHANGE! Holds the values-schema version. For more details, see `otomi migrate`.
+    x-secret: 'print "5"'
 required:
   - cluster

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: encrypt-new-secret-files
+api: main
 console: main
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
Harbor was requiring `databasePassword`, which is only the case when it is enabled. This PR fixes that.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
