### PR TITLE
fix: added check for values input

### DIFF
--- a/src/cmd/bootstrap.test.ts
+++ b/src/cmd/bootstrap.test.ts
@@ -115,6 +115,7 @@ describe('Bootstrapping values', () => {
       },
     }
     const deps = {
+      isChart: true,
       loadYaml: jest.fn().mockReturnValue(workload),
       mkdir: jest.fn(),
       terminal,

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -248,6 +248,7 @@ export const processValues = async (
 // create file structure based on file entry
 export const handleFileEntry = async (
   deps = {
+    isChart,
     loadYaml,
     mkdir,
     terminal,
@@ -255,19 +256,21 @@ export const handleFileEntry = async (
   },
 ) => {
   const { ENV_DIR, VALUES_INPUT } = env
-  // write Values from File
-  const originalValues = (await deps.loadYaml(VALUES_INPUT)) as Record<string, any>
-  if (originalValues && originalValues.files) {
-    for (const [key, value] of Object.entries(originalValues.files as string)) {
-      // extract folder name
-      const filePath = path.dirname(key)
-      // evaluate absolute file name and path
-      const absPath = `${ENV_DIR}/${filePath}`
-      const absFileName = `${ENV_DIR}/${key}`
-      // create Folder
-      await deps.mkdir(absPath, { recursive: true })
-      // write File
-      await deps.writeFile(absFileName, value.toString())
+  if (deps.isChart) {
+    // write Values from File
+    const originalValues = (await deps.loadYaml(VALUES_INPUT)) as Record<string, any>
+    if (originalValues && originalValues.files) {
+      for (const [key, value] of Object.entries(originalValues.files as string)) {
+        // extract folder name
+        const filePath = path.dirname(key)
+        // evaluate absolute file name and path
+        const absPath = `${ENV_DIR}/${filePath}`
+        const absFileName = `${ENV_DIR}/${key}`
+        // create Folder
+        await deps.mkdir(absPath, { recursive: true })
+        // write File
+        await deps.writeFile(absFileName, value.toString())
+      }
     }
   }
 }


### PR DESCRIPTION
This PR:
- adds a fix for not supplying a VALUES_INPUT and breaking drone runner

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
