### PR TITLE
fix: alert manager default receiver

### DIFF
--- a/helmfile.d/snippets/alertmanager.gotmpl
+++ b/helmfile.d/snippets/alertmanager.gotmpl
@@ -65,12 +65,13 @@ receivers:
   - name: "null"
 {{- if or (has "slack" $receivers ) (has "opsgenie" $receivers) (has "msteams" $receivers) (has "email" $receivers) }}
   - name: default
-{{- if has "slack" $receivers  }}
+{{- end }}
+    {{- if has "slack" $receivers  }}
     slack_configs:
       - channel: "#{{ .instance | get "alerts.slack.channel" (.root | get "alerts.slack.channel" "mon-otomi") }}"
         send_resolved: true
         {{- .slackTpl | nindent 8 }}
-{{- end }}
+    {{- end }}
 {{- if has "opsgenie" $receivers  }}
     opsgenie_configs:
       - priority: "P2"
@@ -91,9 +92,10 @@ receivers:
         send_resolved: true
     {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if or (has "slack" $receivers ) (has "opsgenie" $receivers) (has "msteams" $receivers) (has "email" $receivers) }}
   - name: critical
+{{- end }}
 {{- if has "slack" $receivers  }}
     slack_configs:
       - channel: "#{{ .instance | get "alerts.slack.channelCrit" (.root | get "alerts.slack.channelCrit" "mon-otomi-crit") }}"
@@ -119,7 +121,7 @@ receivers:
         send_resolved: true
     {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if $isHomeMonitored }}
   - name: critical-home
   {{- $receivers := .root.home | get "receivers" }}


### PR DESCRIPTION
Some logic improvements to enable the "null" receiver when no receiver is configured in Otomi