### PR TITLE
feat: define kubectl SA for each team

### DIFF
--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -68,3 +68,23 @@ subjects:
 - kind: ServiceAccount
   name: sa-team-{{ $v.teamId }}
   namespace: {{ $ns }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubectl
+  labels: {{- include "team-ns.chart-labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: kubectl
+  namespace: {{ $ns }}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
+api: kubectl-sa
 console: main
 tasks: main
 tools: 1.4.25


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
