### PR TITLE
feat: set the default value of the isMultitentat flag

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -479,7 +479,7 @@ environments:
           hasExternalDNS: false
           hasExternalIDP: false
           isHomeMonitored: false
-          isMultitenant: false
+          isMultitenant: true
           nodeSelector: {}
         # TODO: update this when schema version changes: (and think more?)
         version: 5

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -93,7 +93,6 @@ otomi:
     hasExternalDNS: true
     hasExternalIDP: true
     isHomeMonitored: true
-    isMultitenant: true
     nodeSelector:
         otomi: otomi-sys
     version: main

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -3155,7 +3155,7 @@ properties:
         description: Whether this cluster is home monitored (like when under a Premium SLA). Sends criticals home.
         type: boolean
       isMultitenant:
-        default: false
+        default: true
         description: Whether to separate team metrics and logs. Disabling this lets everybody be admin and see everything.
         type: boolean
       nodeSelector:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
+api: is-multitennat
 console: is-multitennat
 tasks: main
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: is-multitennat
-console: is-multitennat
+api: main
+console: main
 tasks: main
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
-console: main
+console: is-multitennat
 tasks: main
 tools: 1.4.25


### PR DESCRIPTION
implements: https://github.com/redkubes/unassigned-issues/issues/567

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
