### PR TITLE
feat: add migration rules for harbor db type

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -193,7 +193,7 @@ environments:
               schedule: '0 0 0 * * *'
               credentialsName: minio-creds
             database:
-              type: internal
+              type: external
               name: harbor-database
               user: harbor
               coreDatabase: registry

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -94,12 +94,6 @@ environments:
             registry:
               credentials:
                 password: {{ $a | get "harbor.registry.credentials.password" $v.otomi.adminPassword }}
-            database:
-              {{- if $v | get "status.helm.harbor/harbor" nil }}
-                type: {{ $a.harbor.database.type }}
-              {{- else }}
-                type: external
-              {{- end}}
           gatekeeper:
             enabled: {{ or ($a | get "gatekeeper.enabled" false) (not (empty ($v.otomi.nodeSelector))) }}
           gitea:

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -65,3 +65,6 @@ changes:
     deletions:
       - 'apps.harbor.resources.clair'
       - 'apps.harbor.resources.clair-adapter'
+  - version: 9
+    additions:
+      - apps.harbor.database.type: internal


### PR DESCRIPTION
The code from this PR will only work after the https://github.com/redkubes/otomi-core/pull/1131 is merged to main and reflected in other PRs.

This code sets default database type to `external`

The `values-changes.yaml` file defines a migration that happens only once and only for existing otomi instance.
In this way we prevent existing harbor instance to switch to external database upon Otomi upgrade.

There is only one disadvantage that the migration will also happens if harbor is not enabled but we can accept it as it is not harmful.


