### PR TITLE
fix: schema with supported k8s versions

### DIFF
--- a/.github/workflows/integration-on-schedule-full.yml
+++ b/.github/workflows/integration-on-schedule-full.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       install_profile: full
       cluster_region: ams3
-      kubernetes_versions: "['1.24', '1.25']"
+      kubernetes_versions: "['1.24']"
       generate_password: 'yes'

--- a/README.md
+++ b/README.md
@@ -22,27 +22,29 @@ Add developer- and operations-centric tools, automation and self-service on top 
 
 <p align="center"><img src="https://github.com/redkubes/otomi-core/blob/main/docs/img/otomi-console.png/?raw=true" width="100%" align="center" alt="Otomi integrated applications"></p>
 
-## Otomi helps 
+## Otomi helps
 
 **Developers** - To focus on their apps only
-* Build images from application code
-* Deploy containerized workloads without writing any YAML
-* Direct access to logs and metrics
-* Store charts and images in a private registry
-* Build and run custom CI pipelines
-* Easy ingress and network policy configuration
-* Manage your own secrets
+
+- Build images from application code
+- Deploy containerized workloads without writing any YAML
+- Direct access to logs and metrics
+- Store charts and images in a private registry
+- Build and run custom CI pipelines
+- Easy ingress and network policy configuration
+- Manage your own secrets
 
 **Platform teams** - To setup and manage production-ready Kubernetes-based platforms
-* Onboard development teams in a comprehensive multi-tenant setup
-* Get all the required K8s tools in an integrated and automated way
-* Create your platform profile and deploy to any K8s
-* One schema to manage all platform configuration
-* Ensure governance with security policies
-* Implement zero-trust networking
-* Make development teams self-serving
-* Change the desired state of the platform based on Configuration-as-Code
-* Support multi- and hybrid cloud scenarios
+
+- Onboard development teams in a comprehensive multi-tenant setup
+- Get all the required K8s tools in an integrated and automated way
+- Create your platform profile and deploy to any K8s
+- One schema to manage all platform configuration
+- Ensure governance with security policies
+- Implement zero-trust networking
+- Make development teams self-serving
+- Change the desired state of the platform based on Configuration-as-Code
+- Support multi- and hybrid cloud scenarios
 
 ## Getting started
 
@@ -50,7 +52,7 @@ Add developer- and operations-centric tools, automation and self-service on top 
 
 To install Otomi using Helm, make sure to have a K8s cluster running with at least:
 
-- Version `1.22` up to `1.24`
+- Version `1.23` up to `1.24`
 - A node pool with **6 vCPU** and **8GB+ RAM** (more is advised!)
 - Calico CNI installed (or any other CNI that supports K8s network policies)
 - When installing using the `custom` provider, make sure the K8s LoadBalancer Service created by `Otomi` can obtain an external accessible IP (using a cloud load balancer or MetalLB)
@@ -66,7 +68,7 @@ and then install the Helm chart:
 
 ```bash
 helm install otomi otomi/otomi \
---set cluster.k8sVersion=$VERSION \ # 1.22, 1.23 and 1.24 are supported
+--set cluster.k8sVersion=$VERSION \ # 1.23 and 1.24 are supported
 --set cluster.name=$CLUSTERNAME \
 --set cluster.provider=$PROVIDER # use 'azure', 'aws', 'google', 'digitalocean', 'ovh', 'vultr', 'scaleway' or 'custom' for any other cloud or onprem K8s
 ```
@@ -125,6 +127,7 @@ Otomi installs, configures, integrates and automates all of your favorite K8s ap
 - BYO IdP, DNS and/or CA
 
 And much more...
+
 ## Otomi Projects
 
 The open source Core of Otomi consists out of the following projects:

--- a/chart/otomi/values.yaml
+++ b/chart/otomi/values.yaml
@@ -9,9 +9,9 @@ cluster: {}
   # domainSuffix: ''
 
   ## Set the Kubernetes version
-  ## Currently 1.19, 1.20, 1.21, 1.22 and 1.23 are supported
+  ## Currently 1.23 and 1.24 are supported
   ##
-  # k8sVersion: '1.22'
+  # k8sVersion: '1.24'
 
   ## Set the name of your cluster
   ## 

--- a/docs/development.md
+++ b/docs/development.md
@@ -344,7 +344,7 @@ otomi bootstrap
 ```
 cluster:
     name: 'dev'
-    k8sVersion: '1.22'
+    k8sVersion: '1.24'
     provider: 'custom'
 ```
 

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -598,10 +598,8 @@ definitions:
   k8sVersion:
     description: The cluster k8s version. Must match one of the list.
     enum:
-      - '1.22'
       - '1.23'
       - '1.24'
-      - '1.25'
     type: string
   labels:
     $ref: '#/definitions/labelsAnnotations'


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
