### PR TITLE
fix: scaling defaults

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -206,13 +206,13 @@ environments:
             enabled: true
             autoscaling:
               egressgateway:
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 10
               ingressgateway:
                 minReplicas: 2
                 maxReplicas: 10
               pilot:
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 10
             egressGateway:
               enabled: false

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -169,7 +169,7 @@ environments:
             emitAdmissionEvents: false
             emitAuditEvents: false
             logLevel: INFO
-            replicas: 2
+            replicas: 1
           gitea:
             enabled: true
             adminUsername: otomi-admin

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -169,7 +169,7 @@ environments:
             emitAdmissionEvents: false
             emitAuditEvents: false
             logLevel: INFO
-            replicas: 1
+            replicas: 2
           gitea:
             enabled: true
             adminUsername: otomi-admin

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -190,7 +190,7 @@ environments:
             enabled: true
             autoscaling:
               enabled: true
-              minReplicas: 1
+              minReplicas: 2
               maxReplicas: 10
             modsecurity:
               enabled: false
@@ -200,7 +200,7 @@ environments:
               enabled: false
               autoscaling:
                 enabled: true
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 10
           istio:
             enabled: true

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -169,7 +169,7 @@ environments:
             emitAdmissionEvents: false
             emitAuditEvents: false
             logLevel: INFO
-            replicas: 1
+            replicas: 2
           gitea:
             enabled: true
             adminUsername: otomi-admin
@@ -209,7 +209,7 @@ environments:
                 minReplicas: 1
                 maxReplicas: 10
               ingressgateway:
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 10
               pilot:
                 minReplicas: 1

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 0.5.22
+api: scaling
 console: 0.5.24
 tasks: 0.2.31
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: scaling
+api: main
 console: 0.5.24
 tasks: 0.2.31
 tools: 1.4.25


### PR DESCRIPTION
Increase default replica counts so as not to block nodes draining during k8s upgrade.

Notes:
- Gatekeeper controller manager does not support HPA, so the only practical option is to set a static default of 2
- Since istio ingress-gateway is already set to 2 replicas minimum in HPA, I have done the same for the egress gateway, because if egress gateway is enabled it could cause the same issue