### PR TITLE
ci: Add k8s 1.23 option to workflow dispatch within github actions Integration Job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,6 +43,7 @@ on:
         description: 'Kubernetes version'
         type: choice
         options:
+          - "['1.23']"
           - "['1.24']"
           - "['1.25']"
         default: "['1.24']"


### PR DESCRIPTION

Added `1.23` option into workflow dispatch in order to support previous versions.