### PR TITLE
fix: add resources for trivy scanner

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -182,6 +182,14 @@ environments:
                 username: otomi-admin
             backup:
               enabled: false
+            resources:
+              trivy:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 400m
+                  memory: 512Mi
           hello:
             enabled: false
           httpbin:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1848,6 +1848,8 @@ properties:
                 $ref: '#/definitions/resources'
               registry-controller:
                 $ref: '#/definitions/resources'
+              trivy:
+                $ref: '#/definitions/resources'
           secretKey:
             type: string
             x-secret: 'randAlpha 16'

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -150,19 +150,6 @@ notary:
   enabled: false
   secretName: {{ $notarySecretName }}
 
-trivy:
-  resources:
-    {{- with $h | get "resources.trivy" nil }}
-    {{- toYaml . | nindent 4 }}
-    {{- else }}
-    limits:
-      cpu: 400m
-      memory: 512Mi
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    {{- end }}
-  
 persistence:
   enabled: true
   # resourcePolicy: 'keep'
@@ -330,16 +317,7 @@ trivy:
   image:
     tag: {{ $tag }}
   resources:
-    {{- with $h | get "resources.trivy" nil }}
-      {{- toYaml . | nindent 6 }}
-    {{- else }}
-      requests:
-        cpu: 100m 
-        memory: 1Gi
-      limits:
-        cpu: 400m
-        memory: 2Gi
-    {{- end }}
+    {{- $h.resources.trivy }}
   automountServiceAccountToken: true
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -316,6 +316,7 @@ trivy:
   priorityClassName: otomi-critical
   image:
     tag: {{ $tag }}
+  resources: {{- $h.resources.trivy }}
   automountServiceAccountToken: true
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -149,6 +149,19 @@ notary:
       tag: {{ $tag }}
   enabled: false
   secretName: {{ $notarySecretName }}
+
+trivy:
+  resources:
+    {{- with $h | get "resources.trivy" nil }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    limits:
+      cpu: 400m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    {{- end }}
   
 persistence:
   enabled: true

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -316,7 +316,8 @@ trivy:
   priorityClassName: otomi-critical
   image:
     tag: {{ $tag }}
-  resources: {{- $h.resources.trivy }}
+  resources: 
+    {{- $h.resources.trivy | toYaml  | nindent 4 }}
   automountServiceAccountToken: true
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -316,8 +316,6 @@ trivy:
   priorityClassName: otomi-critical
   image:
     tag: {{ $tag }}
-  resources:
-    {{- $h.resources.trivy }}
   automountServiceAccountToken: true
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}


### PR DESCRIPTION
Requires redkubes/otomi-api#395

Allow user to specify resource quota for harbor trivy, also increase quota from helm chart defaults.

The chart default CPU + mem _requests_ were extremely low, which meant that the pod could be scheduled to nodes incapable of providing the resources specified in the _limits_, thereby disrupting the scans of images with larger layer sizes.