### PR TITLE
feat: allow to configure istio mesh config

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -232,6 +232,12 @@ environments:
                 maxReplicas: 10
             egressGateway:
               enabled: false
+            meshConfig:
+              accessLogFile: "/dev/stdout"
+              enableAutoMtls: true
+              defaultConfig:
+                tracing:
+                  sampling: 0.1
           jaeger:
             enabled: false
           keycloak:

--- a/tests/fixtures/env/apps/istio.yaml
+++ b/tests/fixtures/env/apps/istio.yaml
@@ -41,3 +41,11 @@ apps:
                 requests:
                     cpu: 20m
                     memory: 80Mi
+        meshConfig:
+            extensionProviders:
+                - name: 'ext-authz-chain-grpc'
+                  envoyExtAuthzGrpc:
+                  service: 's1.test.svc.cluster.local'
+                  port: '80'
+                  includeRequestBodyInCheck:
+                      maxRequestBytes: 1000000

--- a/tests/kind/env/apps/istio.yaml
+++ b/tests/kind/env/apps/istio.yaml
@@ -1,24 +1,33 @@
 apps:
-    istio:
-        resources:
-            ingressgateway:
-                limits:
-                    cpu: 500m
-                    memory: 256Mi
-                requests:
-                    cpu: 100m
-                    memory: 128Mi
-            pilot:
-                limits:
-                    cpu: 100m
-                    memory: 256Mi
-                requests:
-                    cpu: 10m
-                    memory: 100Mi
-            prometheus:
-                limits:
-                    cpu: 500m
-                    memory: 1Gi
-                requests:
-                    cpu: 200m
-                    memory: 500Mi
+  istio:
+    resources:
+      ingressgateway:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      pilot:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 100Mi
+      prometheus:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 500Mi
+    meshConfig:
+      defaultConfig:
+        extensionProviders:
+          - name: 'ext-authz-chain-grpc'
+            envoyExtAuthzGrpc:
+              service: 's1.test.svc.cluster.local'
+              port: '80'
+              includeRequestBodyInCheck:
+                maxRequestBytes: 1000000

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2089,7 +2089,7 @@ properties:
                   resources:
                     $ref: '#/definitions/resources'
           meshConfig:
-            descrition: 'See: https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig'
+            description: 'See: https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig'
             type: object
           image:
             $ref: '#/definitions/imageSimple'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2089,6 +2089,7 @@ properties:
                   resources:
                     $ref: '#/definitions/resources'
           meshConfig:
+            descrition: 'See: https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig'
             type: object
           image:
             $ref: '#/definitions/imageSimple'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2089,11 +2089,7 @@ properties:
                   resources:
                     $ref: '#/definitions/resources'
           meshConfig:
-            properties:
-              defaultConfig:
-                type: object
-            required:
-              - defaultConfig
+            type: object
           image:
             $ref: '#/definitions/imageSimple'
           resources:

--- a/values/istio-operator/istio-operator-raw.gotmpl
+++ b/values/istio-operator/istio-operator-raw.gotmpl
@@ -153,16 +153,7 @@ resources:
             zipkin:
               address: jaeger-operator-jaeger-collector.jaeger:9411 
           useMCP: false
-        meshConfig:
-          accessLogFile: "/dev/stdout"
-          defaultConfig:
-          {{ with $i | get "meshConfig.defaultConfig" nil }}
-            {{- toYaml . | nindent 14 }}
-          {{- else }}
-            tracing:
-              sampling: 0.1
-          {{- end }}
-          enableAutoMtls: true
+        meshConfig: {{- $i.meshConfig | toYaml | nindent 10 }}
         {{- if $v._derived.untrustedCA }}
         pilot:
           jwksResolverExtraRootCA: |


### PR DESCRIPTION
This change allows full control over the service mesh configuration throw the values repo.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
