### PR TITLE
test: do not set metrics-server

### DIFF
--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -41,8 +41,6 @@ apps:
     enabled: true
   loki:
     enabled: true
-  metrics-server:
-    enabled: true
   minio:
     enabled: true
   prometheus:


### PR DESCRIPTION
The metrics-server is installed automatically depending on the cloud provider.