### PR TITLE
fix: deploy harbor cert after certmaneger crds are deployed

### DIFF
--- a/helmfile.d/helmfile-03.init.yaml
+++ b/helmfile.d/helmfile-03.init.yaml
@@ -58,12 +58,6 @@ releases:
       init: true
       pkg: knative
     <<: *skeleton
-  - name: harbor-artifacts
-    installed: {{ $a | get "harbor.enabled" }}
-    namespace: harbor
-    labels:
-      pkg: harbor
-    <<: *raw
   - name: loki-artifacts
     installed: {{ $a | get "loki.enabled" }}
     namespace: monitoring

--- a/helmfile.d/helmfile-09.init.yaml
+++ b/helmfile.d/helmfile-09.init.yaml
@@ -42,4 +42,9 @@ releases:
     labels:
       pkg: minio
     <<: *default
-
+  - name: harbor-artifacts
+    installed: {{ $a | get "harbor.enabled" }}
+    namespace: harbor
+    labels:
+      pkg: harbor
+    <<: *raw


### PR DESCRIPTION
Solves error:

```
STDERR:
  Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "internal-harbor-token-service-ca" namespace: "harbor" from "": no matches for kind "Certificate" in version "cert-manager.io/v1"
  ensure CRDs are installed first
```
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
