### PR TITLE
feat: add azureblob for thanos

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2727,10 +2727,24 @@ properties:
                       - s3Url
                       - accessKeyId
                       - secretAccessKey
+                  azureBlob:
+                    properties:
+                      accountName:
+                        $ref: '#/definitions/wordCharacterPattern'
+                      containerName:
+                        $ref: '#/definitions/wordCharacterPattern'
+                      accountKey:
+                        $ref: '#/definitions/wordCharacterPattern'
+                        x-secret: ''
+                    required:
+                      - accountName
+                      - containerName
+                      - accountKey
                   type:
                     type: string
                     enum:
                       - s3
+                      - azureBlob
                       - minioLocal
                     default: minioLocal
           resources:

--- a/values/thanos/thanos.gotmpl
+++ b/values/thanos/thanos.gotmpl
@@ -103,6 +103,14 @@ objstoreConfig: |-
     secret_key: {{ $sp.s3.secretAccessKey }}
     insecure: true
 {{- end }}
+{{- if eq $sp.type "azureBlob" }}
+objstoreConfig: |-
+  type: azure
+    config:
+      account_name: {{ $sp.azureBlob.accountName }}
+      account_key: {{ $sp.azureBlob.accountKey }}
+      container_name: {{ $sp.azureBlob.containerName }}
+{{- end }}
 
 metrics:
   enabled: true


### PR DESCRIPTION
Add azure blob storage for Thanos 
## Checklist

- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
