### PR TITLE
fix: cloudtty image versioning

### DIFF
--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '2'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -47,7 +47,7 @@ jobs:
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo printing output of condition -------------------------------
-            git show --name-only --pretty="" HEAD 
+            git show --name-only --pretty="" ${{ github.sha }} 
             # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi
           echo OLD_VERSION = ${OLD_VERSION}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -47,6 +47,7 @@ jobs:
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo printing output of condition -------------------------------
+            echo git show --name-only --pretty="" ${{ github.sha }}
             git show --name-only --pretty="" ${{ github.sha }} 
             # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -53,6 +53,8 @@ jobs:
           fi
           echo git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
           git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
+          echo git version
+          git version
           echo OLD_VERSION = ${OLD_VERSION}
           echo NEW_VERSION = ${NEW_VERSION}
 

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -43,12 +43,12 @@ jobs:
             # If a "[MINOR]" commit is found, increment the minor version by one and reset the patch version to '0'.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$2 = $2 + 1; $3 = 0} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
-          elif git show --name-only --pretty="" HEAD | grep -q "tools\/Dockerfile-tty"; then
+          elif git diff --name-only ${{ github.sha }}..HEAD | grep -q "tools\/Dockerfile-tty"; then
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo printing output of condition -------------------------------
-            echo git show --name-only --pretty="" ${{ github.sha }}
-            git show --name-only --pretty="" ${{ github.sha }} 
+            echo git diff --name-only ${{ github.sha }}..HEAD
+            git diff --name-only ${{ github.sha }}..HEAD
             # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi
           echo OLD_VERSION = ${OLD_VERSION}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -41,25 +41,23 @@ jobs:
             # If a "[MAJOR]" commit is found, increment the major version by one and reset the minor and patch version to '0'.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$1 = $1 + 1; $2 = 0; $3 = 0} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+            echo OLD_VERSION = ${OLD_VERSION}
+            echo NEW_VERSION = ${NEW_VERSION}
           elif git log --format=%B -n 1 ${{ github.sha }} | grep -q "\[MINOR\]"; then
             # If a "[MINOR]" commit is found, increment the minor version by one and reset the patch version to '0'.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$2 = $2 + 1; $3 = 0} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+            echo OLD_VERSION = ${OLD_VERSION}
+            echo NEW_VERSION = ${NEW_VERSION}
           elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q "tools\/Dockerfile-tty"; then
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
-            echo printing output of condition -------------------------------
-            echo git diff --name-only ${{ github.sha }}..HEAD
-            git diff --name-only ${{ github.sha }}..HEAD
-            # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+            echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+            echo OLD_VERSION = ${OLD_VERSION}
+            echo NEW_VERSION = ${NEW_VERSION}
           fi
-          echo git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
-          git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
-          echo git version
-          git version
-          echo OLD_VERSION = ${OLD_VERSION}
-          echo NEW_VERSION = ${NEW_VERSION}
 
+          echo "No need to bump the version. Will skip next steps."
       - name: Build and tag Docker image
         if: ${{ env.NEW_VERSION != null }}
         run: |

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -43,7 +43,7 @@ jobs:
             # If a "[MINOR]" commit is found, increment the minor version by one and reset the patch version to '0'.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$2 = $2 + 1; $3 = 0} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
-          elif git diff --name-only ${{ github.sha }}..HEAD | grep -q "tools\/Dockerfile-tty"; then
+          elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q "tools\/Dockerfile-tty"; then
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo printing output of condition -------------------------------
@@ -51,8 +51,8 @@ jobs:
             git diff --name-only ${{ github.sha }}..HEAD
             # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi
-          echo git diff --name-only ${{ github.sha }}..HEAD
-          git diff --name-only ${{ github.sha }}..HEAD
+          echo git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
+          git diff-tree --no-commit-id --name-only ${{ github.sha }} -r
           echo OLD_VERSION = ${OLD_VERSION}
           echo NEW_VERSION = ${NEW_VERSION}
 

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -51,6 +51,8 @@ jobs:
             git diff --name-only ${{ github.sha }}..HEAD
             # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi
+          echo git diff --name-only ${{ github.sha }}..HEAD
+          git diff --name-only ${{ github.sha }}..HEAD
           echo OLD_VERSION = ${OLD_VERSION}
           echo NEW_VERSION = ${NEW_VERSION}
 

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -3,7 +3,7 @@ name: CloudTTY Build and Versioning
 on:
   push:
     branches:
-      - 'main'
+      - 'ani/fix/cloudtty-pipeline'
 
 env:
   NAMESPACE: otomi
@@ -46,7 +46,9 @@ jobs:
           elif git show --name-only --pretty="" HEAD | grep -q "tools\/Dockerfile-tty"; then
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
-            echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+            echo printing output of condition -------------------------------
+            git show --name-only --pretty="" HEAD 
+            # echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
           fi
           echo OLD_VERSION = ${OLD_VERSION}
           echo NEW_VERSION = ${NEW_VERSION}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -3,7 +3,7 @@ name: CloudTTY Build and Versioning
 on:
   push:
     branches:
-      - 'ani/fix/cloudtty-pipeline'
+      - 'main'
 
 env:
   NAMESPACE: otomi


### PR DESCRIPTION
The default fetch-depth of the "actions/checkout@v3" is '1', so when we checked for the files modified in the last commit it was showing all the files in the repo. This way the third if condition was being triggered and bumped the patch version on every commit to the main branch. 
Setting the fetch-depth to '2' solves the issue by comparing the last commit with the previous one. This way the 3rd if condition is validated correctly.
I also rewrote the git command for a more programatic  one and added some echo to show the version change.