### PR TITLE
fix: team billing quota defaults

### DIFF
--- a/charts/team-ns/templates/rules/prometheus-rules.yaml
+++ b/charts/team-ns/templates/rules/prometheus-rules.yaml
@@ -2,6 +2,9 @@
 {{- if $v.apps.prometheus.enabled }}
 {{- if $v.apps.opencost.enabled }}
 {{- if not (eq $v.teamId "admin") }}
+{{- $billingAlertQuotas := $v.billingAlertQuotas | default dict }}
+{{- $cpuMonthQuotaReached := dig "teamCpuMonthQuotaReached" "quota" "100" $billingAlertQuotas }}
+{{- $memMonthQuotaReached := dig "teamMemMonthQuotaReached" "quota" "100" $billingAlertQuotas }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -15,20 +18,20 @@ spec:
   - name: opencost.rules
     rules:
       - alert: TeamCpuMonthQuotaReached
-        expr: sum(container_cpu_allocation{exported_namespace=~"team-{{ $v.teamId }}"} * on (node) group_left node_cpu_hourly_cost) * 730 > {{ $v.billingAlertQuotas.teamCpuMonthQuotaReached.quota }}
+        expr: sum(container_cpu_allocation{exported_namespace=~"team-{{ $v.teamId }}"} * on (node) group_left node_cpu_hourly_cost) * 730 > {{ $cpuMonthQuotaReached }}
         for: 1d
         labels:
           severity: warning
         annotations:
-          description: The monthly CPU cost of team {{ $v.teamId }} reached {{ $v.billingAlertQuotas.teamCpuMonthQuotaReached.quota }}
+          description: The monthly CPU cost of team {{ $v.teamId }} reached {{ $cpuMonthQuotaReached }}
           summary: team CPU cost quota p.m. reached
       - alert: TeamMemMonthQuotaReached
-        expr: sum(container_memory_allocation_bytes{exported_namespace=~"team-{{ $v.teamId }}"} / 1000000000 * on (node) group_left node_ram_hourly_cost) * 730 > {{ $v.billingAlertQuotas.teamMemMonthQuotaReached.quota }}
+        expr: sum(container_memory_allocation_bytes{exported_namespace=~"team-{{ $v.teamId }}"} / 1000000000 * on (node) group_left node_ram_hourly_cost) * 730 > {{ $memMonthQuotaReached }}
         for: 1d
         labels:
           severity: warning
         annotations:
-          description: The monthly memory cost of team {{ $v.teamId }} reached {{ $v.billingAlertQuotas.teamMemMonthQuotaReached.quota }}
+          description: The monthly memory cost of team {{ $v.teamId }} reached {{ $memMonthQuotaReached }}
           summary: team memory cost quota p.m. reached
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes templating issues while team does not have the `billingAlertQuotas` defined in the values repo.

```
STDERR:
  Error: template: team-ns/templates/rules/prometheus-rules.yaml:18:145: executing "team-ns/templates/rules/prometheus-rules.yaml" at <$v.billingAlertQuotas.teamCpuMonthQuotaReached.quota>: nil pointer evaluating interface {}.teamCpuMonthQuotaReached

COMBINED OUTPUT:
  Release "team-ns-demo" does not exist. Installing it now.
  Error: template: team-ns/templates/rules/prometheus-rules.yaml:18:145: executing "team-ns/templates/rules/prometheus-rules.yaml" at <$v.billingAlertQuotas.teamCpuMonthQuotaReached.quota>: nil pointer evaluating interface {}.teamCpuMonthQuotaReached
    at hfCore (/home/app/stack/dist/src/common/hf.js:44:30)
    exit code: 1
    at ChildProcess.<anonymous> (/home/app/stack/node_modules/zx/dist/bundle.cjs:15261:22)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1100:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5)
Stream closed EOF for default/otomi-mv6lp (install)

```

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
