### PR TITLE
fix: harbor registry htpasswd

### DIFF
--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -329,7 +329,7 @@ registry:
   credentials:
     username: {{ $h | get "registry.credentials.username" }}
     password: {{ $h | get "registry.credentials.password" $v.otomi.adminPassword }}
-    htpasswd: {{ $h | get "registry.credentials.htpasswd" nil }}
+    htpasswdString: {{ $h | get "registry.credentials.htpasswd" nil }}
 
 trivy:
   image:


### PR DESCRIPTION
fixes #1019

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
