### PR TITLE
fix: aws region cfg 4 velero

### DIFF
--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -65,7 +65,7 @@ configuration:
     bucket: {{ $sp.s3.bucket }}
     config:
       s3Url: {{ $sp.s3.s3Url }}
-      region: {{ $sp.s3.region }}
+      region: {{ $cp.aws.region }}
   {{- end }}
   {{- if eq $sp.type "minioLocal" }}
   provider: aws


### PR DESCRIPTION
This PR fixes the configuration of the region setting for using AWS S3 in Velero
