### PR TITLE
feat: extend integration test actions and scheduled tests with optional adminPassword

### DIFF
--- a/.github/workflows/integration-on-schedule-dns-no-admin-pass.yml
+++ b/.github/workflows/integration-on-schedule-dns-no-admin-pass.yml
@@ -1,0 +1,20 @@
+name: Scheduled - minimal with DNS, KMS and Letsencrypt, without admin password
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  start-integration-test-minimal-dns:
+    name: Start integration test (minimal)
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+    with:
+      install_profile: minimal
+      cluster_region: ams3
+      kubernetes_versions: "['1.24']"
+      dns: az_dns
+      kms: az_kms
+      generate_password: false
+      oidc: keycloak
+      certificate: letsencrypt_staging

--- a/.github/workflows/integration-on-schedule-dns-no-admin-pass.yml
+++ b/.github/workflows/integration-on-schedule-dns-no-admin-pass.yml
@@ -15,6 +15,6 @@ jobs:
       kubernetes_versions: "['1.24']"
       dns: az_dns
       kms: az_kms
-      generate_password: false
+      generate_password: 'no'
       oidc: keycloak
       certificate: letsencrypt_staging

--- a/.github/workflows/integration-on-schedule-dns.yml
+++ b/.github/workflows/integration-on-schedule-dns.yml
@@ -17,3 +17,4 @@ jobs:
       kms: az_kms
       oidc: keycloak
       certificate: letsencrypt_staging
+      generate_password: 'yes'

--- a/.github/workflows/integration-on-schedule-full.yml
+++ b/.github/workflows/integration-on-schedule-full.yml
@@ -13,3 +13,4 @@ jobs:
       install_profile: full
       cluster_region: ams3
       kubernetes_versions: "['1.24']"
+      generate_password: 'yes'

--- a/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
+++ b/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
@@ -1,0 +1,16 @@
+name: Scheduled - minimal with nip.io, without admin password
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  start-integration-test-minimal:
+    name: Start integration test (minimal)
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+    with:
+      install_profile: minimal
+      cluster_region: ams3
+      kubernetes_versions: "['1.24']"
+      generate_password: false

--- a/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
+++ b/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
@@ -13,4 +13,4 @@ jobs:
       install_profile: minimal
       cluster_region: ams3
       kubernetes_versions: "['1.24']"
-      generate_password: false
+      generate_password: 'no'

--- a/.github/workflows/integration-on-schedule-minimal.yml
+++ b/.github/workflows/integration-on-schedule-minimal.yml
@@ -13,3 +13,4 @@ jobs:
       install_profile: minimal
       cluster_region: ams3
       kubernetes_versions: "['1.24']"
+      generate_password: 'yes'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,10 @@ on:
         type: string
         description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
         default: az_kms
+      generate_password:
+        type: boolean
+        description: Should a unique password be generated?
+        default: true
       oidc:
         type: string
         description: Should Otomi use external OIDC?
@@ -76,12 +80,9 @@ on:
           - no_kms
           - az_kms
         default: az_kms
-      password:
-        type: choice
+      generate_password:
+        type: boolean
         description: Should a unique password be generated?
-        options:
-          - generate
-          - use-default
       oidc:
         type: choice
         description: Should Otomi use external OIDC?

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,7 +69,6 @@ on:
         type: choice
         description: Select DNS provider
         options:
-          - none
           - nip_io
           - az_dns
         default: nip_io

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,7 +237,7 @@ jobs:
             --values values.yaml \
             $domainSuffix"
 
