### PR TITLE
fix: set olm target namespace

### DIFF
--- a/upgrades.yaml
+++ b/upgrades.yaml
@@ -53,5 +53,6 @@ operations:
       # replace OLM crds because helm won't upgrade them
       # The olmconfigs is a new CRD so it cannot be replaced before applying
       - |
+        [[ ! $(helm status -n olm operator-lifecycle-manager) ]] && echo "The operator-lifecycle-manager release does not exists. Skipping" && exit 0
         kubectl apply -f charts/operator-lifecycle-manager/crds/0000_50_olm_00-olmconfigs.crd.yaml
         kubectl replace -f charts/operator-lifecycle-manager/crds

--- a/values/operator-lifecycle-manager/operator-lifecycle-manager.gotmpl
+++ b/values/operator-lifecycle-manager/operator-lifecycle-manager.gotmpl
@@ -1,6 +1,13 @@
 # operator_namespace: operators
 debug: true
 
+namespace: olm
+catalog_namespace: olm
+operator_namespace: operators
+monitoring:
+  enabled: false
+  namespace: monitoring
+
 catalog:
   resources:
     limits:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
