### PR TITLE
fix:  aws-ebs-csi-driver without dependency on  snapshot-controller and disabled by default 

### DIFF
--- a/helmfile.d/helmfile-02.init.yaml
+++ b/helmfile.d/helmfile-02.init.yaml
@@ -33,7 +33,6 @@ releases:
     <<: *default
   - name: aws-ebs-csi-driver
     installed: {{ $a | get "aws-ebs-csi-driver.enabled" }}
-    needs: [snapshot-controller]
     namespace: kube-system
     labels:
       init: true

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -110,7 +110,7 @@ environments:
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
           snapshot-controller:
-            enabled: false #{{ eq $provider "aws" }}
+            enabled: {{ eq $provider "aws" }}
           tigera-operator:
             enabled: {{ $a | get "tigera-operator.enabled" (eq $provider "aws") }}
         ingress:

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -63,7 +63,7 @@ environments:
           aws-alb-ingress-controller:
             enabled: {{ and (eq $provider "aws") $v.otomi.hasCloudLB }}
           aws-ebs-csi-driver:
-            enabled: {{ $a | get "aws-ebs-csi-driver.enabled" (and (eq $provider "aws") (gt ($v.cluster.k8sVersion | float64) 1.22)) }}
+            enabled: false
           {{- if and (eq $issuer "letsencrypt") (not (hasKey $cm "stage")) }}
           cert-manager:
             enabled: true

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -110,7 +110,8 @@ environments:
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
           snapshot-controller:
-            enabled: {{ eq $provider "aws" }}
+            # TODO: upgrade snapshot-controller from piraeus-charts/snapshot-controller and toggle below:
+            enabled: false # {{ $a | get "snapshot-controller.enabled" (and (eq $provider "aws") (gt ($v.cluster.k8sVersion | float64) 1.22)) }}
           tigera-operator:
             enabled: {{ $a | get "tigera-operator.enabled" (eq $provider "aws") }}
         ingress:

--- a/tests/fixtures/env/cluster.yaml
+++ b/tests/fixtures/env/cluster.yaml
@@ -6,5 +6,5 @@ cluster:
     k8sVersion: '1.24'
     name: demo
     owner: redkubes
-    provider: aws
+    provider: azure
     region: eu-central-1

--- a/tests/fixtures/env/cluster.yaml
+++ b/tests/fixtures/env/cluster.yaml
@@ -6,5 +6,5 @@ cluster:
     k8sVersion: '1.24'
     name: demo
     owner: redkubes
-    provider: azure
+    provider: aws
     region: eu-central-1


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
