### PR TITLE
feat: make custom team Grafana dashboards persistent

### DIFF
--- a/charts/team-ns/templates/dashboards/configmap.yaml
+++ b/charts/team-ns/templates/dashboards/configmap.yaml
@@ -1,0 +1,18 @@
+{{- $v := .Values }}
+{{- if $v.dashboards}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: team-{{ $v.teamId }}-custom-dashboards
+  labels:
+    dashboard-provider: custom-dashboards
+    custom_label: custom-dashboards
+    grafana_dashboard: '1'
+data:
+  {{- range $v.dashboards}}
+  {{ .name }}.json: |-
+  {{- .file | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/helmfile.d/snippets/env.gotmpl
+++ b/helmfile.d/snippets/env.gotmpl
@@ -34,7 +34,7 @@ environments:
       - {{ $app }}
 {{- end }}{{ end }}
 {{- range $team := $teams }}
-  {{- range $type := list "services" "external-secrets" "jobs" "workloads" "backups" "builds"}}
+  {{- range $type := list "services" "external-secrets" "jobs" "workloads" "backups" "builds" "dashboards" }}
     {{- if eq (exec "bash" (list "-c" (printf "( test -f $ENV_DIR/env/teams/%s.%s.yaml && echo 'true' ) || echo 'false'" $type $team)) | trim) "true" }}
       - {{ $ENV_DIR }}/env/teams/{{ $type }}.{{ $team }}.yaml
     {{- end }}

--- a/tests/fixtures/env/teams/dashboards.demo.yaml
+++ b/tests/fixtures/env/teams/dashboards.demo.yaml
@@ -1,0 +1,555 @@
+teamConfig:
+    demo:
+        dashboards:
+            - name: my-dashboard
+              file: |
+                  {
+                    "annotations": {
+                      "list": [
+                        {
+                          "builtIn": 1,
+                          "datasource": "-- Grafana --",
+                          "enable": true,
+                          "expr": "time() == BOOL timestamp(rate(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[2m]) > 0)",
+                          "hide": false,
+                          "iconColor": "rgba(215, 44, 44, 1)",
+                          "name": "Restarts",
+                          "showIn": 0,
+                          "tags": ["restart"],
+                          "type": "rows"
+                        }
+                      ]
+                    },
+                    "editable": false,
+                    "gnetId": null,
+                    "graphTooltip": 0,
+                    "hideControls": false,
+                    "id": null,
+                    "links": [],
+                    "refresh": "",
+                    "rows": [
+                      {
+                        "collapse": false,
+                        "collapsed": false,
+                        "panels": [
+                          {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "gridPos": {},
+                            "id": 2,
+                            "legend": {
+                              "alignAsTable": true,
+                              "avg": true,
+                              "current": true,
+                              "max": false,
+                              "min": false,
+                              "rightSide": true,
+                              "show": true,
+                              "total": false,
+                              "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                              {
+                                "expr": "sum by(container) (container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Current: {{ container }}",
+                                "refId": "A"
+                              },
+                              {
+                                "expr": "sum by(container) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\", container=~\"$container\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Requested: {{ container }}",
+                                "refId": "B"
+                              },
+                              {
+                                "expr": "sum by(container) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\", pod=\"$pod\", container=~\"$container\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Limit: {{ container }}",
+                                "refId": "C"
+                              },
+                              {
+                                "expr": "sum by(container) (container_memory_cache{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"POD\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Cache: {{ container }}",
+                                "refId": "D"
+                              }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Memory Usage",
+                            "tooltip": {
+                              "shared": false,
+                              "sort": 0,
+                              "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": []
+                            },
+                            "yaxes": [
+                              {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              },
+                              {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              }
+                            ]
+                          }
+                        ],
+                        "repeat": null,
+                        "repeatIteration": null,
+                        "repeatRowId": null,
+                        "showTitle": false,
+                        "title": "Dashboard Row",
+                        "titleSize": "h6",
+                        "type": "row"
+                      },
+                      {
+                        "collapse": false,
+                        "collapsed": false,
+                        "panels": [
+                          {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "gridPos": {},
+                            "id": 3,
+                            "legend": {
+                              "alignAsTable": true,
+                              "avg": true,
+                              "current": true,
+                              "max": false,
+                              "min": false,
+                              "rightSide": true,
+                              "show": true,
+                              "total": false,
+                              "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                              {
+                                "expr": "sum by (container) (irate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", image!=\"\", pod=\"$pod\", container=~\"$container\", container!=\"POD\"}[4m]))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Current: {{ container }}",
+                                "refId": "A"
+                              },
+                              {
+                                "expr": "sum by(container) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Requested: {{ container }}",
+                                "refId": "B"
+                              },
+                              {
+                                "expr": "sum by(container) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Limit: {{ container }}",
+                                "refId": "C"
+                              }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "CPU Usage",
+                            "tooltip": {
+                              "shared": false,
+                              "sort": 0,
+                              "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": []
+                            },
+                            "yaxes": [
+                              {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              },
+                              {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              }
+                            ]
+                          }
+                        ],
+                        "repeat": null,
+                        "repeatIteration": null,
+                        "repeatRowId": null,
+                        "showTitle": false,
+                        "title": "Dashboard Row",
+                        "titleSize": "h6",
+                        "type": "row"
+                      },
+                      {
+                        "collapse": false,
+                        "collapsed": false,
+                        "panels": [
+                          {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "gridPos": {},
+                            "id": 4,
+                            "legend": {
+                              "alignAsTable": true,
+                              "avg": true,
+                              "current": true,
+                              "max": false,
+                              "min": false,
+                              "rightSide": true,
+                              "show": true,
+                              "total": false,
+                              "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                              {
+                                "expr": "sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "RX: {{ pod }}",
+                                "refId": "A"
+                              },
+                              {
+                                "expr": "sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[4m])))",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "TX: {{ pod }}",
+                                "refId": "B"
+                              }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Network I/O",
+                            "tooltip": {
+                              "shared": false,
+                              "sort": 0,
+                              "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": []
+                            },
+                            "yaxes": [
+                              {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              },
+                              {
+                                "format": "bytes",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              }
+                            ]
+                          }
+                        ],
+                        "repeat": null,
+                        "repeatIteration": null,
+                        "repeatRowId": null,
+                        "showTitle": false,
+                        "title": "Dashboard Row",
+                        "titleSize": "h6",
+                        "type": "row"
+                      },
+                      {
+                        "collapse": false,
+                        "collapsed": false,
+                        "panels": [
+                          {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "gridPos": {},
+                            "id": 5,
+                            "legend": {
+                              "alignAsTable": true,
+                              "avg": true,
+                              "current": true,
+                              "max": false,
+                              "min": false,
+                              "rightSide": true,
+                              "show": true,
+                              "total": false,
+                              "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                              {
+                                "expr": "max by (container) (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"})",
+                                "format": "time_series",
+                                "intervalFactor": 2,
+                                "legendFormat": "Restarts: {{ container }}",
+                                "refId": "A"
+                              }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Total Restarts Per Container",
+                            "tooltip": {
+                              "shared": false,
+                              "sort": 0,
+                              "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": []
+                            },
+                            "yaxes": [
+                              {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              },
+                              {
+                                "format": "short",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": 0,
+                                "show": true
+                              }
+                            ]
+                          }
+                        ],
+                        "repeat": null,
+                        "repeatIteration": null,
+                        "repeatRowId": null,
+                        "showTitle": false,
+                        "title": "Dashboard Row",
+                        "titleSize": "h6",
+                        "type": "row"
+                      }
+                    ],
+                    "schemaVersion": 14,
+                    "style": "dark",
+                    "tags": ["kubernetes-mixin"],
+                    "templating": {
+                      "list": [
+                        {
+                          "current": {
+                            "text": "Prometheus-platform",
+                            "value": "Prometheus-platform"
+                          },
+                          "hide": 0,
+                          "label": null,
+                          "name": "datasource",
+                          "options": [],
+                          "query": "prometheus",
+                          "refresh": 1,
+                          "regex": "",
+                          "type": "datasource"
+                        },
+                        {
+                          "allValue": null,
+                          "current": {},
+                          "datasource": "$datasource",
+                          "hide": 2,
+                          "includeAll": false,
+                          "label": "cluster",
+                          "multi": false,
+                          "name": "cluster",
+                          "options": [],
+                          "query": "label_values(kube_pod_info, cluster)",
+                          "refresh": 2,
+                          "regex": "",
+                          "sort": 1,
+                          "tagValuesQuery": "",
+                          "tags": [],
+                          "tagsQuery": "",
+                          "type": "query",
+                          "useTags": false
+                        },
+                        {
+                          "allValue": null,
+                          "current": {},
+                          "datasource": "$datasource",
+                          "hide": 0,
+                          "includeAll": false,
+                          "label": "Namespace",
+                          "multi": false,
+                          "name": "namespace",
+                          "options": [],
+                          "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                          "refresh": 2,
+                          "regex": "/(.*team\\-#TEAM#.*)/",
+                          "sort": 1,
+                          "tagValuesQuery": "",
+                          "tags": [],
+                          "tagsQuery": "",
+                          "type": "query",
+                          "useTags": false
+                        },
+                        {
+                          "allValue": null,
+                          "current": {},
+                          "datasource": "$datasource",
+                          "hide": 0,
+                          "includeAll": false,
+                          "label": "Pod",
+                          "multi": false,
+                          "name": "pod",
+                          "options": [],
+                          "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=~\"$namespace\"}, pod)",
+                          "refresh": 2,
+                          "regex": "",
+                          "sort": 1,
+                          "tagValuesQuery": "",
+                          "tags": [],
+                          "tagsQuery": "",
+                          "type": "query",
+                          "useTags": false
+                        },
+                        {
+                          "allValue": null,
+                          "current": {},
+                          "datasource": "$datasource",
+                          "hide": 0,
+                          "includeAll": true,
+                          "label": "Container",
+                          "multi": false,
+                          "name": "container",
+                          "options": [],
+                          "query": "label_values(kube_pod_container_info{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}, container)",
+                          "refresh": 2,
+                          "regex": "",
+                          "sort": 1,
+                          "tagValuesQuery": "",
+                          "tags": [],
+                          "tagsQuery": "",
+                          "type": "query",
+                          "useTags": false
+                        }
+                      ]
+                    },
+                    "time": {
+                      "from": "now-1h",
+                      "to": "now"
+                    },
+                    "timepicker": {
+                      "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+                      "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+                    },
+                    "timezone": "",
+                    "title": "Custom / Pods",
+                    "uid": "ab4f13a9892a76a4d21ce8c2445bf4ea",
+                    "version": 0
+                  }

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1379,7 +1379,7 @@ definitions:
 
   dashboard:
     type: object
-    description: Define location of the application's manifests or chart
+    description: Make a custom Team Grafana dashboard persistent in otomi-values
     properties:
       name:
         $ref: '#/definitions/wordCharacterPattern'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1217,6 +1217,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/workload'
+      dashboards:
+        type: array
+        items:
+          $ref: '#/definitions/dashboard'
       projects:
         type: array
         items:
@@ -1372,6 +1376,19 @@ definitions:
     required:
       - name
       - url
+
+  dashboard:
+    type: object
+    description: Define location of the application's manifests or chart
+    properties:
+      name:
+        $ref: '#/definitions/wordCharacterPattern'
+      file:
+        description: URL to either Helm or Git repository
+        $ref: '#/definitions/files'
+    required:
+      - name
+      - file
 
 properties:
   alerts:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: kubeclarity
-console: kubeclarity-logo
+api: main
+console: main
 tasks: main
 tools: 1.4.25


### PR DESCRIPTION
Team Grafana dashboards in Otomi are automatically configured. If a dashboard is added manually and the team's Gafana instance restarts, all custom dashboards are lost. This PR adds the option to make custom dashboards persistent, by creating a custom-dashboards configmap in the team-namespace that will then be automatically loaded.
