### PR TITLE
fix: cluster autoscaler memory requests

### DIFF
--- a/helmfile.d/snippets/templates.gotmpl
+++ b/helmfile.d/snippets/templates.gotmpl
@@ -73,7 +73,6 @@ templates:
           - -w
           - post
   wait: &wait
-    namespace: maintenance
     chart: ../charts/wait-for
     hooks:
       - events: [presync]

--- a/values/cluster-autoscaler/cluster-autoscaler.gotmpl
+++ b/values/cluster-autoscaler/cluster-autoscaler.gotmpl
@@ -29,7 +29,7 @@ resources:
     memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
Cluster autoscaler is OOM Killed in a crash loop. 
Resource is increased to 256 MBi
