### PR TITLE
fix: certmanager secrets

### DIFF
--- a/chart/otomi/values.yaml
+++ b/chart/otomi/values.yaml
@@ -67,15 +67,17 @@ otomi: {}
 #   domainFilters: []
 #   zoneIdFilters: []
 #   provider:
-#     # provide one of the following below: aws|azure|google
+#     # choose your DNS provider: aws|azure|google|digitalocean|cloudflare|other
 #     aws:
-#       # next two keys are optional for explicit access with an iam role
+#       # credentials are optional for explicit access with an iam role
 #       # (if no metadata exists with implicit role access to manage dns)
-#       accessKeySecret: ''
-#       secretAccessKey: ''
+#       credentials:
+#         secretKey: '' 
+#         accessKey: ''
 #       # region is always needed
 #       region: eu-central-1
-#       role: '' # optional ARN, may be set explicitly if no metadata can be accessed
+#       # optional ARN, may be set explicitly if no metadata can be accessed
+#       role: '' 
 #     azure:
 #       aadClientId: ''
 #       aadClientSecret: ''
@@ -84,6 +86,11 @@ otomi: {}
 #     google:
 #       serviceAccountKey: ''
 #       project: ''
+#     digitalocean:
+#       apiToken: ''
+#       apiSecret: ''
+#       email: ''
+#       proxied: # true|false (default is true)
 # KMS for encrypting values
 # kms:
 #   sops:

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -9,8 +9,9 @@ azure:
         clientSecret: somesecretvalue
 dns:
     provider:
-        azure-private-dns:
-            aadClientSecret: 00-aadClientSecret
+        aws:
+            credentials:
+                secretKey: DuJ/T6fFYMysjRUxxxxxxxxxxxxxxxxx
 home:
     email:
         critical: admins@yourdoma.in

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -24,11 +24,16 @@ dns:
     domainFilters:
         - otomi.cloud
     provider:
-        azure-private-dns:
-            aadClientId: 00-aadClientId
-            resourceGroup: external-dns
-            subscriptionId: 00-subscriptionId
-            tenantId: 00-tenantId
+        aws:
+            credentials:
+                accessKey: AAAAAAAAAAAAAAAAA
+            region: eu-central-1
+
+        # azure-private-dns:
+        #     aadClientId: 00-aadClientId
+        #     resourceGroup: external-dns
+        #     subscriptionId: 00-subscriptionId
+        #     tenantId: 00-tenantId
     zoneIdFilters:
         - otomi
 home:

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -20,11 +20,11 @@ resources:
       secret: "{{ $p | get "azure-private-dns.aadClientSecret" | b64enc }}"
       {{- else if or (hasKey $p "azure") }}
       secret: "{{ $p.azure.aadClientSecret | b64enc }}"
-      {{- else if ($p | get "$p.aws.credentials.secretKey" nil) }}
+      {{- else if or (hasKey $p "aws") }}
       secret: "{{ $p.aws.credentials.secretKey | b64enc }}"
-      {{- else if hasKey $p "digitalocean" }}
+      {{- else if or (hasKey $p "digitalocean") }}
       secret: "{{ $p.digitalocean.apiToken | b64enc }}"
-      {{- else if hasKey $p "cloudflare" }}
+      {{- else if or (hasKey $p "cloudflare") }}
       secret: "{{ $p.cloudflare.apiToken | b64enc }}"
       {{- end }}
 {{- end }}


### PR DESCRIPTION
fixes logic to create external-dns secret for non Azure providers
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
