### PR TITLE
fix: otomi version tag update

### DIFF
--- a/chart/otomi/templates/values-secrets.yaml
+++ b/chart/otomi/templates/values-secrets.yaml
@@ -1,3 +1,9 @@
+{{- $otomi_version := .Chart.AppVersion}}
+{{- $updatedValues := .Values }}
+{{- if not .Values.otomi.version }}
+{{- $updatedValues := merge .Values (dict "otomi" (dict "version" $otomi_version)) }}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +12,4 @@ metadata:
 type: Opaque
 data:
   values.yaml: |-
-{{ .Values | toYaml | b64enc | indent 4 }}
+{{ $updatedValues | toYaml | base64 | indent 4 }}

--- a/chart/otomi/templates/values-secrets.yaml
+++ b/chart/otomi/templates/values-secrets.yaml
@@ -12,4 +12,4 @@ metadata:
 type: Opaque
 data:
   values.yaml: |-
-{{ $updatedValues | toYaml | base64 | indent 4 }}
+{{ $updatedValues | toYaml | b64enc | indent 4 }}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
 console: main
-tasks: otomi-version-fix
+tasks: main
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
 console: main
-tasks: main
+tasks: otomi-version-fix
 tools: 1.4.25


### PR DESCRIPTION
This PR adds logic to set the otomi version to the one specified in Charts.appVersion when its not specified  by the user

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [x] Helm releases are meeting otomi's baseline security policies, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
