### PR TITLE
fix: added upgrade script for kube prom stack

### DIFF
--- a/upgrades/pre/upgrade-0-22-0.sh
+++ b/upgrades/pre/upgrade-0-22-0.sh
@@ -9,4 +9,4 @@ helm uninstall -n kube-system kured
 
 [[ ! $(helm status -n monitoring prometheus-operator) ]] && echo "The old prometheus-operator release does not exists. Skipping" && exit 0
 # It is safe to uninstall the release as it is stateless app.
-helm uninstall -n monitoring prometheus-operator0
+helm uninstall -n monitoring prometheus-operator

--- a/upgrades/pre/upgrade-0-22-0.sh
+++ b/upgrades/pre/upgrade-0-22-0.sh
@@ -5,3 +5,8 @@ set -eu
 [[ ! $(helm status -n kube-system kured) ]] && echo "The old kured release does not exists. Skipping" && exit 0
 # It is safe to uninstall the release as it is stateless app.
 helm uninstall -n kube-system kured
+
+
+[[ ! $(helm status -n monitoring prometheus-operator) ]] && echo "The old prometheus-operator release does not exists. Skipping" && exit 0
+# It is safe to uninstall the release as it is stateless app.
+helm uninstall -n monitoring prometheus-operator0


### PR DESCRIPTION
The script will uninstall the "prometheus-operator" release before upgrading to any otomi version prior to 0.22.0.