### PR TITLE
fix: do not upgrade on very first install

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,20 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug playground",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/.bin/ts-node",
+      "runtimeArgs": ["--nolazy"],
+      "args": ["src/playground.ts"],
+      "envFile": ".env",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"],
+      "resolveSourceMapLocations": ["${workspaceFolder}/src/**"]
+    },
+    {
       "type": "node",
       "request": "attach",
       "name": "Attach to current script",

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -35,7 +35,7 @@ const applyAll = async () => {
   const argv: HelmArguments = getParsedArgs()
   const prevState = await getDeploymentState()
 
-  if (prevState) await upgrade({ when: 'pre' })
+  if (!isEmpty(prevState)) await upgrade({ when: 'pre' })
   d.info('Start apply all')
   d.debug(`Deployment state: ${JSON.stringify(prevState)}`)
   const tag = await getImageTag()
@@ -78,7 +78,7 @@ const applyAll = async () => {
     },
     { streams: { stdout: d.stream.log, stderr: d.stream.error } },
   )
-  if (prevState) await upgrade({ when: 'post' })
+  if (!isEmpty(prevState)) await upgrade({ when: 'post' })
   if (!(env.isDev && env.DISABLE_SYNC))
     if (!isCli || isEmpty(prevState.status))
       // commit first time when not deployed only, always commit in chart (might have previous failure)

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -35,7 +35,7 @@ const applyAll = async () => {
   const argv: HelmArguments = getParsedArgs()
   const prevState = await getDeploymentState()
 
-  if (!isEmpty(prevState)) await upgrade({ when: 'pre' })
+  await upgrade({ when: 'pre' })
   d.info('Start apply all')
   d.debug(`Deployment state: ${JSON.stringify(prevState)}`)
   const tag = await getImageTag()
@@ -78,7 +78,7 @@ const applyAll = async () => {
     },
     { streams: { stdout: d.stream.log, stderr: d.stream.error } },
   )
-  if (!isEmpty(prevState)) await upgrade({ when: 'post' })
+  await upgrade({ when: 'post' })
   if (!(env.isDev && env.DISABLE_SYNC))
     if (!isCli || isEmpty(prevState.status))
       // commit first time when not deployed only, always commit in chart (might have previous failure)

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -4,7 +4,7 @@
 import { prepareEnvironment } from 'src/common/cli'
 import { hfValues } from 'src/common/hf'
 import { getDeploymentState, setDeploymentState } from 'src/common/k8s'
-import { getFilename, guccify, loadYaml, rootDir, semverCompare } from 'src/common/utils'
+import { getFilename, guccify, loadYaml, pkg, rootDir, semverCompare } from 'src/common/utils'
 import { getCurrentVersion } from 'src/common/values'
 import { BasicArguments, setParsedArgs } from 'src/common/yargs'
 import { Argv } from 'yargs'
@@ -65,7 +65,7 @@ async function execute(d: typeof console, dryRun: boolean, operations: string[],
 export const upgrade = async ({ dryRun = false, release, when }: Arguments): Promise<void> => {
   const d = console // wrapped stream created by terminal(... is not showing
   const upgrades: Upgrades = (await loadYaml(`${rootDir}/upgrades.yaml`))?.operations
-  const prevVersion: string = (await getDeploymentState()).version ?? '0.1.0'
+  const prevVersion: string = (await getDeploymentState()).version ?? pkg.version
   const values = (await hfValues()) as Record<string, any>
   d.info(`Current version of otomi: ${prevVersion}`)
   const filteredUpgrades = filterUpgrades(prevVersion, upgrades)

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -4,7 +4,7 @@
 import { prepareEnvironment } from 'src/common/cli'
 import { hfValues } from 'src/common/hf'
 import { getDeploymentState, setDeploymentState } from 'src/common/k8s'
-import { getFilename, guccify, loadYaml, pkg, rootDir, semverCompare } from 'src/common/utils'
+import { getFilename, guccify, loadYaml, rootDir, semverCompare } from 'src/common/utils'
 import { getCurrentVersion } from 'src/common/values'
 import { BasicArguments, setParsedArgs } from 'src/common/yargs'
 import { Argv } from 'yargs'
@@ -65,7 +65,8 @@ async function execute(d: typeof console, dryRun: boolean, operations: string[],
 export const upgrade = async ({ dryRun = false, release, when }: Arguments): Promise<void> => {
   const d = console // wrapped stream created by terminal(... is not showing
   const upgrades: Upgrades = (await loadYaml(`${rootDir}/upgrades.yaml`))?.operations
-  const prevVersion: string = (await getDeploymentState()).version ?? pkg.version
+  const version = await getCurrentVersion()
+  const prevVersion: string = (await getDeploymentState()).version ?? version
   const values = (await hfValues()) as Record<string, any>
   d.info(`Current version of otomi: ${prevVersion}`)
   const filteredUpgrades = filterUpgrades(prevVersion, upgrades)
@@ -92,7 +93,6 @@ export const upgrade = async ({ dryRun = false, release, when }: Arguments): Pro
     }
     $.quote = q
     // set latest version deployed in configmap
-    const version = await getCurrentVersion()
     await setDeploymentState({ version })
   } else d.info('No upgrade operations detected, skipping')
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -15,7 +15,7 @@ const packagePath = process.cwd()
 
 // we keep the rootDir for zx, but have to fix it for drone, which starts in /home/app/stack/env (to accommodate write perms):
 export const rootDir = process.cwd() === '/home/app/stack/env' ? '/home/app/stack' : process.cwd()
-export const pkg = readFileSync(`${rootDir}/package.json`, 'utf8') as any
+export const pkg = JSON.parse(readFileSync(`${rootDir}/package.json`, 'utf8'))
 export const getFilename = (path: string): string => path.split('/').pop()?.split('.')[0] as string
 
 export const asArray = (args: string | string[]): string[] => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -2,19 +2,20 @@
 /* eslint-disable no-await-in-loop */
 import $RefParser, { JSONSchema } from '@apidevtools/json-schema-ref-parser'
 import cleanDeep, { CleanOptions } from 'clean-deep'
-import { existsSync, pathExists } from 'fs-extra'
+import { existsSync, pathExists, readFileSync } from 'fs-extra'
 import { readdir, readFile } from 'fs/promises'
 import walk from 'ignore-walk'
 import { dump, load } from 'js-yaml'
 import { omit } from 'lodash'
 import { resolve } from 'path'
 import { $, ProcessOutput } from 'zx'
-import * as pkg from '../../package.json'
 import { env } from './envalid'
+
 const packagePath = process.cwd()
 
 // we keep the rootDir for zx, but have to fix it for drone, which starts in /home/app/stack/env (to accommodate write perms):
 export const rootDir = process.cwd() === '/home/app/stack/env' ? '/home/app/stack' : process.cwd()
+export const pkg = readFileSync(`${rootDir}/package.json`, 'utf8') as any
 export const getFilename = (path: string): string => path.split('/').pop()?.split('.')[0] as string
 
 export const asArray = (args: string | string[]): string[] => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -2,20 +2,19 @@
 /* eslint-disable no-await-in-loop */
 import $RefParser, { JSONSchema } from '@apidevtools/json-schema-ref-parser'
 import cleanDeep, { CleanOptions } from 'clean-deep'
-import { existsSync, pathExists, readFileSync } from 'fs-extra'
+import { existsSync, pathExists } from 'fs-extra'
 import { readdir, readFile } from 'fs/promises'
 import walk from 'ignore-walk'
 import { dump, load } from 'js-yaml'
 import { omit } from 'lodash'
 import { resolve } from 'path'
 import { $, ProcessOutput } from 'zx'
+import * as pkg from '../../package.json'
 import { env } from './envalid'
-
 const packagePath = process.cwd()
 
 // we keep the rootDir for zx, but have to fix it for drone, which starts in /home/app/stack/env (to accommodate write perms):
 export const rootDir = process.cwd() === '/home/app/stack/env' ? '/home/app/stack' : process.cwd()
-export const pkg = readFileSync(`${rootDir}/package.json`, 'utf8') as any
 export const getFilename = (path: string): string => path.split('/').pop()?.split('.')[0] as string
 
 export const asArray = (args: string | string[]): string[] => {

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -3,7 +3,6 @@ import { pathExists } from 'fs-extra'
 import { unlink, writeFile } from 'fs/promises'
 import { cloneDeep, get, isEmpty, isEqual, merge, omit, pick, set } from 'lodash'
 import { stringify } from 'yaml'
-import * as pkg from '../../package.json'
 import { decrypt, encrypt } from './crypt'
 import { terminal } from './debug'
 import { env } from './envalid'
@@ -14,6 +13,7 @@ import {
   getValuesSchema,
   gucci,
   loadYaml,
+  pkg,
   removeBlankAttributes,
   stringContainsSome,
 } from './utils'

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -3,6 +3,7 @@ import { pathExists } from 'fs-extra'
 import { unlink, writeFile } from 'fs/promises'
 import { cloneDeep, get, isEmpty, isEqual, merge, omit, pick, set } from 'lodash'
 import { stringify } from 'yaml'
+import * as pkg from '../../package.json'
 import { decrypt, encrypt } from './crypt'
 import { terminal } from './debug'
 import { env } from './envalid'
@@ -13,7 +14,6 @@ import {
   getValuesSchema,
   gucci,
   loadYaml,
-  pkg,
   removeBlankAttributes,
   stringContainsSome,
 } from './utils'

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node --nolazy -r ts-node/register
+
+import { getDeploymentState } from './common/k8s'
+import { getCurrentVersion } from './common/values'
+
+async function play() {
+  const version = await getCurrentVersion()
+  const prevVersion: string = (await getDeploymentState()).version ?? version
+  console.log(version)
+}
+
+play()


### PR DESCRIPTION
This is an enhancement to the upgrade script that prevents upgrading on very first otomi installation
Moreover in case of any development branch the upgrade will get the otomi version from the package.json.

There is also a playground file that make it easy to debug a give piece of code without the need to run any otomi command.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
