### PR TITLE
fix: thanos receive ingress path

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -376,7 +376,7 @@ adminApps:
       - svc: thanos-receive
         port: 19291
         namespace: monitoring
-        paths: [/api/v1/receive/]
+        paths: [/api]
         forwardPath: true
         type: public
   - name: trivy


### PR DESCRIPTION
Fix for ingress configuration to enable remote-write to Thanos for external clusters 
