### PR TITLE
feat: allow to disable individual prometheus rules

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -306,6 +306,8 @@ environments:
           prometheus-blackbox-exporter: {}
           prometheus:
             enabled: false
+            disabledRules:
+              - InfoInhibitor
             remoteWrite:
               enabled: false
               rwConfig:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2383,6 +2383,10 @@ properties:
           enabled:
             type: boolean
             default: false
+          disabledRules:
+            type: array
+            items:
+              type: string
           remoteWrite:
             properties:
               enabled:

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -23,6 +23,8 @@ prometheusOperator:
 
 defaultRules:
   create: true
+  disabled:
+    InfoInhibitor: true
   rules:
     alertmanager: true
     configReloaders: false

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -23,8 +23,6 @@ prometheusOperator:
 
 defaultRules:
   create: true
-  disabled:
-    InfoInhibitor: true
   rules:
     alertmanager: true
     configReloaders: false

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -24,6 +24,12 @@ global:
   imagePullSecrets:
     - name: otomi-pullsecret-global
 {{- end }}
+
+defaultRules:
+  disabled:
+    {{- range $p.disabledRules }}
+    {{ . }}: true
+    {{- end }}
 prometheusOperator:
   resources:
     limits:


### PR DESCRIPTION
partially-implements: redkubes/unassigned-issues#570


<img width="1195" alt="image" src="https://user-images.githubusercontent.com/17126497/234607551-c6140f3b-95f3-48b4-ac30-af48ae50cde3.png">


## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
