### PR TITLE
fix: external-secrets migration script

### DIFF
--- a/upgrades.yaml
+++ b/upgrades.yaml
@@ -44,7 +44,7 @@ operations:
             kubectl -n "team-$id" annotate podmonitor/$p --overwrite "meta.helm.sh/release-name"=team-ns-$id
           done
         done
-  - version: dev
+  - version: 0.18.0
     post:
       # convert secrets to new format and apply
       - vendor/kes-to-eso/migrate-post.sh && echo "Success"

--- a/upgrades.yaml
+++ b/upgrades.yaml
@@ -47,4 +47,4 @@ operations:
   - version: 0.18.0
     post:
       # convert secrets to new format and apply
-      - vendor/kes-to-eso/migrate-post.sh && echo "Success"
+      - vendor/kes-to-eso/migrate-post.sh && true

--- a/vendor/kes-to-eso/migrate-post.sh
+++ b/vendor/kes-to-eso/migrate-post.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-set -e
+set -ex
 KES_NAMESPACE="vault"
 
 scriptDir="$(dirname -- "$0")"
 
 echo "Upgrade from KES to ESO"
-[[ $(helm status -n external-secrets external-secrets) && ! $(helm status -n vault external-secrets) ]] && echo "Skipping" && exit 0
+[[ ! $(helm status -n external-secrets external-secrets) ]] && echo "The external-secrets release does not exists. Skipping" && exit 0
+[[ ! $(helm status -n vault external-secrets) ]] && echo "The external-secrets has been already migrated. Skipping" && exit 0
 
 echo "Scaling down KES"
 kubectl scale deployment -n $KES_NAMESPACE external-secrets --replicas=0

--- a/vendor/kes-to-eso/migrate-post.sh
+++ b/vendor/kes-to-eso/migrate-post.sh
@@ -7,7 +7,7 @@ scriptDir="$(dirname -- "$0")"
 
 echo "Upgrade from KES to ESO"
 [[ ! $(helm status -n external-secrets external-secrets) ]] && echo "The external-secrets release does not exists. Skipping" && exit 0
-[[ ! $(helm status -n vault external-secrets) ]] && echo "The external-secrets has been already migrated. Skipping" && exit 0
+[[ ! $(helm status -n vault external-secrets) ]] && echo "The external-secrets release has already been migrated. Skipping" && exit 0
 
 echo "Scaling down KES"
 kubectl scale deployment -n $KES_NAMESPACE external-secrets --replicas=0

--- a/vendor/kes-to-eso/migrate-post.sh
+++ b/vendor/kes-to-eso/migrate-post.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 KES_NAMESPACE="vault"
 
 scriptDir="$(dirname -- "$0")"


### PR DESCRIPTION
I improved upgrade script so it does not kickoff if the external-secrets release is not present.
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
