### PR TITLE
feat: scaleway provider

### DIFF
--- a/chart/otomi/values.yaml
+++ b/chart/otomi/values.yaml
@@ -18,7 +18,7 @@ cluster: {}
   # name: 'dev'
 
   ## Set provider
-  ## Can be one of aws|azure|google|digitalocean|ovh|vultr|custom
+  ## Can be one of aws|azure|google|digitalocean|ovh|vultr|scaleway|custom
   ## Choose 'custom' for Minikube and any other K8s cluster.
   ##
   # provider: 'custom'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -759,6 +759,7 @@ definitions:
       - kind
       - ovh
       - vultr
+      - scaleway
   redisChart:
     properties:
       _rawValues:


### PR DESCRIPTION
To install Otomi on Scaleway, we need a new provider. By using the Scaleway provider, metrics-server is not enabled (because Scaleway already runs metrics-server by default)
