### PR TITLE
fix: Istio VirtualService response header parsing

### DIFF
--- a/charts/team-ns/templates/istio-virtualservices.yaml
+++ b/charts/team-ns/templates/istio-virtualservices.yaml
@@ -88,7 +88,7 @@ spec:
             response:
               set:
               {{- range . }}
-                {{ .name }}: {{ .value}}
+                {{ .name }}: {{ .value | quote }}
               {{- end }}
             {{- end }}
 


### PR DESCRIPTION
In the case where the value is an asterisk (*), the value will fail tests.
This is due to how the templator handles strings starting with an asterisk - even if quoted in the values file, the quotes are stripped during templating, and passed to Helm as a bare asterisk, which is not valid here.

This is the error but the line numbers are not relevant;
`  otomi:global:error   Error: YAML parse error on team-ns/templates/istio-virtualservices.yaml: error converting YAML to JSON: yaml: line 45: did not find expected alphabetic or numeric character`

Fails:
<img width="351" alt="Screenshot 2023-05-02 at 12 50 47" src="https://user-images.githubusercontent.com/59235486/235651345-0e4da37a-dcf3-4108-9674-eecf8a544dc5.png">

My hacky workaround - Passes tests and works correctly
<img width="349" alt="Screenshot 2023-05-02 at 12 50 34" src="https://user-images.githubusercontent.com/59235486/235651398-da7b3392-bff4-4ccd-8c6c-6112673556ee.png">

