### PR TITLE
test: otomi upgrade test scenario

### DIFF
--- a/.github/workflows/integration-on-schedule-full.yml
+++ b/.github/workflows/integration-on-schedule-full.yml
@@ -2,7 +2,7 @@ name: Scheduled - full with nip.io
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 0 * * *'
 
 jobs:
   start-integration-test-full:

--- a/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
+++ b/.github/workflows/integration-on-schedule-minimal-no-admin-pass.yml
@@ -2,7 +2,7 @@ name: Scheduled - minimal with nip.io, without admin password
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 0 * * *'
 
 jobs:
   start-integration-test-minimal:

--- a/.github/workflows/integration-on-schedule-minimal-with-team.yml
+++ b/.github/workflows/integration-on-schedule-minimal-with-team.yml
@@ -2,7 +2,7 @@ name: Scheduled - minimal with team
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   start-integration-test-minimal:

--- a/.github/workflows/integration-on-schedule-minimal.yml
+++ b/.github/workflows/integration-on-schedule-minimal.yml
@@ -2,7 +2,7 @@ name: Scheduled - minimal with nip.io
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   start-integration-test-minimal:

--- a/.github/workflows/integration-on-schedule-upgrade.yml
+++ b/.github/workflows/integration-on-schedule-upgrade.yml
@@ -2,7 +2,7 @@ name: Scheduled - upgrade
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '30 1 * * *'
 
 jobs:
   start-integration-test-upgrade:

--- a/.github/workflows/integration-on-schedule-upgrade.yml
+++ b/.github/workflows/integration-on-schedule-upgrade.yml
@@ -2,7 +2,7 @@ name: Scheduled - upgrade
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   start-integration-test-upgrade:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -668,6 +668,8 @@ environments:
           nodeSelector: {}
         e2e:
           enabled: false
+          upgrade:
+            version: main
         # TODO: update this when schema version changes: (and think more?)
         version: 11
         letsencryptRootCA: |

--- a/tests/integration/upgrade.yaml
+++ b/tests/integration/upgrade.yaml
@@ -5,6 +5,201 @@ cluster:
   provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
-  version: 'OTOMI_VERSION_PLACEHOLDER'
+  version: v0.22.3
 e2e:
   enabled: true
