### PR TITLE
fix: added all apiGroups instead of only core

### DIFF
--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -104,7 +104,7 @@ metadata:
   labels: {{- include "team-ns.chart-labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - ''
+      - '*'
     resources:
       - '*'
     verbs:


### PR DESCRIPTION
This MR will fix the tty role so users can access all apiGroups in their namespace. If we don't define '*' than the role gives access only to the core apiGroup.
