### PR TITLE
feat: k8s 1.25 upgrade

### DIFF
--- a/charts/ingress-nginx/ci/deamonset-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-psp-values.yaml
@@ -9,5 +9,6 @@ controller:
   service:
     type: ClusterIP
 
+#Disabled for k8s 1.25
 podSecurityPolicy:
-  enabled: true
+  enabled: false

--- a/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
@@ -9,5 +9,6 @@ controller:
   service:
     type: ClusterIP
 
+#Disabled for k8s 1.25
 podSecurityPolicy:
-  enabled: true
+  enabled: false

--- a/charts/ingress-nginx/ci/deployment-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-psp-values.yaml
@@ -6,5 +6,6 @@ controller:
   service:
     type: ClusterIP
 
+#Disabled for k8s 1.25
 podSecurityPolicy:
-  enabled: true
+  enabled: false

--- a/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
@@ -8,5 +8,6 @@ controller:
   service:
     type: ClusterIP
 
+#Disabled for k8s 1.25
 podSecurityPolicy:
-  enabled: true
+  enabled: false

--- a/charts/kube-descheduler/templates/cronjob.yaml
+++ b/charts/kube-descheduler/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "descheduler.fullname" . }}

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,19 +1,23 @@
-apiVersion: v1
-appVersion: 0.16.0
+apiVersion: v2
 description: Prometheus Blackbox Exporter
-home: https://github.com/prometheus/blackbox_exporter
-keywords:
-- prometheus
-- blackbox
-- monitoring
-maintainers:
-- email: cedric@desaintmartin.fr
-  name: desaintmartin
-- email: gianrubio@gmail.com
-  name: gianrubio
-- email: me@sota.sh
-  name: rsotnychenko
 name: prometheus-blackbox-exporter
+version: 7.10.0
+appVersion: v0.24.0
+home: https://github.com/prometheus/blackbox_exporter
 sources:
-- https://github.com/prometheus/blackbox_exporter
-version: 4.1.1
+  - https://github.com/prometheus/blackbox_exporter
+  - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-blackbox-exporter
+keywords:
+  - prometheus
+  - blackbox
+  - monitoring
+maintainers:
+  - name: desaintmartin
+    email: cedric@desaintmartin.fr
+  - name: gianrubio
+    email: gianrubio@gmail.com
+  - name: rsotnychenko
+    email: me@sota.sh
+  - name: monotek
+    email: monotek23@gmail.com
+type: application

