### PR TITLE
feat: add license property to schema

### DIFF
--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -101,4 +101,5 @@ smtp:
     from: no-reply@doma.in
     hello: doma.in
     smarthost: smtp-relay.gmail.com:587
+license: license-in-jwt-format
 version: 8

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -3663,5 +3663,9 @@ properties:
   version:
     type: integer
     description: DO NOT CHANGE! Holds the values-schema version. For more details, see `otomi migrate`.
+  license:
+    type: string
+    describe: License in form of JWT
+    x-secret: ''
 required:
   - cluster

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
-console: main
-tasks: 0.4.0
+api: licensing-finalize
+console: licensing-finalize
+tasks: main
 tools: 1.4.25


### PR DESCRIPTION

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