-          If [[ ${{ inputs.generate_password }} -eq "no" ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
+          If [[ '${{ inputs.generate_password }}' -eq "no" ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
 
           helm install $install_args
       - name: Gather k8s events on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -236,7 +236,7 @@ jobs:
             $domainSuffix"
 
           if [[ '${{ inputs.generate_password }}' ]]; then
-            password=$(openssl rand -base64 12 | tr -dc A-Za-z0-9)
+            password=$(openssl rand -base64 16 | tr -dc A-Za-z0-9)
             install_args="$install_args --set otomi.adminPassword=$password"
           else
             install_args="$install_args --set otomi.adminPassword=welcomeotomi"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,7 +237,7 @@ jobs:
             --values values.yaml \
             $domainSuffix"
 
-          If [[ '${{ inputs.generate_password }}' == 'no' ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
+          [[ '${{ inputs.generate_password }}' == 'no' ]] && install_args="$install_args --set otomi.adminPassword=welcomeotomi"
 
           helm install $install_args
       - name: Gather k8s events on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -234,7 +234,7 @@ jobs:
             --values values.yaml \
             $domainSuffix"
 
-          if [[ '${{ inputs.generate_password }}' ]]; then
+          if [[ inputs.generate_password ]]; then
             password=$(openssl rand -base64 16 | tr -dc A-Za-z0-9)
             install_args="$install_args --set otomi.adminPassword=$password"
           else

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,6 +83,7 @@ on:
       generate_password:
         type: boolean
         description: Should a unique password be generated?
+        default: true
       oidc:
         type: choice
         description: Should Otomi use external OIDC?

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,7 +224,7 @@ jobs:
         run: |
           domainSuffix=''
           touch values.yaml
-          [[ '${{ inputs.dns }}' == 'az_dns' ]] && echo "$AZ_DNS" >> values.yaml && domainSuffix=' --set cluster.domainSuffix=tst-${{ github.run_id }}.aks.redkubes.net'
+          [[ '${{ inputs.dns }}' == 'az_dns' ]] && echo "$AZ_DNS" >> values.yaml && domainSuffix='--set cluster.domainSuffix=tst-${{ github.run_id }}.aks.redkubes.net'
           [[ '${{ inputs.kms }}' == 'az_kms' ]] && echo "$AZ_KMS" >> values.yaml
           [[ '${{ inputs.oidc }}' == 'az_oidc' ]] && echo "$AZ_OIDC" >> values.yaml
           [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
@@ -232,16 +232,17 @@ jobs:
           install_args="--wait --wait-for-jobs --timeout 90m0s otomi chart/otomi \
             --values tests/integration/${{ inputs.install_profile }}.yaml \
             --values values-container-registry.yaml
-            --values values.yaml \"
+            --values values.yaml \
+            $domainSuffix"
 
-          if [[ "${{ inputs.generate_password }}" == "true" ]]; then
+          if [[ '${{ inputs.generate_password }}' ]]; then
             password=$(openssl rand -base64 12 | tr -dc A-Za-z0-9)
             install_args="$install_args --set otomi.adminPassword=$password"
           else
             install_args="$install_args --set otomi.adminPassword=welcomeotomi"
           fi
 
-          helm install $install_args $domainSuffix
+          helm install $install_args
       - name: Gather k8s events on failure
         if: failure()
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,9 @@ on:
         description: Should Otomi encrypt secrets in values repo (DNS or KMS is used)
         default: az_kms
       generate_password:
-        type: boolean
+        type: string
         description: Should a unique password be generated?
-        default: true
+        default: 'no'
       oidc:
         type: string
         description: Should Otomi use external OIDC?
@@ -80,9 +80,12 @@ on:
           - az_kms
         default: az_kms
       generate_password:
-        type: boolean
+        type: choice
         description: Should a unique password be generated?
-        default: true
+        options:
+          - 'yes'
+          - 'no'
+        default: 'no'
       oidc:
         type: choice
         description: Should Otomi use external OIDC?
@@ -234,12 +237,7 @@ jobs:
             --values values.yaml \
             $domainSuffix"
 
-          if [[ inputs.generate_password ]]; then
-            password=$(openssl rand -base64 16 | tr -dc A-Za-z0-9)
-            install_args="$install_args --set otomi.adminPassword=$password"
-          else
-            install_args="$install_args --set otomi.adminPassword=welcomeotomi"
-          fi
+          If [[ ${{ inputs.generate_password }} -eq "no" ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
 
           helm install $install_args
       - name: Gather k8s events on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -226,12 +226,20 @@ jobs:
           [[ '${{ inputs.kms }}' == 'az_kms' ]] && echo "$AZ_KMS" >> values.yaml
           [[ '${{ inputs.oidc }}' == 'az_oidc' ]] && echo "$AZ_OIDC" >> values.yaml
           [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
-          # Sometimes the DO cluster is having hiccups while scaling up nodes, thus we need keep the timeout high.
-          helm install --wait --wait-for-jobs --timeout 90m0s otomi chart/otomi \
-          --values tests/integration/${{ inputs.install_profile }}.yaml \
-          --values values-container-registry.yaml \
-          --values values.yaml \
-          $domainSuffix
+
+          install_args="--wait --wait-for-jobs --timeout 90m0s otomi chart/otomi \
+            --values tests/integration/${{ inputs.install_profile }}.yaml \
+            --values values-container-registry.yaml
+            --values values.yaml \"
+
+          if [[ "${{ inputs.generate_password }}" == "true" ]]; then
+            password=$(openssl rand -base64 12 | tr -dc A-Za-z0-9)
+            install_args="$install_args --set otomi.adminPassword=$password"
+          else
+            install_args="$install_args --set otomi.adminPassword=welcomeotomi"
+          fi
+
+          helm install $install_args $domainSuffix
       - name: Gather k8s events on failure
         if: failure()
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,7 +237,7 @@ jobs:
             --values values.yaml \
             $domainSuffix"
 
-          If [[ '${{ inputs.generate_password }}' -eq "no" ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
+          If [[ '${{ inputs.generate_password }}' == 'no' ]]; then install_args="$install_args --set otomi.adminPassword=welcomeotomi"
 
           helm install $install_args
       - name: Gather k8s events on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,6 +65,7 @@ on:
         type: choice
         description: Select DNS provider
         options:
+          - none
           - nip_io
           - az_dns
         default: nip_io
@@ -75,6 +76,12 @@ on:
           - no_kms
           - az_kms
         default: az_kms
+      password:
+        type: choice
+        description: Should a unique password be generated?
+        options:
+          - generate
+          - use-default
       oidc:
         type: choice
         description: Should Otomi use external OIDC?

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -124,6 +124,7 @@ jobs:
           echo 'cluster_persistence: ${{ inputs.cluster_persistence }}'
           echo 'dns: ${{ inputs.dns }}'
           echo 'kms: ${{ inputs.kms }}'
+          echo 'generate_password: ${{ inputs.generate_password }}'
           echo 'oidc: ${{ inputs.oidc }}'
           echo 'certificate: ${{ inputs.certificate }}'
       - name: Install doctl

--- a/tests/integration/minimal.yaml
+++ b/tests/integration/minimal.yaml
@@ -6,4 +6,3 @@ cluster:
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
   version: 'OTOMI_VERSION_PLACEHOLDER'
-  adminPassword: welcomeotomi


### PR DESCRIPTION
This allows the user to choose to either generate an admin password, or to use the default one.
Also adds test scenarios.

Related to #1055 