--- a/charts/prometheus-blackbox-exporter/OWNERS
+++ b/charts/prometheus-blackbox-exporter/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- desaintmartin
-- gianrubio
-reviewers:
-- desaintmartin
-- gianrubio

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -4,139 +4,104 @@ Prometheus exporter for blackbox testing
 
 Learn more: [https://github.com/prometheus/blackbox_exporter](https://github.com/prometheus/blackbox_exporter)
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-blackbox-exporter
-```
-
-## Introduction
-
 This chart creates a Blackbox-Exporter deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
+- Helm >= 3.0
 
-## Installing the Chart
+## Get Repository Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-blackbox-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
 ```
 
-The command deploys Blackbox Exporter on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
-
-```bash
-$ helm delete --purge my-release
-```
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Configuration
-
-The following table lists the configurable parameters of the Blackbox-Exporter chart and their default values.
-
-| Parameter                                 | Description                                                                      | Default                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `kind`                                    | You can choose between `Deployment` or `DaemonSet`                               | `Deployment`                                                                 |
-| `config`                                  | Prometheus blackbox configuration                                                | {}                                                                           |
-| `secretConfig`                            | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
-| `extraArgs`                               | Optional flags for blackbox                                                      | `[]`                                                                         |
-| `image.repository`                        | container image repository                                                       | `prom/blackbox-exporter`                                                     |
-| `image.tag`                               | container image tag                                                              | `v0.15.1`                                                                    |
-| `image.pullPolicy`                        | container image pull policy                                                      | `IfNotPresent`                                                               |
-| `image.pullSecrets`                       | container image pull secrets                                                     | `[]`                                                                         |
-| `ingress.annotations`                     | Ingress annotations                                                              | None                                                                         |
-| `ingress.enabled`                         | Enables Ingress                                                                  | `false`                                                                      |
-| `ingress.hosts`                           | Ingress accepted hostnames                                                       | None                                                                         |
-| `ingress.path`                            | Ingress accepted path                                                            | `/`                                                                         |
-| `ingress.tls`                             | Ingress TLS configuration                                                        | None                                                                         |
-| `nodeSelector`                            | node labels for pod assignment                                                   | `{}`                                                                         |
-| `runAsUser`                               | User to run blackbox-exporter container as                                       | `1000`                                                                       |
-| `readOnlyRootFilesystem`                  | Set blackbox-exporter file-system to read-only                                   | `true`                                                                       |
-| `runAsNonRoot`                            | Run blackbox-exporter as non-root                                                | `true`                                                                       |
-| `tolerations`                             | node tolerations for pod assignment                                              | `[]`                                                                         |
-| `affinity`                                | node affinity for pod assignment                                                 | `{}`                                                                         |
-| `podAnnotations`                          | annotations to add to each pod                                                   | `{}`                                                                         |
-| `podDisruptionBudget`                     | pod disruption budget                                                            | `{}`                                                                         |
-| `pspEnabled`                              | create pod security policy resources                                             | `true`                                                                       |
-| `priorityClassName`                       | priority class name                                                              | None                                                                         |
-| `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
-| `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
-| `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
-| `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
-| `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
-| `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
-| `service.labels`                          | additional labels for the service                                                | None                                                                         |
-| `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |
-| `service.port`                            | port for the blackbox http service                                               | `9115`                                                                       |
-| `service.externalIPs`                     | list of external ips                                                             | []                                                                           |
-| `serviceAccount.create`                   | Specifies whether a service account should be created.                           | `true`                                                                       |
-| `serviceAccount.name`                     | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
-| `serviceAccount.annotations`              | ServiceAccount annotations                                                       |                                                                              |
-| `serviceMonitor.enabled`                  | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
-| `serviceMonitor.defaults.labels`          | Labels for prometheus operator                                                   | `{}`                                                                         |
-| `serviceMonitor.defaults.interval`        | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
-| `serviceMonitor.defaults.scrapeTimeout`   | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
-| `serviceMonitor.defaults.module`          | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
-| `serviceMonitor.targets.[]`               | List of targets to scrape                                                        | `[]`                                                                         |
-| `serviceMonitor.targets.[].name`          | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
-| `serviceMonitor.targets.[].url`           | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
-| `serviceMonitor.targets.[].labels`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.labels }`                                        |
-| `serviceMonitor.targets.[].interval`      | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
-| `serviceMonitor.targets.[].scrapeTimeout` | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
-| `serviceMonitor.targets.[].module`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
-| `prometheusRule.enabled`                  | Set this to true to create PrometheusRule for Prometheus operator | `false`     |
-| `prometheusRule.additionalLabels`         | Additional labels that can be passed to PrometheusRule | `{}`  |
-| `prometheusRule.namespace`                | Namespace where PrometheusRule resource should be created |      |
-| `prometheusRule.rules`                    | [PrometheusRule](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created                      | `[]`                                                    |
-| `strategy`                                | strategy used to replace old Pods with new ones                                  | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-$ helm install --name my-release \
-    --set key_1=value_1,key_2=value_2 \
-    stable/prometheus-blackbox-exporter
+```console
+helm install [RELEASE_NAME] prometheus-community/prometheus-blackbox-exporter
 ```
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+_See [configuration](#configuration) below._
 
-```bash
-# example for staging
-$ helm install --name my-release -f values.yaml stable/prometheus-blackbox-exporter
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+This removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Upgrading an existing Release to a new major version
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-### 4.0.0
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 7.0.0
+
+This version introduces the `securityContext` and `podSecurityContext` and removes `allowICMP`option.
+
+All previous values are setup as default. In case that you want to enable previous functionality for `allowICMP` you need to explicit enabled with the following configuration:
+
+```yaml
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    add: ["NET_RAW"]
+```
+
+### To 6.0.0
+
+This version introduces the relabeling field for the ServiceMonitor.
+All values in the list `additionalRelabeling` will now appear under `relabelings` instead of `metricRelabelings`.
+
+### To 5.0.0
+
+This version removes Helm 2 support. Also the ingress config has changed, so you have to adapt to the example in the values.yaml.
+
+### To 4.0.0
 
 This version create the service account by default and introduce pod security policy, it can be enabled by setting `pspEnabled: true`.
 
-### 2.0.0
+### To 2.0.0
 
 This version removes the `podDisruptionBudget.enabled` parameter and changes the default value of `podDisruptionBudget` to `{}`, in order to fix Helm 3 compatibility.
 
 In order to upgrade, please remove `podDisruptionBudget.enabled` from your custom values.yaml file and set the content of `podDisruptionBudget`, for example:
+
 ```yaml
 podDisruptionBudget:
   maxUnavailable: 0
 ```
 
-### 1.0.0
+### To 1.0.0
 
 This version introduce the new recommended labels.
 
 In order to upgrade, delete the Deployment before upgrading:
+
 ```bash
-$ kubectl delete deployment my-release-prometheus-blackbox-exporter
+kubectl delete deployment [RELEASE_NAME]-prometheus-blackbox-exporter
 ```
 
 Note that this will cause downtime of the blackbox.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/prometheus-blackbox-exporter
+```

--- a/charts/prometheus-blackbox-exporter/ci/extraenv-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/extraenv-values.yaml
@@ -1,0 +1,3 @@
+extraEnv:
+  HTTP_PROXY: "http://superproxy.com:3128"
+  NO_PROXY: "localhost,127.0.0.1"

--- a/charts/prometheus-blackbox-exporter/ci/hostAliases.yml
+++ b/charts/prometheus-blackbox-exporter/ci/hostAliases.yml
@@ -1,0 +1,9 @@
+hostAliases:
+  - ip: 192.168.1.1
+    hostNames:
+      - test.example.com
+      - another.example.net
+  - ip: 192.168.1.2
+    hostNames:
+      - test2.example.com
+      - another2.example.net

--- a/charts/prometheus-blackbox-exporter/ci/icmp-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/icmp-values.yaml
@@ -1,1 +1,0 @@
-allowIcmp: true

--- a/charts/prometheus-blackbox-exporter/ci/networkpolicy-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/networkpolicy-values.yaml
@@ -1,0 +1,2 @@
+networkPolicy:
+  enabled: true

--- a/charts/prometheus-blackbox-exporter/templates/NOTES.txt
+++ b/charts/prometheus-blackbox-exporter/templates/NOTES.txt
@@ -1,1 +1,31 @@
 See https://github.com/prometheus/blackbox_exporter/ for how to configure Prometheus and the Blackbox Exporter.
+
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+
+{{- $kubeVersion := include "prometheus-blackbox-exporter.kubeVersion" . -}}
+{{ if and .Values.ingress.className (semverCompare "<=1.18-0" $kubeVersion) }}
+You've set ".Values.ingressClassName" but it's not supported by your Kubernetes version!
+Therefore the option was not added and the old ingress annotation was set.
+{{ end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-blackbox-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} svc -w {{ include "prometheus-blackbox-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} {{ include "prometheus-blackbox-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -l "app.kubernetes.io/name={{ include "prometheus-blackbox-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -1,56 +1,93 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "prometheus-blackbox-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "prometheus-blackbox-exporter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus-blackbox-exporter.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-blackbox-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+{{ include "prometheus-blackbox-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.releaseLabel }}
+release: {{ .Release.Name }}
+{{- end }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-blackbox-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "prometheus-blackbox-exporter.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "prometheus-blackbox-exporter.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-blackbox-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
 
 {{/*
-Generate a right Ingress apiVersion
+Return the appropriate apiVersion for rbac.
 */}}
-{{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
-networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-networking.k8s.io/v1beta1
-{{- else  -}}
-extensions/v1
-{{- end }}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
 {{- end -}}
 
+
+{{- define "prometheus-blackbox-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Enable overriding Kubernetes version for some use cases */}}
+{{- define "prometheus-blackbox-exporter.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}

--- a/charts/prometheus-blackbox-exporter/templates/configmap.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/configmap.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.config }}
+{{- if and .Values.config (eq .Values.configExistingSecretName "") }}
 apiVersion: v1
 kind: {{ if .Values.secretConfig -}} Secret {{- else -}} ConfigMap {{- end }}
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 {{ if .Values.secretConfig -}} stringData: {{- else -}} data: {{- end }}
   blackbox.yaml: |
 {{ toYaml .Values.config | indent 4 }}

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -3,26 +3,20 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-  strategy:
-{{ toYaml .Values.strategy | indent 4 }}
+      {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+        {{- include "prometheus-blackbox-exporter.labels" . | nindent 8 }}
+        {{- if .Values.pod.labels }}
+{{ toYaml .Values.pod.labels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
@@ -48,23 +42,45 @@ spec:
         - name: {{ . }}
       {{- end }}
     {{- end }}
-
+      {{- if .Values.hostAliases }}
+      hostAliases:
+        {{- range .Values.hostAliases }}
+        - ip: {{ .ip }}
+          hostnames:
+          {{- range .hostNames }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
 
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
         - name: blackbox-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-            runAsUser: {{ .Values.runAsUser }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+          {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
           args:
-{{- if .Values.config }}
+{{- if (or .Values.config .Values.configExistingSecretName) }}
+   {{- if .Values.configPath }}
+            - "--config.file={{ .Values.configPath }}"
+   {{- else }}
             - "--config.file=/config/blackbox.yaml"
+   {{- end }}
 {{- else }}
             - "--config.file=/etc/blackbox_exporter/config.yml"
 {{- end }}
@@ -95,11 +111,22 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+{{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | toString }}
+{{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+{{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+{{- end }}
       volumes:
         - name: config
 {{- if .Values.secretConfig }}
           secret:
             secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
+{{- else if .Values.configExistingSecretName }}
+          secret:
+            secretName: {{ .Values.configExistingSecretName }}
 {{- else }}
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -3,44 +3,46 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}
   strategy:
 {{ toYaml .Values.strategy | indent 4 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+        {{- include "prometheus-blackbox-exporter.labels" . | nindent 8 }}
+        {{- if .Values.pod.labels }}
+{{ toYaml .Values.pod.labels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
-    {{- if .Values.nodeSelector }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.affinity }}
+    {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.tolerations }}
+    {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -48,28 +50,50 @@ spec:
         - name: {{ . }}
       {{- end }}
     {{- end }}
-
+      {{- if .Values.hostAliases }}
+      hostAliases:
+        {{- range .Values.hostAliases }}
+        - ip: {{ .ip }}
+          hostnames:
+          {{- range .hostNames }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
 
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
+        {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8 }}
+        {{- end }}
         - name: blackbox-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            {{- if .Values.allowIcmp }}
-            capabilities:
-              add: ["NET_RAW"]
-            {{- else }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-            runAsUser: {{ .Values.runAsUser }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+          {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
           args:
 {{- if .Values.config }}
+   {{- if .Values.configPath }}
+            - "--config.file={{ .Values.configPath }}"
+   {{- else }}
             - "--config.file=/config/blackbox.yaml"
+   {{- end }}
 {{- else }}
             - "--config.file=/etc/blackbox_exporter/config.yml"
 {{- end }}
@@ -79,7 +103,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.containerPort }}
               name: http
           livenessProbe:
             {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
@@ -100,11 +124,28 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+          {{- end }}
+{{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | toString }}
+{{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+{{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+{{- end }}
       volumes:
+    {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+    {{- end }}
         - name: config
 {{- if .Values.secretConfig }}
           secret:
             secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
+{{- else if .Values.configExistingSecretName }}
+          secret:
+            secretName: {{ .Values.configExistingSecretName }}
 {{- else }}
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}

--- a/charts/prometheus-blackbox-exporter/templates/extra-manifests.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/prometheus-blackbox-exporter/templates/ingress.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/ingress.yaml
@@ -1,31 +1,66 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "prometheus-blackbox-exporter.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $fullName := include "prometheus-blackbox-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $kubeVersion := include "prometheus-blackbox-exporter.kubeVersion" . -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" $kubeVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" $kubeVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $kubeVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  name: {{ $fullName }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+    {{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+    {{- end}}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-    {{- end -}}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" $kubeVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $kubeVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $kubeVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}  
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}
+  ingress:
+{{- if .Values.networkPolicy.allowMonitoringNamespace }}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+{{- else }}
+  - {}
+{{- end }}
+  policyTypes:
+  - Ingress
+{{- end }}
+

--- a/charts/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,19 +1,18 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
-      helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+      {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.pspEnabled }}
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
   # Prevents running in privileged mode
   privileged: false
@@ -36,4 +34,8 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
+  {{- if has "NET_RAW" .Values.securityContext.capabilities.add }}
+  allowedCapabilities: 
+  - NET_RAW
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ . }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
     {{- with .Values.prometheusRule.additionalLabels -}}
 {{- toYaml . | nindent 4 -}}
     {{- end }}
@@ -18,6 +15,6 @@ spec:
   {{- with .Values.prometheusRule.rules }}
   groups:
     - name: {{ template "prometheus-blackbox-exporter.name" $ }}
-      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+      rules: {{ toYaml . | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/role.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/role.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
 rules:
   - apiGroups:
     - policy

--- a/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.serviceMonitor.selfMonitor.labels  }}
+    {{- toYaml (.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - path: /metrics
+    interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
+    scheme: http
+
+{{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
+{{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/service.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/service.yaml
@@ -1,29 +1,27 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
-  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
-  {{- if .Values.service.annotations }}
+{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
+  name: {{ include "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
+    - port: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
+      name: http
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
 {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-blackbox-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
+  name: {{ include "prometheus-blackbox-exporter.serviceAccountName" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-{{- end -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -5,18 +5,22 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
     {{- if or $.Values.serviceMonitor.defaults.labels .labels }}
     {{- toYaml (.labels | default $.Values.serviceMonitor.defaults.labels) | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
   - port: http
-    scheme: http
+    scheme: {{ $.Values.serviceMonitor.scheme }}
+    {{- if $.Values.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ $.Values.serviceMonitor.bearerTokenFile }}
+    {{- end }}
+    {{- if $.Values.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     path: "/probe"
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}
@@ -25,21 +29,31 @@ spec:
       - {{ .module | default $.Values.serviceMonitor.defaults.module }}
       target:
       - {{ .url }}
+      {{- if .hostname }}
+      hostname:
+      - {{ .hostname }}
+      {{- end }}
     metricRelabelings:
-      - sourceLabels: [__address__]
-        targetLabel: __param_target
-      - sourceLabels: [__param_target]
+      - sourceLabels: [instance]
         targetLabel: instance
-      - targetLabel: target
+        replacement: {{ .url }}
+      - sourceLabels: [target]
+        targetLabel: target
         replacement: {{ .name }}
+        {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
+      - targetLabel: {{ $targetLabel | quote }}
+        replacement: {{ $replacement | quote }}
+        {{- end }}
+{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling }}
+    relabelings:
+{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling) | indent 6 }}
+{{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ $.Release.Namespace }}
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
 {{- end }}
 {{- end }}
-

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -2,11 +2,73 @@ restartPolicy: Always
 
 kind: Deployment
 
+## Override the namespace
+##
+namespaceOverride: ""
+
+# Override Kubernetes version if your distribution does not follow semver v2
+kubeVersionOverride: ""
+
+## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+releaseLabel: false
+
 podDisruptionBudget: {}
   # maxUnavailable: 0
 
+## Allow automount the serviceaccount token for sidecar container (eg: oauthproxy)
+automountServiceAccountToken: false
+
+## Additional blackbox-exporter container environment variables
+## For instance to add a http_proxy
+##
+## extraEnv:
+##   HTTP_PROXY: "http://superproxy.com:3128"
+##   NO_PROXY: "localhost,127.0.0.1"
+extraEnv: {}
+
+extraVolumes: []
+  # - name: secret-blackbox-oauth-htpasswd
+  #   secret:
+  #     defaultMode: 420
+  #     secretName: blackbox-oauth-htpasswd
+  # - name: storage-volume
+  #   persistentVolumeClaim:
+  #     claimName: example
+
+## Additional volumes that will be attached to the blackbox-exporter container
+extraVolumeMounts:
+  # - name: ca-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+
+## Additional InitContainers to initialize the pod
+##
+extraInitContainers: []
+
+extraContainers: []
+  # - name: oAuth2-proxy
+  #   args:
+  #     - -https-address=:9116
+  #     - -upstream=http://localhost:9115
+  #     - -skip-auth-regex=^/metrics
+  #     - -openshift-delegate-urls={"/":{"group":"monitoring.coreos.com","resource":"prometheuses","verb":"get"}}
+  #   image: openshift/oauth-proxy:v1.1.0
+  #   ports:
+  #       - containerPort: 9116
+  #         name: proxy
+  #   resources:
+  #       limits:
+  #         memory: 16Mi
+  #       requests:
+  #         memory: 4Mi
+  #         cpu: 20m
+  #   volumeMounts:
+  #     - mountPath: /etc/prometheus/secrets/blackbox-tls
+  #       name: secret-blackbox-tls
+
 ## Enable pod security policy
 pspEnabled: true
+
+hostNetwork: false
 
 strategy:
   rollingUpdate:
@@ -16,7 +78,8 @@ strategy:
 
 image:
   repository: prom/blackbox-exporter
-  tag: v0.16.0
+  # if not set appVersion field from Chart.yaml is used
+  tag: ""
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -26,25 +89,51 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## User to run blackbox-exporter container as
-runAsUser: 1000
-readOnlyRootFilesystem: true
-runAsNonRoot: true
+podSecurityContext: {}
+# fsGroup: 1000
+
+## User and Group to run blackbox-exporter container as
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+# Add NET_RAW to enable ICMP
+#    add: ["NET_RAW"]
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
+  failureThreshold: 3
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 nodeSelector: {}
 tolerations: []
 affinity: {}
 
+## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: failure-domain.beta.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+#       app.kubernetes.io/instance: jiralert
+
+# if the configuration is managed as secret outside the chart, using SealedSecret for example,
+# provide the name of the secret here. If secretConfig is set to true, configExistingSecretName will be ignored
+# in favor of the config value.
+configExistingSecretName: ""
+# Store the configuration as a `Secret` instead of a `ConfigMap`, useful in case it contains sensitive data
 secretConfig: false
 config:
   modules:
@@ -52,9 +141,12 @@ config:
       prober: http
       timeout: 5s
       http:
-        valid_http_versions: ["HTTP/1.1", "HTTP/2"]
-        no_follow_redirects: false
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        follow_redirects: true
         preferred_ip_protocol: "ip4"
+
+# Set custom config path, other than default /config/blackbox.yaml. If let empty, path will be "/config/blackbox.yaml"
+# configPath: "/foo/bar"
 
 extraConfigmapMounts: []
   # - name: certs-configmap
@@ -73,8 +165,6 @@ extraSecretMounts: []
   #   readOnly: true
   #   defaultMode: 420
 
-allowIcmp: false
-
 resources: {}
   # limits:
   #   memory: 300Mi
@@ -85,8 +175,13 @@ priorityClassName: ""
 
 service:
   annotations: {}
+  labels: {}
   type: ClusterIP
   port: 9115
+
+# Only changes container port. Application port can be changed with extraArgs (--web.listen-address=:9115)
+# https://github.com/prometheus/blackbox_exporter/blob/998037b5b40c1de5fee348ffdea8820509d85171/main.go#L55
+containerPort: 9115
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
@@ -102,45 +197,81 @@ serviceAccount:
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  hosts: []
-     # - chart-example.local
-  path: '/'
+  className: ""
+  labels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 podAnnotations: {}
 
+# Hostaliases allow to add additional DNS entries to be injected directly into pods.
+# This will take precedence over your implemented DNS solution
+hostAliases: []
+#  - ip: 192.168.1.1
+#    hostNames:
+#      - test.example.com
+#      - another.example.net
+
+pod:
+  labels: {}
+
 extraArgs: []
-#  --history.limit=1000
+  # - --history.limit=1000
 
 replicas: 1
 
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
-  ## https://github.com/coreos/prometheus-operator
+  ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
+  ##
+  selfMonitor:
+    enabled: false
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
+    labels: {}
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator for each target
   ##
   enabled: false
 
   # Default values that will be used for all ServiceMonitors created by `targets`
   defaults:
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
     labels: {}
     interval: 30s
     scrapeTimeout: 30s
     module: http_2xx
+  ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+  scheme: http
+  ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  tlsConfig: {}
+  bearerTokenFile:
 
   targets:
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
 #      url: http://example.com/healthz  # The URL that blackbox will scrape
-#      labels: {}                       # List of labels for ServiceMonitor. Overrides value set in `defaults`
+#      hostname: example.com            # HTTP probes can accept an additional `hostname` parameter that will set `Host` header and TLS SNI
+#      labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
 #      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
 #      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
 #      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`
+#      additionalMetricsRelabels: {}    # Map of metric labels and values to add
+#      additionalRelabeling: []         # List of metric relabeling actions to run
 
 ## Custom PrometheusRules to be defined
 ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
@@ -149,3 +280,30 @@ prometheusRule:
   additionalLabels: {}
   namespace: ""
   rules: []
+
+## Network policy for chart
+networkPolicy:
+  # Enable network policy and allow access from anywhere
+  enabled: false
+  # Limit access only from monitoring namespace
+  # Before setting this value to true, you must add the name=monitoring label to the monitoring namespace
+  # Network Policy uses label filtering
+  allowMonitoringNamespace: false
+
+## dnsPolicy and dnsConfig for Deployments and Daemonsets if you want non-default settings.
+## These will be passed directly to the PodSpec of same.
+dnsPolicy:
+dnsConfig:
+
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #   labels:
+  #     name: prometheus-extra
+  #   data:
+  #     extra-data: "value"
+
+# global common labels, applied to all ressources
+commonLabels: {}

--- a/tests/fixtures/env/cluster.yaml
+++ b/tests/fixtures/env/cluster.yaml
@@ -3,7 +3,7 @@ cluster:
     apiServer: https://1.1.1.1:8443
     domainSuffix: demo.eks.otomi.cloud
     k8sContext: otomi-eks-demo
-    k8sVersion: '1.24'
+    k8sVersion: '1.25'
     name: demo
     owner: redkubes
     provider: custom

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -606,6 +606,7 @@ definitions:
     enum:
       - '1.23'
       - '1.24'
+      - '1.25'
     type: string
   labels:
     $ref: '#/definitions/labelsAnnotations'

--- a/values/falco/falco.gotmpl
+++ b/values/falco/falco.gotmpl
@@ -40,8 +40,9 @@ driver:
 
 falcosidekick:
   enabled: true
+  #Disabled for k8s 1.25
   podSecurityPolicy:
-    create: true
+    create: false
   config:
     debug: false
     {{- if $v.apps.alertmanager.enabled }}

--- a/values/gatekeeper/gatekeeper.gotmpl
+++ b/values/gatekeeper/gatekeeper.gotmpl
@@ -65,3 +65,7 @@ crds:
       memory: 64Mi
 
 otomiVersions: {{- toYaml .Values.versions | nindent 2 }}
+
+#Disable for k8s 1.25
+psp:
+  enabled: false

--- a/values/kiali-operator/kiali-operator.gotmpl
+++ b/values/kiali-operator/kiali-operator.gotmpl
@@ -5,7 +5,7 @@
 
 image:
   {{- with .Values.otomi | get "globalPullSecret" nil }}
-  imagePullSecrets:
+  pullSecrets:
     - name: otomi-pullsecret-global
   {{- end }}
 

--- a/values/kiali-operator/kiali-operator.gotmpl
+++ b/values/kiali-operator/kiali-operator.gotmpl
@@ -3,11 +3,11 @@
 {{- $kk := $v.apps.keycloak }}
 {{- $appsDomain := printf "apps.%s" $v.cluster.domainSuffix }}
 
+{{- with .Values.otomi | get "globalPullSecret" nil }}
 image:
-  {{- with .Values.otomi | get "globalPullSecret" nil }}
   pullSecrets:
     - name: otomi-pullsecret-global
-  {{- end }}
+{{- end }}
 
 podAnnotations:
   policy.otomi.io/ignore: psp-allowed-users

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -17,7 +17,7 @@ config:
 
 replicas: 2
 podDisruptionBudget:
-  enabled: true
+  enabled: false
   minAvailable: 1
 priorityClassName: otomi-critical
 resources:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
