### PR TITLE
feat: upgrading istio-operator to 1.17.4

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -158,7 +158,7 @@ appsInfo:
     integration: Otomi integrated ingress-nginx into an advanced ingress architecture.
   istio:
     title: Istio
-    appVersion: 1.16.4
+    appVersion: 1.17.4
     repo: https://github.com/istio/istio
     maintainers: Istio
     relatedLinks:

--- a/charts/istio-operator/Chart.yaml
+++ b/charts/istio-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: istio-operator
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
-version: 1.16.4
-appVersion: 1.16.4
+version: 1.17.4
+appVersion: 1.17.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:

--- a/charts/istio-operator/files/gen-operator.yaml
+++ b/charts/istio-operator/files/gen-operator.yaml
@@ -178,7 +178,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.17-dev
+          image: istio/operator:1.17.4
           command:
           - operator
           - server

--- a/charts/istio-operator/files/gen-operator.yaml
+++ b/charts/istio-operator/files/gen-operator.yaml
@@ -171,14 +171,19 @@ spec:
     metadata:
       labels:
         name: istio-operator
+      annotations:
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: istio/operator:1.16.4
+          image: gcr.io/istio-testing/operator:1.17-dev
           command:
           - operator
           - server
+          - --monitoring-host=127.0.0.1
+          - --monitoring-port=15014
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -189,7 +194,6 @@ spec:
             runAsGroup: 1337
             runAsUser: 1337
             runAsNonRoot: true
-          imagePullPolicy: IfNotPresent
           resources:
             limits:
               cpu: 200m

--- a/charts/istio-operator/templates/deployment.yaml
+++ b/charts/istio-operator/templates/deployment.yaml
@@ -16,8 +16,10 @@ spec:
         {{- range $key, $val := .Values.podLabels }}
         {{ $key }}: "{{ $val }}"
         {{- end }}
-    {{- if .Values.podAnnotations }}
       annotations:
+        prometheus.io/port: "{{ .Values.operator.monitoring.port }}"
+        prometheus.io/scrape: "true"
+    {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
     spec:
@@ -28,6 +30,8 @@ spec:
           command:
           - operator
           - server
+          - --monitoring-host={{ .Values.operator.monitoring.host }}
+          - --monitoring-port={{ .Values.operator.monitoring.port }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -42,7 +46,9 @@ spec:
             seccompProfile:
 {{ toYaml .Values.operator.seccompProfile | trim | indent 14 }}
 {{- end }}
-          imagePullPolicy: IfNotPresent
+{{- if .Values.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+{{- end }}
           resources:
 {{ toYaml .Values.operator.resources | trim | indent 12 }}
           env:

--- a/charts/istio-operator/values.yaml
+++ b/charts/istio-operator/values.yaml
@@ -1,9 +1,13 @@
 hub: docker.io/istio
-tag: 1.16.4
+tag: 1.17.4
 
 # ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
 # used to pull operator image. Must be set for any cluster configured with private docker registry.
 imagePullSecrets: []
+
+# Specify image pull policy if default behavior isn't desired.
+# Default behavior: latest images will be Always else IfNotPresent.
+imagePullPolicy: ""
 
 # Used to replace istioNamespace to support operator watch multiple namespaces.
 watchedNamespaces: istio-system
@@ -20,6 +24,9 @@ deploymentHistory: 10
 
 # Operator resource defaults
 operator:
+  monitoring:
+    host: 127.0.0.1
+    port: 15014
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [x] Helm releases are meeting otomi's baseline security policies, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
