### PR TITLE
fix: drone-activation

### DIFF
--- a/values/jobs/drone-activation.gotmpl
+++ b/values/jobs/drone-activation.gotmpl
@@ -9,7 +9,7 @@ image:
   pullPolicy: Always
 
 script: | 
-    yarn cypress run --spec 'cypress/integration/otomi-applications/20-drone.feature' --record false --env BASE_URL={{$v.cluster.domainSuffix}}   
+    yarn cypress run --spec 'cypress/integration/otomi-applications/20-drone.feature' --config video=false --env BASE_URL={{$v.cluster.domainSuffix}}   
 
 
 nativeSecrets:

--- a/values/jobs/e2e.gotmpl
+++ b/values/jobs/e2e.gotmpl
@@ -8,7 +8,7 @@ image:
   tag: 'v0.3.2'
 
 script: | 
-    yarn cypress run --spec 'cypress/integration/otomi-applications/90-otomi-upgrade.feature' --record false --env BASE_URL={{$v.cluster.domainSuffix}}   
+    yarn cypress run --spec 'cypress/integration/otomi-applications/90-otomi-upgrade.feature' --config video=false --env BASE_URL={{$v.cluster.domainSuffix}}   
 
 
 nativeSecrets:


### PR DESCRIPTION
### Implements:
https://github.com/redkubes/otomi-core/pull/1200

### Description:
This PR fixes and disables video recordings for drone-activation and otomi-upgrade jobs.

### Changes Made:
Updated cypress scripts for drone-activation and otomi-upgrade jobs.

### Screenshot:
<img width="1680" alt="Screenshot 2023-08-10 at 16 23 23" src="https://github.com/redkubes/otomi-core/assets/63190600/8fdd37a9-a335-436d-ad45-f407e7801089">


## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
