### PR TITLE
fix: kured raw values

### DIFF
--- a/tests/fixtures/env/apps/kured.yaml
+++ b/tests/fixtures/env/apps/kured.yaml
@@ -1,3 +1,10 @@
 apps:
     kured:
         enabled: true
+        _rawValues:
+            configuration:
+                endTime: '07:00'
+                rebootDays:
+                    - su
+                startTime: '22:00'
+                timeZone: CET

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2176,6 +2176,8 @@ properties:
       kured:
         additionalProperties: false
         properties:
+          _rawValues:
+            $ref: '#/definitions/rawValues'
           enabled:
             default: false
             type: boolean


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