+  upgrade:
+    version: 'OTOMI_VERSION_PLACEHOLDER'
+apps:
+  alertmanager:
+    enabled: true
+  argocd:
+    enabled: true
+  cert-manager:
+    issuer: custom-ca
+  gatekeeper:
+    enabled: true
+    disableValidatingWebhook: false
+  grafana:
+    enabled: true
+  harbor:
+    enabled: true
+  hello:
+    enabled: true
+  httpbin:
+    enabled: true
+  jaeger:
+    enabled: true
+  kiali:
+    enabled: true
+  knative:
+    enabled: true
+  kube-descheduler:
+    enabled: true
+  kubeapps:
+    enabled: true
+  kubeclarity:
+    enabled: true
+  kured:
+    enabled: true
+  loki:
+    enabled: true
+  minio:
+    enabled: true
+  prometheus:
+    enabled: true
+  promtail:
+    enabled: true
+  redis-shared:
+    enabled: false
+  snapshot-controller:
+    enabled: true
+  tigera-operator:
+    enabled: true
+  thanos:
+    enabled: true
+  vault:
+    enabled: true
+teamConfig:
+  demo:
+    password: somesecretvalue
+    id: demo
+    networkPolicy:
+      egressPublic: true
+      ingressPrivate: true
+    builds:
+      - name: nodejs-hello-world
+        tag: v0.0.1
+        repoAccess:
+          otomiGit: false
+          privateGit: false
+        mode:
+          docker:
+            repoUrl: https://github.com/redkubes/nodejs-helloworld
+            revision: HEAD
+            path: ./Docker
+          type: docker
+      - name: demo-java-maven
+        tag: v0.0.1
+        repoAccess:
+          otomiGit: false
+          privateGit: false
+        mode:
+          buildpacks:
+            repoUrl: https://github.com/buildpacks/samples
+            revision: HEAD
+            path: apps/java-maven
+          type: buildpacks
+    services:
+      - headers:
+          response:
+            set: []
+        id: 78595314-cdaf-4b60-acc2-3b1a7f80fe2b
+        ingressClassName: platform
+        name: httpbin
+        networkPolicy:
+          ingressPrivate:
+            mode: DenyAll
+        ownHost: true
+        port: 80
+        type: public
+      - id: a106eb22-8c06-41b6-ab15-97aafb0888b5
+        ingressClassName: platform
+        name: nginx-deployment
+        networkPolicy:
+          ingressPrivate:
+            mode: DenyAll
+        ownHost: true
+        paths: []
+        port: 80
+        type: public
+      - id: 91f6af98-ad8e-4111-b916-cf1b5bdcafb0
+        ingressClassName: platform
+        ksvc:
+          predeployed: true
+        name: nginx-ksvc
+        networkPolicy:
+          ingressPrivate:
+            mode: DenyAll
+        ownHost: true
+        paths: []
+        port: 80
+        type: public
+    workloads:
+      - name: nodejs-helloworld
+        url: https://github.com/redkubes/nodejs-helloworld.git
+        path: /
+        revision: HEAD
+      - name: httpbin
+        path: charts/httpbin
+        revision: HEAD
+        url: https://github.com/redkubes/otomi-core.git
+      - name: nginx-deployment
+        path: deployment
+        revision: main
+        selectedChart: deployment
+        url: https://github.com/redkubes/otomi-charts.git
+      - name: nginx-ksvc
+        path: ksvc
+        revision: main
+        selectedChart: ksvc
+        url: https://github.com/redkubes/otomi-charts.git
+  admin:
+    services: []
+    workloads:
+      - name: nodejs-helloworld
+        url: https://github.com/redkubes/nodejs-helloworld.git
+        path: /
+        revision: HEAD
+files:
+  env/teams/workloads/demo/nodejs-helloworld.yaml: |
+    values: |
+      image:
+        repository: otomi/nodejs-helloworld
+        tag: v1.2.13
+  env/teams/workloads/demo/nginx-deployment.yaml: |
+    values: |
+      fullnameOverride: nginx-deployment
+      image:
+        repository: nginxinc/nginx-unprivileged
+        tag: stable
+      containerPorts:
+        - containerPort: 8080
+          protocol: TCP
+          name: http
+      resources:
+        requests:
+          cpu: 200m
+          memory: 32Mi
+      autoscaling:
+        minReplicas: 2
+        maxReplicas: 10
+  env/teams/workloads/demo/nginx-ksvc.yaml: |
+    values: |
+      fullnameOverride: nginx-ksvc
+      image:
+        repository: nginxinc/nginx-unprivileged
+        tag: stable
+      containerPorts:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      readinessProbe:
+          httpGet:
+              path: /
+              port: http1
+      resources:
+        requests:
+          cpu: 200m
+          memory: 32Mi
+      autoscaling:
+        minReplicas: 0
+        maxReplicas: 10
+  env/teams/workloads/demo/httpbin.yaml: |
+    values: |
+      {}
+  env/teams/workloads/admin/nodejs-helloworld.yaml: |
+    values: |
+      image:
+        repository: otomi/nodejs-helloworld
+        tag: v1.2.13

--- a/tests/integration/upgrade.yaml
+++ b/tests/integration/upgrade.yaml
@@ -5,7 +5,7 @@ cluster:
   provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
-  version: v0.22.3
+  version: v0.24.0
 e2e:
   enabled: true
   upgrade:

--- a/tests/integration/upgrade.yaml
+++ b/tests/integration/upgrade.yaml
@@ -2,7 +2,6 @@
 cluster:
   k8sVersion: 'K8S_VERSION_PLACEHOLDER'
   name: 'dev'
-  provider: digitalocean
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
   version: v0.24.0

--- a/values/jobs/e2e.gotmpl
+++ b/values/jobs/e2e.gotmpl
@@ -16,7 +16,7 @@ nativeSecrets:
   CYPRESS_ROOT_PASSWORD: {{$k.adminPassword}}
   CYPRESS_ADMIN_USERNAME: 'otomi-admin'
   CYPRESS_ADMIN_PASSWORD: {{$k.adminPassword}}
-  CYPRESS_OTOMI_VERSION: 'main'
+  CYPRESS_OTOMI_VERSION: {{ $v.e2e.upgrade.version }}
 
 resources:
   limits:


### PR DESCRIPTION
This PR will perform the Otomi upgrade test from version `v0.24.0` to the one that is indicated by a user while selecting the branch in Github Actions for `Deploy Otomi` pipeline.

I also changed the cron job start time, as it is not possible to create 7 clusters at once due to the resource quota.