### PR TITLE
feat: olm channel

### DIFF
--- a/charts/argocd-operator/templates/catalog_source.yaml
+++ b/charts/argocd-operator/templates/catalog_source.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: argocd-catalog
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: quay.io/argoprojlabs/argocd-operator-registry@v0.5.0
+  displayName: Argo CD Operators
+  publisher: Argo CD Community

--- a/charts/argocd-operator/templates/subscription.yaml
+++ b/charts/argocd-operator/templates/subscription.yaml
@@ -3,10 +3,9 @@ kind: Subscription
 metadata:
   name: argocd-operator
 spec:
-  # channel: alpha
+  channel: alpha
   name: argocd-operator
-  # source: argocd-catalog
-  source: operatorhubio-catalog
+  source: argocd-catalog
   sourceNamespace: olm
   config:
     env:
@@ -14,3 +13,4 @@ spec:
         value: "true"
       - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
         value: argocd
+  # installPlanApproval: Manual


### PR DESCRIPTION
This PR enforces usage of certain argocd-operator, so argocd applicationset controller is deployed properly.

However this PR does not downgrade the controller that has already been upgraded to v0.6.0 which seems to be broken.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
