### PR TITLE
fix: service account for generating kubeconfig

### DIFF
--- a/charts/otomi-api/templates/clusterrole.yaml
+++ b/charts/otomi-api/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
 - apiGroups: [""]
   resources:
     - secrets
-  verbs: ["get"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -74,6 +74,8 @@ kind: ServiceAccount
 metadata:
   name: kubectl
 automountServiceAccountToken: false
+secrets:
+- name: kubectl-token
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -75,6 +75,14 @@ metadata:
   name: kubectl
 automountServiceAccountToken: false
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubectl-token
+  annotations:
+    kubernetes.io/service-account.name: kubectl
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
Since k8s 1.24 the SA token are not autogenerated by default. 

There are three use cases that needs to be covered:
- k8s cluster is 1.23
- k8s cluster is 1.24 with SA token autogeneration disabled
- k8s cluster is 1.24 with SA token autogeneration enabled

This solution aims to cover above scenarios. The users can observe the `kubectl` SA with either one or two secrets depending if autogeneration enabled or disabled.

```
apiVersion: v1
automountServiceAccountToken: false
kind: ServiceAccount
metadata:
  name: kubectl
  namespace: team-demo
secrets:
- name: kubectl-token
- name: kubectl-token-t84qg
```

```
apiVersion: v1
automountServiceAccountToken: false
kind: ServiceAccount
metadata:
  name: kubectl
  namespace: team-demo
secrets:
- name: kubectl-token
```
 

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
