### PR TITLE
feat: improved error message

### DIFF
--- a/binzx/otomi
+++ b/binzx/otomi
@@ -284,7 +284,7 @@ if { { [ "$otomi_version_used" = 'latest' ] || [ "$otomi_version_used" = 'main' 
   silent docker pull $otomi_tools_image
   status=$?
   if [ "$status" -ne 0 ]; then
-    echo "Something went wrong when trying to pull '${otomi_tools_image}'"
+    echo "Something went wrong when trying to pull '${otomi_tools_image}', is Docker running?"
     exit $status
   fi
 fi


### PR DESCRIPTION
When you try to run otomi core without docker running you get the generic error message saying "Something went wrong when trying to pull '[otomi-core:branch]'". Although there might be multiple reasons to throw this error, the majority of reasons is that docker is simply not running, by adding a little bit of text at the end with the question if docker is running it might save a lot of time debugging. 