### PR TITLE
fix: gucci

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,9 +58,9 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "name": "Bootstrap",
+      "name": "Bootstrap-dev",
       "request": "launch",
-      "runtimeArgs": ["run", "bootstrap"],
+      "runtimeArgs": ["run", "bootstrap-dev"],
       "runtimeExecutable": "npm",
       "type": "node",
       "envFile": ".env",

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v1.4.27 as prod
+FROM otomi/tools:v1.4.28 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "validate-templates": "NODE_ENV=test binzx/otomi validate-templates",
     "validate-templates:all": "set -e; i=19; while [ $i -le 23 ]; do NODE_ENV=test binzx/otomi validate-templates -k 1.$i; i=$(($i+1)); done",
     "validate-values": "NODE_ENV=test binzx/otomi validate-values",
-    "bootstrap-dev": "rm -rf /tmp/otomi-bootstrap-dev; CI=1 VALUES_INPUT=$PWD/tests/bootstrap/input.yaml ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap"
+    "bootstrap-dev": "rm -rf /tmp/otomi-bootstrap-dev; CI=1 VALUES_INPUT=$PWD/tests/bootstrap/input.yaml ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap",
+    "bootstrap-dev-with-repo": "CI=1 ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap"
   },
   "standard-version": {
     "skip": {

--- a/src/cmd/migrate.test.ts
+++ b/src/cmd/migrate.test.ts
@@ -27,14 +27,14 @@ describe('Upgrading values', () => {
       version: 2,
       deletions: ['some.json.path'],
       relocations: [{ 'some.json': 'some.bla' }],
-      mutations: [{ strToArray: 'list .prev' }],
+      // mutations: [{ strToArray: 'list .prev' }],
     },
     {
       version: 3,
       mutations: [
-        { 'some.k8sVersion': 'printf "v%s" .prev' },
+        // { 'some.k8sVersion': 'printf "v%s" .prev' },
         { 'teamConfig.{team}.services[].prop': 'replaced' },
-        { 'teamConfig.{team}.services[].bla[].ok': 'print .prev "ee"' },
+        // { 'teamConfig.{team}.services[].bla[].ok': 'print .prev "ee"' },
       ],
       renamings: [{ 'somefile.yaml': 'newloc.yaml' }],
     },

--- a/src/cmd/migrate.test.ts
+++ b/src/cmd/migrate.test.ts
@@ -15,19 +15,17 @@ describe('Upgrading values', () => {
       },
     },
     version: oldVersion,
-    strToArray: 'ok',
     some: { json: { path: 'bla' }, k8sVersion: '1.18' },
   }
   const mockChanges: Changes = [
     {
       version: 1,
-      mutations: [{ 'some.version': 'printf "v%s" .prev' }],
+      // mutations: [{ 'some.version': 'printf "v%s" .prev' }],
     },
     {
       version: 2,
       deletions: ['some.json.path'],
       relocations: [{ 'some.json': 'some.bla' }],
-      // mutations: [{ strToArray: 'list .prev' }],
     },
     {
       version: 3,
@@ -60,13 +58,12 @@ describe('Upgrading values', () => {
           teamConfig: {
             teamA: {
               services: [
-                { name: 'svc1', prop: 'replaced', bla: [{ ok: 'replaceMeee' }] },
+                { name: 'svc1', prop: 'replaced', bla: [{ ok: 'replaceMe' }] },
                 { name: 'svc1', prop: 'replaced', di: [{ ok: 'replaceMeNot' }] },
               ],
             },
           },
-          some: { bla: {}, k8sVersion: 'v1.18' },
-          strToArray: ['ok'],
+          some: { bla: {}, k8sVersion: '1.18' },
           version: 3,
         },
         true,

--- a/src/common/values.test.ts
+++ b/src/common/values.test.ts
@@ -7,7 +7,6 @@ const { terminal } = stubs
 describe('generateSecrets', () => {
   const values = { one: 'val', secret: 'prop', apps: { yo: { di: { lo: 'loves you' } } } }
   const simpleTemplate = '"dummy"'
-  const twoStageTemplate = '.dot.templatedSecret | upper'
   const schema = {
     properties: {
       one: {
@@ -30,7 +29,7 @@ describe('generateSecrets', () => {
               },
               mama: {
                 type: 'string',
-                'x-secret': 'printf "%s!" .v.di.lo',
+                'x-secret': '{{ printf "%s!" loves you }}',
               },
             },
           },
@@ -42,17 +41,13 @@ describe('generateSecrets', () => {
             type: 'string',
             'x-secret': simpleTemplate,
           },
-          twoStage: {
-            type: 'string',
-            'x-secret': twoStageTemplate,
-          },
         },
       },
     },
   }
   const expected = {
     secret: 'prop',
-    nested: { templatedSecret: 'dummy', twoStage: 'DUMMY' },
+    nested: { templatedSecret: 'dummy' },
     apps: { yo: { mama: 'loves you!' } },
   }
   let deps

--- a/src/common/values.test.ts
+++ b/src/common/values.test.ts
@@ -6,7 +6,7 @@ const { terminal } = stubs
 
 describe('generateSecrets', () => {
   const values = { one: 'val', secret: 'prop', apps: { yo: { di: { lo: 'loves you' } } } }
-  const simpleTemplate = '"dummy"'
+  const simpleTemplate = 'dummy'
   const schema = {
     properties: {
       one: {
@@ -29,7 +29,7 @@ describe('generateSecrets', () => {
               },
               mama: {
                 type: 'string',
-                'x-secret': '{{ printf "%s!" loves you }}',
+                'x-secret': '{{ printf "%s!" "loves you" }}',
               },
             },
           },
@@ -40,6 +40,10 @@ describe('generateSecrets', () => {
           templatedSecret: {
             type: 'string',
             'x-secret': simpleTemplate,
+          },
+          twoStage: {
+            type: 'string',
+            'x-secret': '',
           },
         },
       },

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -254,7 +254,7 @@ export const deriveSecrets = async (values: Record<string, any> = {}): Promise<R
   // Some secrets needs to be drived from the generated secrets
 
   const secrets = {}
-  if (values.apps.harbor.enabled) {
+  if (values?.apps?.harbor?.enabled) {
     const htpasswd = (
       await $`htpasswd -nbB ${values.apps.harbor.registry.credentials.username} ${values.apps.harbor.registry.credentials.password}`
     ).stdout.trim()

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -1,22 +1,15 @@
 import { JSONSchema } from '@apidevtools/json-schema-ref-parser'
 import { pathExists } from 'fs-extra'
 import { unlink, writeFile } from 'fs/promises'
-import { cloneDeep, get, isEmpty, isEqual, merge, omit, pick, set } from 'lodash'
+import { cloneDeep, get, isEmpty, isEqual, merge, omit, pick } from 'lodash'
 import { stringify } from 'yaml'
+import { $ } from 'zx'
 import { decrypt, encrypt } from './crypt'
 import { terminal } from './debug'
 import { env } from './envalid'
 import { hfValues } from './hf'
-import {
-  extract,
-  flattenObject,
-  getValuesSchema,
-  gucci,
-  loadYaml,
-  pkg,
-  removeBlankAttributes,
-  stringContainsSome,
-} from './utils'
+import { extract, flattenObject, getValuesSchema, gucci, loadYaml, pkg, removeBlankAttributes } from './utils'
+
 import { HelmArguments } from './yargs'
 
 const objectToYaml = (obj: Record<string, any>): string => {
@@ -257,6 +250,25 @@ export const writeValues = async (inValues: Record<string, any>, overwrite = fal
   d.info('All values were written to ENV_DIR')
 }
 
+export const deriveSecrets = async (values: Record<string, any> = {}): Promise<Record<string, any>> => {
+  // Some secrets needs to be drived from the generated secrets
+  const htpasswd = (
+    await $`htpasswd -nbB ${values.apps.harbor.registry.credentials.username} ${values.apps.harbor.registry.credentials.password}`
+  ).stdout.trim()
+  const derivedSecrets = {
+    apps: {
+      harbor: {
+        registry: {
+          credentials: {
+            htpasswd,
+          },
+        },
+      },
+    },
+  }
+
+  return derivedSecrets
+}
 /**
  * Takes values as input and generates secrets that don't exist yet.
  * Returns all generated secrets.
@@ -270,65 +282,25 @@ export const generateSecrets = async (
 ): Promise<Record<string, any>> => {
   const d = deps.terminal('common:values:generateSecrets')
   const leaf = 'x-secret'
-  const localRefs = ['.dot.', '.v.', '.root.', '.o.']
-
   const schema = await deps.getValuesSchema()
 
   d.info('Extracting secrets')
-  const secrets = extract(schema, leaf, (val: any) => {
-    if (val.length > 0) {
-      if (stringContainsSome(val as string, ...localRefs)) return val
-      return `{{ ${val} }}`
-    }
-    return undefined
-  })
-  d.debug('secrets: ', secrets)
-  d.info('First round of templating')
-  const firstTemplateRound = (await gucci(secrets, {})) as Record<string, any>
-  const firstTemplateFlattend = flattenObject(firstTemplateRound)
+  const schemaSecrets = extract(schema, leaf)
+  // Remove properties with blank `x-secret`
+  const template = removeBlankAttributes(schemaSecrets)
 
-  d.info('Parsing values for second round of templating')
-  const expandedTemplates = Object.entries(firstTemplateFlattend)
-    // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
-    .filter(([_, v]) => stringContainsSome(v, ...localRefs))
-    .map(([path, v]: string[]) => {
-      /*
-       * dotDot:
-       *  Get full path, except last item, this allows to parse for siblings
-       * dotV:
-       *  Get .v by getting the second . after apps
-       *  apps.hello.world
-       *  ^----------^ Get this content (apps.hello)
-       */
-      const dotDot = path.slice(0, path.lastIndexOf('.'))
-      const dotV = path.slice(0, path.indexOf('.', path.indexOf('apps.') + 'apps.'.length))
+  d.debug('Secrets template: ', template)
+  d.info('Generating secrets from the secrets template')
+  const generatedSecrets = (await gucci(template, {})) as Record<string, any>
+  const mergedGeneratedSecrets = merge(generatedSecrets, cloneDeep(values))
 
-      const sDot = v.replaceAll('.dot.', `.${dotDot}.`)
-      const vDot = sDot.replaceAll('.v.', `.${dotV}.`)
-      const oDot = vDot.replaceAll('.o.', '.otomi.')
-      const rootDot = oDot.replaceAll('.root.', '.')
-      return [path, rootDot]
-    })
-
-  expandedTemplates.map(([k, v]) => {
-    // Activate these templates and put them back into the object
-    set(firstTemplateRound, k, `{{ ${v} }}`)
-    return [k, v]
-  })
-  d.debug('firstTemplateRound: ', firstTemplateRound)
-
-  d.info('Gather all values for the second round of templating')
-  const gucciOutputAsTemplate = merge(cloneDeep(firstTemplateRound), cloneDeep(values))
-  d.debug('gucciOutputAsTemplate: ', gucciOutputAsTemplate)
-
-  d.info('Second round of templating')
-  const secondTemplateRound = (await gucci(firstTemplateRound, gucciOutputAsTemplate)) as Record<string, any>
-  d.debug('secondTemplateRound: ', secondTemplateRound)
+  const derivedSecrets = await deriveSecrets(mergedGeneratedSecrets)
+  const allSecrets = merge(cloneDeep(derivedSecrets), cloneDeep(mergedGeneratedSecrets))
 
   d.info('Generated all secrets')
   // Only return values that have x-secrets prop and are now fully templated:
-  const allSecrets = extract(schema, leaf)
-  const res = pick(merge(secondTemplateRound, cloneDeep(values)), Object.keys(flattenObject(allSecrets)))
+  const templatePaths = Object.keys(flattenObject(schemaSecrets))
+  const res = pick(allSecrets, templatePaths)
   d.debug('generateSecrets result: ', res)
   return res
 }

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /
 RUN apt-get update -qq \
   && apt install --reinstall coreutils \
   && apt install -qqy --no-install-recommends \
+  apache2-utils \
   apt-transport-https \
   awscli \
   ca-certificates \

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -783,7 +783,7 @@ definitions:
         default: standalone
       password:
         type: string
-        x-secret: 'randAlpha 24'
+        x-secret: '{{ randAlpha 24 }}'
       resources:
         additionalProperties: false
         properties:
@@ -977,7 +977,7 @@ definitions:
   secretTemplates:
     definitions:
       otomiAdminUsername:
-        x-secret: '"admin"'
+        x-secret: 'admin'
   securityContext:
     additionalProperties:
       uniqueItems: true
@@ -1460,7 +1460,7 @@ definitions:
                 type: string
                 description: The secret of the access key. Optional if cloud provider is AWS.
                 $ref: '#/definitions/wordCharacterPattern'
-                x-secret: true
+                x-secret: ''
             required:
               - bucket
               - s3Url
@@ -1722,7 +1722,7 @@ properties:
           sharedSecret:
             description: A secret used by drone-admit-members plugin. https://docs.drone.io/runner/kubernetes/configuration/reference/drone-secret-plugin-token/
             type: string
-            x-secret: 'randAlphaNum 32'
+            x-secret: '{{ randAlphaNum 32 }}'
           sourceControl:
             additionalProperties: false
             properties:
@@ -1901,7 +1901,7 @@ properties:
           postgresqlPassword:
             type: string
             description: This password was generated and cannot be changed without manual intervention.
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
             readOnly: true
           image:
             additionalProperties: false
@@ -1954,20 +1954,20 @@ properties:
           databasePassword:
             type: string
             description: Once set and deployed it cannot be changed with manual intervention.
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
           core:
             properties:
               secret:
                 type: string
-                x-secret: 'randAlphaNum 16'
+                x-secret: '{{ randAlphaNum 16 }}'
               xsrfKey:
                 type: string
-                x-secret: 'randAlphaNum 32'
+                x-secret: '{{ randAlphaNum 32 }}'
           jobservice:
             properties:
               secret:
                 type: string
-                x-secret: 'randAlphaNum 16'
+                x-secret: '{{ randAlphaNum 16 }}'
           persistence:
             additionalProperties: false
             properties:
@@ -2040,18 +2040,18 @@ properties:
             properties:
               secret:
                 type: string
-                x-secret: 'randAlpha 16'
+                x-secret: '{{ randAlpha 16 }}'
               credentials:
                 properties:
                   htpasswd:
                     type: string
-                    x-secret: 'htpasswd .dot.username .dot.password'
+                    x-secret: ''
                   username:
                     type: string
                     $ref: '#/definitions/secretTemplates/definitions/otomiAdminUsername'
                   password:
                     type: string
-                    x-secret: 'randAlphaNum 32'
+                    x-secret: '{{ randAlphaNum 32 }}'
             required:
               - secret
               - credentials
@@ -2097,7 +2097,7 @@ properties:
                 $ref: '#/definitions/resources'
           secretKey:
             type: string
-            x-secret: 'randAlpha 16'
+            x-secret: '{{ randAlpha 16 }}'
         required:
           - databasePassword
       hello:
@@ -2257,11 +2257,11 @@ properties:
                 default: otomi
               clientSecret:
                 type: string
-                x-secret: 'randAlphaNum 32'
+                x-secret: '{{ randAlphaNum 32 }}'
           postgresqlPassword:
             type: string
             description: This password was generated and cannot be changed without manual intervention.
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
             readOnly: true
           adminPassword:
             type: string
@@ -2363,7 +2363,7 @@ properties:
           postgresqlPassword:
             type: string
             description: Once set and deployed it cannot be changed with manual intervention.
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
         required:
           - postgresqlPassword
       kubeclarity:
@@ -2385,7 +2385,7 @@ properties:
           databasePassword:
             type: string
             description: Once set and deployed it cannot be changed with manual intervention.
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
           resources:
             additionalProperties: false
             properties:
@@ -2477,7 +2477,7 @@ properties:
                 $ref: '#/definitions/autoscalingEnabled'
           adminPassword:
             type: string
-            x-secret: 'randAlphaNum 20'
+            x-secret: '{{ randAlphaNum 20 }}'
           persistence:
             properties:
               querier:
@@ -2608,7 +2608,7 @@ properties:
                 description: Cookie secret must be 32 byte base64 encoded string.
                 pattern: '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'
                 type: string
-                x-secret: 'randAlphaNum 32 | b64enc'
+                x-secret: '{{ randAlphaNum 32 | b64enc }}'
       oauth2-proxy-redis:
         $ref: '#/definitions/redisChart'
       opa-exporter:
@@ -3294,7 +3294,7 @@ properties:
                 properties:
                   apiToken:
                     type: string
-                    x-secret: true
+                    x-secret: ''
                 required:
                   - apiToken
             required:
@@ -3306,10 +3306,10 @@ properties:
                 properties:
                   apiToken:
                     type: string
-                    x-secret: true
+                    x-secret: ''
                   apiSecret:
                     type: string
-                    x-secret: true
+                    x-secret: ''
                     description: Required when Email is set.
                   email:
                     $ref: '#/definitions/email'
@@ -3498,7 +3498,7 @@ properties:
             - provider
       adminPassword:
         type: string
-        x-secret: 'randAlphaNum 20'
+        x-secret: '{{ randAlphaNum 20 }}'
       globalPullSecret:
         title: Global pullsecret
         description: Will be connected to each "default" service account in all otomi app namespaces.
@@ -3905,7 +3905,7 @@ properties:
         properties:
           password:
             type: string
-            x-secret: randAlpha 16
+            x-secret: '{{ randAlpha 16 }}'
   version:
     type: integer
     description: DO NOT CHANGE! Holds the values-schema version. For more details, see `otomi migrate`.


### PR DESCRIPTION
Fixes issue with E2BIG that happens if values repo bitumen too big.

The underlying issue is that all user values were converted to the shell parameters, reaching in this way shell limits.
This code changes ensures that values are not propagated as shell parameters.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
