### PR TITLE
fix: remove option for Gitea repo access for Builds

### DIFF
--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -12,9 +12,7 @@ metadata:
 spec:
   workspaces:
     - name: shared-data
-    {{- if .repoAccess.otomiGit }}
     - name: git-credentials
-    {{- end }}
   tasks:
   - name: fetch-source
     taskRef:
@@ -22,10 +20,8 @@ spec:
     workspaces:
     - name: output
       workspace: shared-data
-    {{- if .repoAccess.otomiGit }}
     - name: ssh-directory
       workspace: git-credentials
-    {{- end }}
     params:
     - name: url
       value: {{ .mode.buildpacks.repoUrl }}
@@ -69,11 +65,9 @@ spec:
           resources:
             requests:
               storage: 1Gi
-    {{- if .repoAccess.otomiGit }}
     - name: git-credentials
       secret:
         secretName: gitea-credentials
-    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/team-ns/templates/builds/docker.yaml
+++ b/charts/team-ns/templates/builds/docker.yaml
@@ -13,9 +13,7 @@ spec:
   workspaces:
   - name: shared-data
   - name: docker-credentials
-  {{- if .repoAccess.otomiGit }}
   - name: git-credentials
-  {{- end }}
   tasks:
   - name: fetch-source
     taskRef:
@@ -23,10 +21,8 @@ spec:
     workspaces:
     - name: output
       workspace: shared-data
-    {{- if .repoAccess.otomiGit }}
     - name: ssh-directory
       workspace: git-credentials
-    {{- end }}
     params:
     - name: url
       value: {{ .mode.docker.repoUrl }}
@@ -70,11 +66,9 @@ spec:
         resources:
           requests:
             storage: 1Gi
-  {{- if .repoAccess.otomiGit }}
   - name: git-credentials
     secret:
       secretName: gitea-credentials
-  {{- end }}
   - name: docker-credentials
     secret:
       secretName: harbor-pushsecret-builds

--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -17,12 +17,9 @@ metadata:
   name: sa-team-{{ $v.teamId }}
 secrets:
 {{- if $h.enabled }}
-- name: harbor-pushsecret
-{{- end }}
-{{- if $b.enabled }}
 - name: harbor-pushsecret-builds
-- name: gitea-credentials
 {{- end }}
+- name: gitea-credentials
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tests/fixtures/env/teams/builds.demo.yaml
+++ b/tests/fixtures/env/teams/builds.demo.yaml
@@ -3,9 +3,6 @@ teamConfig:
         builds:
             - name: demo-java1
               tag: v.0.0.1
-              repoAccess:
-                  otomiGit: true
-                  #   privateGit: false
               mode:
                   docker:
                       repoUrl: https://github.com/buildpacks/samples
@@ -14,8 +11,6 @@ teamConfig:
                   type: docker
             - name: demo-java2
               tag: v.0.0.1
-              repoAccess:
-                  otomiGit: true
               mode:
                   buildpacks:
                       repoUrl: https://github.com/buildpacks/samples
@@ -24,8 +19,6 @@ teamConfig:
                   type: buildpacks
             - name: demo-java3
               tag: v_0_0_1
-              repoAccess:
-                  otomiGit: false
               mode:
                   docker:
                       repoUrl: https://github.com/buildpacks/samples

--- a/tests/fixtures/rendered-values.yaml
+++ b/tests/fixtures/rendered-values.yaml
@@ -1,2216 +1,2216 @@
 helmDefaults:
-    atomic: true
-    historyMax: 3
-    wait: true
-    timeout: 1200
-    force: false
-    cleanupOnFail: false
-    skipDeps: true
+  atomic: true
+  historyMax: 3
+  wait: true
+  timeout: 1200
+  force: false
+  cleanupOnFail: false
+  skipDeps: true
 environments:
-    default:
-        values:
-            - _derived:
-                  caCert: |
-                      -----BEGIN CERTIFICATE-----
-                      MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-                      ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-                      BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-                      YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-                      AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-                      ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-                      jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-                      wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-                      oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-                      TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-                      fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-                      rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-                      FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-                      mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-                      GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-                      mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-                      Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-                      9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-                      nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-                      qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-                      qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-                      sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-                      CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-                      5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-                      xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-                      fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-                      gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-                      7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-                      -----END CERTIFICATE-----
+  default:
+    values:
+      - _derived:
+          caCert: |
+            -----BEGIN CERTIFICATE-----
+            MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+            ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+            BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+            YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+            AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+            ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+            jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+            wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+            oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+            TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+            fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+            rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+            FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+            mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+            GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+            mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+            Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+            9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+            nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+            qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+            qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+            sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+            CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+            5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+            xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+            fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+            gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+            7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+            -----END CERTIFICATE-----
 
-                      -----BEGIN CERTIFICATE-----
-                      MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
-                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-                      ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
-                      BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
-                      Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
-                      AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
-                      gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
-                      L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
-                      nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
-                      nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
-                      biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
-                      DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
-                      BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
-                      ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
-                      MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
-                      HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
-                      MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
-                      DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
-                      vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
-                      y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
-                      Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
-                      yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
-                      xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
-                      Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
-                      zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
-                      qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
-                      xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
-                      hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
-                      -----END CERTIFICATE-----
-                  caCertRoot: |
-                      -----BEGIN CERTIFICATE-----
-                      MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-                      ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-                      BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-                      YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-                      AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-                      ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-                      jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-                      wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-                      oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-                      TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-                      fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-                      rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-                      FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-                      mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-                      GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-                      mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-                      Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-                      9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-                      nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-                      qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-                      qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-                      sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-                      CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-                      5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-                      xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-                      fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-                      gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-                      7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-                      -----END CERTIFICATE-----
-                  isInitialDeployment: false
-                  oidcBaseUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi
-                  oidcBaseUrlBackchannel: http://keycloak-http.keycloak/realms/otomi
-                  oidcWellKnownUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi/.well-known/openid-configuration
-                  oidcWellKnownUrlBackchannel: http://keycloak-http.keycloak/realms/otomi/.well-known/openid-configuration
-                  supportedCloud: false
-                  untrustedCA: true
-              adminApps:
-                  - deps:
-                        - prometheus
-                    ingress:
-                        - auth: true
-                          namespace: monitoring
-                          port: 9093
-                          svc: po-alertmanager
-                          type: public
-                    name: alertmanager
-                    tags:
-                        - alerting
-                        - observability
-                  - ingress:
-                        - auth: true
-                          namespace: argocd
-                          svc: argocd-server
-                          type: public
-                    isShared: true
-                    name: argocd
-                    ownHost: true
-                    tags:
-                        - cicd
-                        - gitops
-                  - name: cert-manager
-                    tags:
-                        - ingress
-                        - security
-                        - tls
-                  - ingress:
-                        - auth: true
-                          namespace: drone
-                          removeRequestHeaders:
-                              - authorization
-                          svc: drone
-                          type: public
-                        - forwardPath: true
-                          namespace: drone
-                          paths:
-                              - /hook
-                              - /api/user
-                              - /api/repo
-                          removeRequestHeaders:
-                              - authorization
-                          svc: drone
-                          type: public
-                    isShared: true
-                    name: drone
-                    ownHost: true
-                    tags:
-                        - cicd
-                        - deployment
-                        - pipeline
-                  - ingress:
-                        - auth: true
-                          namespace: ingress
-                          svc: tty
-                          type: public
-                    isShared: true
-                    name: tty
-                    ownHost: true
-                    tags:
-                        - tty
-                  - name: external-dns
-                    tags:
-                        - ingress
-                        - security
-                        - tls
-                  - name: external-secrets
-                    tags:
-                        - secrets
-                        - security
-                        - tls
-                  - deps:
-                        - prometheus
-                    ingress:
-                        - auth: true
-                          namespace: falco
-                          port: 2802
-                          svc: falco-falcosidekick-ui
-                          type: public
-                    isShared: true
-                    name: falco
-                    ownHost: true
-                    tags:
-                        - security
-                  - name: gatekeeper
-                    tags:
-                        - security
-                        - policies
-                        - observability
-                  - ingress:
-                        - namespace: gitea
-                          port: 3000
-                          svc: gitea-http
-                          type: public
-                    isShared: true
-                    name: gitea
-                    ownHost: true
-                    tags:
-                        - git
-                  - deps:
-                        - prometheus
-                    ingress:
-                        - auth: true
-                          namespace: grafana
-                          removeRequestHeaders:
-                              - authorization
-                          svc: po-grafana
-                          type: public
-                    name: grafana
-                    ownHost: true
-                    shortcuts:
-                        - description: NGINX ingress controller metrics
-                          path: /d/nginx/nginx-ingress-controller?orgId=1&refresh=5s
-                          title: NGINX
-                    tags:
-                        - tracing
-                        - telemetry
-                        - observability
-                  - ingress:
-                        - auth: true
-                          namespace: harbor
-                          svc: harbor-portal
-                          type: public
-                        - auth: true
-                          forwardPath: true
-                          namespace: harbor
-                          paths:
-                              - /api/
-                              - /c/
-                          svc: harbor-core
-                          type: public
-                        - forwardPath: true
-                          namespace: harbor
-                          paths:
-                              - /chartrepo/
-                              - /service/
-                              - /v1/
-                              - /v2/
-                          svc: harbor-core
-                          type: public
-                    isShared: true
-                    name: harbor
-                    ownHost: true
-                    tags:
-                        - security
-                  - hide: true
-                    name: hello
-                    tags:
-                        - demo
-                  - ingress:
-                        - auth: true
-                          namespace: httpbin
-                          svc: httpbin
-                          type: public
-                    isShared: true
-                    name: httpbin
-                    ownHost: true
-                    tags:
-                        - dev
-                        - testing
-                        - debugging
-                  - name: ingress-nginx
-                    tags:
-                        - ingress
-                        - auth
-                  - name: istio
-                    tags:
-                        - ingress
-                        - egress
-                        - routing
-                        - security
-                        - tls
-                        - observability
-                        - policies
-                  - deps:
-                        - istio
-                    ingress:
-                        - auth: true
-                          forwardPath: true
-                          namespace: jaeger
-                          port: 16686
-                          svc: jaeger-operator-jaeger-query
-                          type: public
-                    isShared: true
-                    name: jaeger
-                    tags:
-                        - ingress
-                        - telemetry
-                        - observability
-                  - ingress:
-                        - namespace: keycloak
-                          svc: keycloak-http
-                          type: public
-                    name: keycloak
-                    ownHost: true
-                    shortcuts:
-                        - description: Edit your account settings.
-                          path: /realms/otomi/account/
-                          title: Account
-                    tags:
-                        - auth
-                        - sso
-                  - deps:
-                        - istio
-                        - prometheus
-                    ingress:
-                        - auth: true
-                          forwardPath: true
-                          namespace: kiali
-                          port: 20001
-                          removeRequestHeaders:
-                              - authorization
-                          svc: kiali
-                          type: public
-                    name: kiali
-                    path: /api/auth/openid_redirect
-                    tags:
-                        - tracing
-                        - telemetry
-                        - observability
-                  - deps:
-                        - istio
-                    name: knative
-                    tags:
-                        - serverless
-                        - functions
-                  - deps:
-                        - operator-lifecycle-manager
-                    ingress:
-                        - namespace: kubeapps
-                          svc: kubeapps
-                          type: public
-                    isShared: true
-                    name: kubeapps
-                    ownHost: true
-                    tags:
-                        - dev
-                        - apps
-                  - ingress:
-                        - auth: true
-                          namespace: kubeclarity
-                          port: 8080
-                          svc: kubeclarity
-                          type: public
-                    isShared: true
-                    name: kubeclarity
-                    ownHost: true
-                    tags:
-                        - security
-                  - name: kured
-                    tags:
-                        - security
-                  - name: tekton
-                    tags:
-                        - buildpacks
-                  - deps:
-                        - grafana
-                        - prometheus
-                        - minio
-                    name: loki
-                    path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
-                    shortcuts:
-                        - description: All logs generated in the "ingress" namespace
-                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D","refId":"A"%7D%5D
-                          title: Ingress logs
-                        - description: All OWASP rule violations
-                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D%20%7C%3D%5C"ModSecurity:%20%5C""%7D%5D
-                          title: OWASP violations
-                        - description: Kube API violations logged by OPA gatekepeer
-                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"gatekeeper-system%5C"%7D%20%7C%3D%5C"Policy:%20%5C""%7D%5D
-                          title: Gatekeeper violations
-                    tags:
-                        - logging
-                        - telemetry
-                        - observability
-                    useHost: grafana
-                  - ingress:
-                        - auth: true
-                          namespace: minio
-                          port: 9001
-                          removeRequestHeaders:
-                              - authorization
-                          svc: minio
-                          type: public
-                    name: minio
-                    ownHost: true
-                    tags:
-                        - storage
-                        - backup
-                  - ingress:
-                        - auth: true
-                          namespace: opencost
-                          port: 9090
-                          svc: opencost
-                          type: public
-                    name: opencost
-                    ownHost: true
-                    tags:
-                        - finops
-                  - hide: true
-                    ingress:
-                        - auth: true
-                          namespace: otomi
-                          paths:
-                              - /api/
-                          svc: otomi-api
-                          type: public
-                        - auth: true
-                          namespace: otomi
-                          svc: otomi-console
-                          type: public
-                    isShared: true
-                    name: otomi
-                    ownHost: true
-                  - ingress:
-                        - auth: true
-                          namespace: monitoring
-                          port: 9090
-                          svc: po-prometheus
-                          type: public
-                    name: prometheus
-                    tags:
-                        - metrics
-                        - observability
-                  - deps:
-                        - prometheus
-                        - grafana
-                        - minio
-                    ingress:
-                        - auth: true
-                          forwardPath: true
-                          namespace: monitoring
-                          port: 9090
-                          svc: thanos-query-frontend
-                          type: public
-                        - forwardPath: true
-                          namespace: monitoring
-                          paths:
-                              - /api/
-                          port: 19291
-                          svc: thanos-receive
-                          type: public
-                    name: thanos
-                    ownHost: true
-                    tags:
-                        - metrics
-                        - observability
-                  - deps:
-                        - prometheus
-                        - grafana
-                    name: trivy
-                    tags:
-                        - security
-                  - deps:
-                        - external-secrets
-                    ingress:
-                        - auth: true
-                          namespace: vault
-                          port: 8200
-                          svc: vault
-                          type: public
-                    isShared: true
-                    name: vault
-                    ownHost: true
-                    path: /ui/vault/auth?redirect_to=%2Fvault%2Fsecrets%2Fsecret%2Flist%2Fteams%2F#NS#%2F&with=oidc
-                    tags:
-                        - secrets
-                        - security
-                        - observability
-                  - name: velero
-                    tags:
-                        - backup
-              alerts:
-                  drone:
-                      - slack
-                  email:
-                      critical: admins@yourdoma.in
-                      nonCritical: admins@yourdoma.in
-                  groupInterval: 5m
-                  receivers:
-                      - slack
-                      - email
-                  repeatInterval: 3h
-                  slack:
-                      url: https://hooks.slack.com/services/id
-              apps:
-                  alertmanager:
-                      enabled: true
-                  argocd:
-                      autoscaling:
-                          enabled: false
-                          maxReplicas: 3
-                          minReplicas: 1
-                          targetCPUUtilizationPercentage: 50
-                      enabled: true
-                  aws-alb-ingress-controller:
-                      enabled: false
-                  aws-ebs-csi-driver:
-                      enabled: false
-                  cert-manager:
-                      customRootCA: |
-                          -----BEGIN CERTIFICATE-----
-                          MIIDdDCCAlygAwIBAgIBATANBgkqhkiG9w0BAQUFADBuMRUwEwYDVQQDEwxyZWRr
-                          dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
-                          EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
-                          HhcNMjExMTAzMTAxOTAyWhcNMzExMTAzMTAxOTAyWjBuMRUwEwYDVQQDEwxyZWRr
-                          dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
-                          EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
-                          ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD4quPwHrharZhmqVQx/75N
-                          M7Vp3ZmSd3gR2u8Dc1PkmEa6W9CiheVAB5KCzdN5sWaOlFKTy5sHg/zvyYZjvNGX
-                          xaHCa4i6OyRgiTOC4NCrxuN5010G0vAxYaM1aIFcqObXuLcaK6miOybDLRfDxoHl
-                          g/TKqdiPOMEb2ZgphFxL7oYXjkobOggH+wzwwMIc/1nA3eBjEPsIkQehmb0R0Kxw
-                          K5VHPCvbPQb3USVqUs+NmsuCxmqkTtI32WqR0IuNAVqjaD9oNqcsKBgUOPYLYXM8
-                          xsTzIn0QPysJIKUCRn1quHwvCQc1RnQBB8UG6iJboVdRe0GNS13vu5ikhoCb0oyV
-                          AgMBAAGjHTAbMAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MA0GCSqGSIb3DQEB
-                          BQUAA4IBAQBJWHPGnTqXME/MGwG2nAG/JqiCQ0ZOOyKgwN97wrQIlbra2BaUT1K4
-                          tMDOjZlft1Luipg/IkzzMXt4eAmqGMxLIweqbve6aLm8KTpHkLdxLm3VPnhK8zzg
-                          ysRRRjtkMo9KUOSvrS2dFsY+fQnbGUzpRcK8RrzM6CpgIaf29neP1xLUWQuUsy5y
-                          yKCb6OQ9vaJBf/uvz73rQq0ym4Kx0FCFssshaja6lbz/jqCJmppdZE5pe5jvMVVv
-                          ae5UQLbva0JyLY8Rc1vSY/epIHMLrV90GEagSkF/ejgF3uh8cliLuUYFAFyU8TnN
-                          FWG+enMJfR04aWjp8M3MQ1IoCPVxoXxI
-                          -----END CERTIFICATE-----
-                      customRootCAKey: |
-                          -----BEGIN RSA PRIVATE KEY-----
-                          MIIEpQIBAAKCAQEA+Krj8B64Wq2YZqlUMf++TTO1ad2Zknd4EdrvA3NT5JhGulvQ
-                          ooXlQAeSgs3TebFmjpRSk8ubB4P878mGY7zRl8WhwmuIujskYIkzguDQq8bjedNd
-                          BtLwMWGjNWiBXKjm17i3Giupojsmwy0Xw8aB5YP0yqnYjzjBG9mYKYRcS+6GF45K
-                          GzoIB/sM8MDCHP9ZwN3gYxD7CJEHoZm9EdCscCuVRzwr2z0G91ElalLPjZrLgsZq
-                          pE7SN9lqkdCLjQFao2g/aDanLCgYFDj2C2FzPMbE8yJ9ED8rCSClAkZ9arh8LwkH
-                          NUZ0AQfFBuoiW6FXUXtBjUtd77uYpIaAm9KMlQIDAQABAoIBAQCTsIuotdYwpSH6
-                          9172Qzq3h5qbwe3QO/yoPivvFLQi9P4s+RM1M+kw2k5+Odj8UgzjadyRwz/UeuPj
-                          VwHmguLJDaxBWLTgRvgYDeT2Oqg1He9FD/AUeXwHGEJjGiqa6gYQ4bh+Zqhdnlwr
-                          V8DhmijUNEdThwUEK2UmMVpabi6TOW/dfO6sbnOHYwx326qF3LhYcUrmdeowEGLT
-                          UhxdXJQQUsfD+zft6dcPnqucIxd5OEsn3L8/pcumOxHUGFBHDMuB5nTpcZyDxKaN
-                          joC0zQy0BDQIMN1F7wNRukSiSYqvRvmvztF2Ka0yEWAdvBBXVVN8nKQw69oGoe9B
-                          EQ5HSkKBAoGBAP0KnCE19jW9jq1CWFkFwd1BALWA3GOuxJqSX6M5APM+JRBR4UOZ
-                          AUOogvGlrc1ns58q7oNoc1CHiMHd2lNFgfqWqopfVz1Tt9qHqU6VoJnkmJlJRriE
-                          57F08RTjslTFzYEsE9zMlL1xa5pq1aGAFB0/mYuxopRw39mS14ugxF1pAoGBAPuT
-                          MFLfp2wttGe2WhVepOnhD13sEMGCS6GE16jinjP3qAWIPM/Wdy+Ab8n+KWQkYPLw
-                          UsQVi+41LWFIexjzdrq9rG5LQbZdjDCyR4eomDGZhc0Vtsu79NbVrnSmjH8w6psa
-                          DXB1uN9/VcCzae/hRpk2Q6zFiMcPE8utUU5RvFRNAoGBAJ19+wsYoPN11dW0k3Rl
-                          BvKEwMI3P/SzFB74t5nJovPCXCM6MzB1jLnlqgppCjHsN3n7qJQVcKBQmye+w2JM
-                          wseK+v5AtPWwo5/aC+CjdGAUTX4qg1/ZKLPkiyBrT9U/f9bD7mDg3DrE2yozEGAC
-                          bYJ+0TyHBR/K2Sh8Irf/CfjxAoGBAM4wuwCRkpUVeLEwQfEV2zBdZ8zg+HLBqd8+
-                          E8u1wVhyeOHf4YevDYx/RiBWEfKj5ln3Ir7XshKQvxrm3w16Liur3bGgOMGRNp+K
-                          3xmO0v6EB6gpTeL5sBiMlinBf5GXtBFfbvhnZBi6Mrx30DHtf4F/ekQWup37+4uK
-                          CAOa9jJZAoGAYbU4CoCxktBECxAVAjtpvYW5176cxiitd75s1ANhXGiOH1A6/y6H
-                          rnZ+fMAuvPjrDXbtmqJsq0RXq1E07ng4ZDIjN+0pShVFQdakJRFo1y+d3b82lBYX
-                          EZrfMBCWVj31dXeGEHfVvOpwrQ5ffTzs2lVmTh7Ft61gs4TJ7gNTDbE=
-                          -----END RSA PRIVATE KEY-----
-                      email: test@test.local
-                      issuer: letsencrypt
-                      resources:
-                          limits:
-                              cpu: 200m
-                              memory: 384Mi
-                          requests:
-                              cpu: 50m
-                              memory: 64Mi
-                      stage: staging
-                  cloudnative-pg:
-                      resources:
-                          limits:
-                              cpu: 500m
-                              memory: 512Mi
-                          requests:
-                              cpu: 100m
-                              memory: 100Mi
-                  cluster-autoscaler:
-                      enabled: false
-                  cluster-overprovisioner:
-                      enabled: true
-                  demo-tlspass:
-                      enabled: false
-                  drone:
-                      adminUser: somesecretvalue
-                      debug: false
-                      enabled: true
-                      githubAdmins:
-                          org: redkubes
-                          team: admins
-                          token: somesecretvalue
-                      orgsFilter: redkubes
-                      repoFilter: redkubes
-                      sharedSecret: somesecretvalue
-                      sourceControl:
-                          github:
-                              clientID: somesecretvalue
-                              clientSecretValue: somesecretvalue
-                              server: https://github.com
-                          provider: github
-                          username: otomi-admin
-                      trace: false
-                  drone-admit-members:
-                      enabled: true
-                  external-dns:
-                      enabled: true
-                      logLevel: info
-                  external-secrets:
-                      enabled: true
-                      logLevel: warn
-                      pollingInterval: 60000
-                  falco:
-                      _rawValues:
-                          customRules:
-                              otomi-rules.yaml: >-
-                                  - macro: k8s_containers
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/openpolicyagent/gatekeeper,
-                                          docker.io/velero/velero,
-                                          docker.io/weaveworks/kured,
-                                          k8s.gcr.io/kube-state-metrics/kube-state-metrics,
-                                          quay.io/jetstack/cert-manager-cainjector,
-                                          quay.io/jetstack/cert-manager-controller,
-                                          quay.io/jetstack/cert-manager-webhook,
-                                          quay.io/prometheus-operator/prometheus-operator,
-                                          quay.io/prometheus/prometheus,
-                                          quay.io/kiwigrid/k8s-sidecar,
-                                          docker.io/otomi/core,
-                                          docker.io/otomi/tasks,
-                                          docker.io/otomi/api,
-                                          docker.io/drone/drone-runner-kube,
-                                          docker.io/grafana/promtail,
-                                          quay.io/argoprojlabs/argocd-image-updater
-                                        ) or (k8s.ns.name = "kube-system")
-                                          or (k8s.ns.name = "ingress")
-                                      )
-                                  - macro: user_known_write_below_etc_activities
-                                    condition: (
-                                        (container.image.repository = docker.io/goharbor/harbor-core and proc.name = cp) or
-                                        (container.image.repository = docker.io/goharbor/harbor-registryctl and proc.name = cp) or
-                                        (container.image.repository = docker.io/goharbor/registry-photon and proc.name = cp) or
-                                        (container.image.repository = docker.io/goharbor/trivy-adapter-photon and proc.name = cp)
-                                      )
-                                  - macro: user_sensitive_mount_containers
-                                    condition: (
-                                        container.image.repository in (
-                                          quay.io/prometheus/node-exporter
-                                        )
-                                      )
-                                  - macro: user_trusted_containers
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/drone/drone-runner-kube,
-                                          docker.io/otomi/api,
-                                          docker.io/otomi/tasks
-                                        )
-                                      )
-                                  - macro: user_known_package_manager_in_container
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/otomi/tasks
-                                        )
-                                      )
-                                  - macro: user_known_k8s_client_container
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/otomi/tasks,
-                                          ocker.io/otomi/core
-                                        ) or (k8s.ns.name = "drone-pipelines")
-                                      )
-                                  - macro: user_known_non_sudo_setuid_conditions
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/otomi/tasks,
-                                          docker.io/otomi/api,
-                                          docker.io/otomi/console,
-                                          docker.io/gitea/gitea,
-                                          docker.io/grafana/grafana
-                                        ) or (k8s.ns.name = "ingress")
-                                          or (k8s.ns.name = "keycloak")
-                                      )
-                                  - macro: excessively_capable_container
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/otomi/console,
-                                          docker.io/otomi/api
-                                        ) or (k8s.ns.name = "keycloak")
-                                      )
-                                  - macro: user_known_write_below_root_activities
-                                    condition: (
-                                        k8s.ns.name = "drone-pipelines"
-                                      )
-                                  - macro: user_known_network_tool_activities
-                                    condition: (
-                                        container.image.repository in (
-                                          docker.io/gitea/gitea
-                                        ) or (k8s.ns.name = "keycloak")  
-                                      )
-                                  - macro: user_known_create_files_below_dev_activities
-                                    condition: (
-                                        container.image.repository in (
-                                          quay.io/operatorhubio/catalog
-                                        )
-                                      )
-                      enabled: false
-                      falcoSidekick:
-                          minPrio: informational
-                          replicas: 1
-                      resources:
-                          falco:
-                              limits:
-                                  cpu: 500m
-                                  memory: 256Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          falcoExporter:
-                              limits:
-                                  cpu: 100m
-                                  memory: 64Mi
-                              requests:
-                                  cpu: 50m
-                                  memory: 32Mi
-                          falcoSidekick:
-                              limits:
-                                  cpu: 50m
-                                  memory: 64Mi
-                              requests:
-                                  cpu: 20m
-                                  memory: 32Mi
-                  gatekeeper:
-                      auditFromCache: false
-                      auditInterval: 60
-                      constraintViolationsLimit: 20
-                      dataSync:
-                          - kind: CronJob
-                            version: v1
-                          - kind: DaemonSet
-                            version: v1
-                          - kind: Deployment
-                            version: v1
-                          - kind: Job
-                            version: v1
-                          - kind: Pod
-                            version: v1
-                          - kind: StatefulSet
-                            version: v1
-                      disableValidatingWebhook: false
-                      emitAdmissionEvents: false
-                      emitAuditEvents: false
-                      enabled: true
-                      excludedNamespaces:
-                          - sandbox
-                      logLevel: INFO
-                      replicas: 1
-                  gitea:
-                      adminPassword: bladibla
-                      adminUsername: otomi-admin
-                      enabled: false
-                      postgresqlPassword: postgresqlPassword
-                  grafana:
-                      adminPassword: somesecretvalue
-                      enabled: true
-                  harbor:
-                      adminPassword: bladibla
-                      backup:
-                          enabled: true
-                          schedule: 0/3 * * * *
-                      databasePassword: somesecretvalue
-                      enabled: true
-                      persistence:
-                          imageChartStorage:
-                              gcs:
-                                  bucket: otomi-harbor
-                                  encodedkey: somesecretvalue
-                                  rootdirectory: /google/demo
-                              type: gcs
-                      registry:
-                          credentials:
-                              password: bladibla
-                              username: otomi-admin
-                      resources:
-                          trivy:
-                              limits:
-                                  cpu: 400m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 200m
-                                  memory: 256Mi
-                      secretKey: somesecretvalue
-                  hello:
-                      enabled: true
-                  host-mods:
-                      enabled: true
-                  httpbin:
-                      enabled: true
-                  ingress-azure:
-                      enabled: false
-                  ingress-nginx:
-                      autoscaling:
-                          enabled: true
-                          maxReplicas: 10
-                          minReplicas: 2
-                      enabled: true
-                      modsecurity:
-                          block: false
-                          enabled: false
-                          owasp: true
-                      private:
-                          autoscaling:
-                              enabled: true
-                              maxReplicas: 10
-                              minReplicas: 2
-                          enabled: false
-                  ingress-nginx-net-a:
-                      _rawValues:
-                          controller:
-                              config:
-                                  modsecurity-snippet: |
-                                      SecRuleRemoveById 911101
-                      maxBodySize: 1024m
-                      modsecurity:
-                          enabled: true
-                      resources:
-                          limits:
-                              cpu: 200m
-                              memory: 256Mi
-                          requests:
-                              cpu: 100m
-                              memory: 192Mi
-                  ingress-nginx-platform:
-                      _rawValues:
-                          controller:
-                              config:
-                                  modsecurity-snippet: |
-                                      SecRuleRemoveById 911102
-                      maxBodySize: 2048m
-                      modsecurity:
-                          enabled: true
-                      resources:
-                          limits:
-                              cpu: 200m
-                              memory: 256Mi
-                          requests:
-                              cpu: 100m
-                              memory: 192Mi
-                  ingress-nginx-private:
-                      _rawValues:
-                          controller:
-                              config:
-                                  modsecurity-snippet: |
-                                      SecRuleRemoveById 911103
-                      maxBodySize: 4096m
-                      modsecurity:
-                          enabled: true
-                      resources:
-                          limits:
-                              cpu: 200m
-                              memory: 256Mi
-                          requests:
-                              cpu: 100m
-                              memory: 192Mi
-                  istio:
-                      autoscaling:
-                          egressgateway:
-                              maxReplicas: 10
-                              minReplicas: 2
-                          ingressgateway:
-                              maxReplicas: 5
-                              minReplicas: 1
-                          pilot:
-                              maxReplicas: 5
-                              minReplicas: 1
-                      egressGateway:
-                          enabled: false
-                      enabled: true
-                      global:
-                          logging:
-                              level: default:warn
-                      meshConfig:
-                          accessLogFile: /dev/stdout
-                          defaultConfig:
-                              tracing:
-                                  sampling: 0.1
-                          enableAutoMtls: true
-                          extensionProviders:
-                              - envoyExtAuthzGrpc: null
-                                includeRequestBodyInCheck:
-                                    maxRequestBytes: 1000000
-                                name: ext-authz-chain-grpc
-                                port: '80'
-                                service: s1.test.svc.cluster.local
-                      resources:
-                          ingressgateway:
-                              limits:
-                                  cpu: 500m
-                                  memory: 256Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          pilot:
-                              limits:
-                                  cpu: 100m
-                                  memory: 256Mi
-                              requests:
-                                  cpu: 10m
-                                  memory: 100Mi
-                          prometheus:
-                              limits:
-                                  cpu: 500m
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 200m
-                                  memory: 500Mi
-                          proxy:
-                              limits:
-                                  cpu: 500m
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 20m
-                                  memory: 80Mi
-                  jaeger:
-                      enabled: true
-                  keycloak:
-                      address: https://keycloak.demo.eks.otomi.cloud
-                      adminPassword: bladibla
-                      adminUsername: otomi-admin
-                      enabled: true
-                      idp:
-                          alias: redkubes-azure
-                          clientID: otomi
-                          clientSecret: somsecretvalue
-                      postgresqlPassword: postgresqlPassword
-                      theme: otomi
-                  kiali:
-                      enabled: true
-                      resources:
-                          operator:
-                              limits:
-                                  cpu: 200m
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 50m
-                                  memory: 256Mi
-                          pod:
-                              limits:
-                                  cpu: 200m
-                                  memory: 256Mi
-                              requests:
-                                  cpu: 50m
-                                  memory: 128Mi
-                  knative:
-                      enabled: false
-                      serving:
-                          replicas: 1
-                  kube-descheduler:
-                      enabled: false
-                  kubeapps:
-                      autoscaling:
-                          dashboard:
-                              maxReplicas: 10
-                              minReplicas: 1
-                          frontend:
-                              maxReplicas: 10
-                              minReplicas: 1
-                          kubeops:
-                              maxReplicas: 10
-                              minReplicas: 1
-                      enableCommonGround: false
-                      enabled: true
-                      postgresqlPassword: postgresqlPassword
-                  kubeclarity:
-                      databasePassword: 123jefkejoql
-                      enabled: true
-                      logLevel: warning
-                      resources:
-                          cdbScanner:
-                              limits:
-                                  cpu: '1'
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 50m
-                                  memory: 50Mi
-                          kubeclarity:
-                              limits:
-                                  cpu: '1'
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 100m
-                                  memory: 200Mi
-                          postgresql:
-                              limits:
-                                  cpu: '1'
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 251m
-                                  memory: 256Mi
-                          sbomDb:
-                              limits:
-                                  cpu: 100m
-                                  memory: 100Mi
-                              requests:
-                                  cpu: 10m
-                                  memory: 20Mi
-                          trivyServer:
-                              limits:
-                                  cpu: '1'
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 200m
-                                  memory: 200Mi
-                          vulnerabilityScanner:
-                              limits:
-                                  cpu: '1'
-                                  memory: 2Gi
-                              requests:
-                                  cpu: 100m
-                                  memory: 256Mi
-                  kured:
-                      _rawValues:
-                          configuration:
-                              endTime: 07:00
-                              rebootDays:
-                                  - su
-                              startTime: 22:00
-                              timeZone: CET
-                      enabled: true
-                      resources:
-                          kuredDaemonSet:
-                              limits:
-                                  cpu: 50m
-                                  memory: 32Mi
-                              requests:
-                                  cpu: 20m
-                                  memory: 16Mi
-                  loki:
-                      adminPassword: somesecretvalue
-                      autoscaling:
-                          distributor:
-                              enabled: true
-                              maxReplicas: 3
-                              minReplicas: 1
-                              targetCPUUtilizationPercentage: 60
-                              targetMemoryUtilizationPercentage: 80
-                          gateway:
-                              enabled: true
-                              maxReplicas: 3
-                              minReplicas: 1
-                              targetCPUUtilizationPercentage: 60
-                              targetMemoryUtilizationPercentage: 80
-                          ingester:
-                              enabled: true
-                              maxReplicas: 3
-                              minReplicas: 1
-                              targetCPUUtilizationPercentage: 60
-                              targetMemoryUtilizationPercentage: 80
-                          querier:
-                              enabled: true
-                              maxReplicas: 3
-                              minReplicas: 1
-                              targetCPUUtilizationPercentage: 60
-                              targetMemoryUtilizationPercentage: 80
-                          queryFrontend:
-                              enabled: true
-                              maxReplicas: 3
-                              minReplicas: 1
-                              targetCPUUtilizationPercentage: 60
-                              targetMemoryUtilizationPercentage: 80
-                      enabled: true
-                      persistence:
-                          ingester:
-                              size: 20Gi
-                          querier:
-                              size: 10Gi
-                      resources:
-                          compactor:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          distributor:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          gateway:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          ingester:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          querier:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          queryFrontend:
-                              limits:
-                                  cpu: 900m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                      retention:
-                          duration: 24h
-                          period: 24h
-                      storage:
-                          azure:
-                              account_key: account_key
-                          type: minioLocal
-                      v11StartDate: 2021-05-13
-                  metrics-server:
-                      apiServer:
-                          create: true
-                      enabled: true
-                      extraArgs:
-                          kubelet-preferred-address-types: InternalIP
-                  minio:
-                      enabled: true
-                      persistence:
-                          enabled: true
-                          size: 20Gi
-                      provisioning:
-                          enabled: true
-                      resources:
-                          limits:
-                              cpu: 1
-                              memory: 1Gi
-                          requests:
-                              cpu: 500m
-                              memory: 128Mi
-                  oauth2-proxy:
-                      config:
-                          cookieSecret: gkhugxJsPjhbCybH
-                  oauth2-proxy-redis:
-                      password: gkhugxJsPjhbCybH
-                  opa-exporter: {}
-                  opencost:
-                      alerts:
-                          costOfAllNodesQuotaPerMonthReached:
-                              quota: 500
-                          enabled: true
-                      enabled: true
-                      resources:
-                          exporter:
-                              limits:
-                                  cpu: 1
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 500m
-                                  memory: 128Mi
-                          ui:
-                              limits:
-                                  cpu: 1
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 500m
-                                  memory: 128Mi
-                  otomi-api:
-                      editorInactivityTimeout: 5
-                      git:
-                          email: some@secret.value
-                          password: somesecretvalue
-                          repoUrl: github.com/redkubes/otomi-values-demo.git
-                          user: someuser
-                  otomi-console: {}
-                  prometheus:
-                      disabledRules:
-                          - InfoInhibitor
-                          - PrometheusOperatorListErrors
-                      enabled: true
-                      remoteWrite:
-                          enabled: true
-                          otomiThanos: false
-                          rwConfig:
-                              basicAuth:
-                                  enabled: true
-                                  password: blalalalalal
-                                  username: testaccount
-                              customConfig: |-
-                                  writeRelabelConfigs:
-                                    - targetLabel: tenant
-                                      sourceLabels:
-                                      - instance
-                                      replacement: otomi-aks-ont
-                                    - targetLabel: cluster
-                                      sourceLabels:
-                                      - instance
-                                      replacement: otomi-aks-ont
-                                    - targetLabel: customer_id
-                                      sourceLabels:
-                                      - instance
-                                      replacement: "00001"
-                                  queueConfig:
-                                    capacity: 18000
-                                    maxShards: 100
-                                    maxSamplesPerSend: 6000
-                              insecureSkipVerify: false
-                              target: https://remote.target.io/api/v1/push
-                      replicas: 1
-                      retentionSize: 4GB
-                      scrapeInterval: 60s
-                      storageSize: 5Gi
-                  prometheus-blackbox-exporter: {}
-                  prometheus-msteams:
-                      enabled: false
-                  promtail:
-                      enabled: false
-                  redis-shared:
-                      enabled: false
-                      sizes:
-                          master: 1Gi
-                  snapshot-controller:
-                      enabled: false
-                  tekton:
-                      enabled: true
-                  thanos:
-                      compactor:
-                          retentionResolution1h: 0s
-                          retentionResolution5m: 0s
-                          retentionResolutionRaw: 0s
-                      enabled: true
-                      objstore:
-                          storageProvider:
-                              type: minioLocal
-                      persistence:
-                          compactor:
-                              size: 8Gi
-                          receiver:
-                              size: 50Gi
-                          ruler:
-                              size: 8Gi
-                          storegateway:
-                              size: 8Gi
-                      query:
-                          replicaCount: 1
-                      receiver:
-                          mode: dual-mode
-                          replicaCount: 2
-                          replicationFactor: 1
-                          tsdbRetention: 7d
-                      receiverDistributor:
-                          enabled: true
-                      resources:
-                          bucketweb:
-                              limits:
-                                  cpu: 100m
-                                  memory: 128Mi
-                              requests:
-                                  cpu: 50m
-                                  memory: 64Mi
-                          compactor:
-                              limits:
-                                  cpu: '1'
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          query:
-                              limits:
-                                  cpu: 500m
-                                  memory: 1Gi
-                              requests:
-                                  cpu: 100m
-                                  memory: 256Mi
-                          queryFrontend:
-                              limits:
-                                  cpu: 500m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          receiver:
-                              limits:
-                                  cpu: '1'
-                                  memory: 2Gi
-                              requests:
-                                  cpu: 200m
-                                  memory: 512Mi
-                          receiverDistributor:
-                              limits:
-                                  cpu: '1'
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                          ruler:
-                              limits:
-                                  cpu: 500m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 256Mi
-                          storegateway:
-                              limits:
-                                  cpu: 500m
-                                  memory: 256Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 128Mi
-                      ruler:
-                          enabled: false
-                  tigera-operator:
-                      enabled: false
-                  trivy:
-                      enabled: true
-                      operator:
-                          replicaCount: 1
-                      resources:
-                          operator:
-                              limits:
-                                  cpu: 500m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 64Mi
-                          trivy:
-                              limits:
-                                  cpu: 500m
-                                  memory: 512Mi
-                              requests:
-                                  cpu: 100m
-                                  memory: 64M
-                  vault:
-                      enabled: true
-                      logLevel: warn
-                      resources:
-                          limits:
-                              cpu: 1000m
-                              memory: 512Mi
-                          requests:
-                              cpu: 500m
-                              memory: 256Mi
-                  velero:
-                      cloud:
-                          google:
-                              project: velero
-                              saKeyJson: '{key in json format}'
-                              serviceAccount: bla
-                          type: google
-                      enabled: true
-                      logLevel: info
-                      resources:
-                          limits:
-                              cpu: 1000m
-                              memory: 512Mi
-                          requests:
-                              cpu: 500m
-                              memory: 128Mi
-                      restic:
-                          enabled: false
-                      storage:
-                          gcs:
-                              bucket: velero
-                              serviceAccount: bla
-                          type: gcs
+            -----BEGIN CERTIFICATE-----
+            MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
+            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+            ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
+            BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
+            Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
+            AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
+            gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
+            L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
+            nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
+            nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
+            biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
+            DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
+            BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
+            ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
+            MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
+            HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
+            MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
+            DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
+            vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
+            y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
+            Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
+            yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
+            xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
+            Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
+            zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
+            qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
+            xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
+            hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
+            -----END CERTIFICATE-----
+          caCertRoot: |
+            -----BEGIN CERTIFICATE-----
+            MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+            ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+            BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+            YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+            AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+            ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+            jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+            wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+            oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+            TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+            fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+            rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+            FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+            mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+            GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+            mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+            Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+            9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+            nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+            qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+            qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+            sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+            CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+            5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+            xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+            fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+            gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+            7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+            -----END CERTIFICATE-----
+          isInitialDeployment: false
+          oidcBaseUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi
+          oidcBaseUrlBackchannel: http://keycloak-http.keycloak/realms/otomi
+          oidcWellKnownUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi/.well-known/openid-configuration
+          oidcWellKnownUrlBackchannel: http://keycloak-http.keycloak/realms/otomi/.well-known/openid-configuration
+          supportedCloud: false
+          untrustedCA: true
+        adminApps:
+          - deps:
+              - prometheus
+            ingress:
+              - auth: true
+                namespace: monitoring
+                port: 9093
+                svc: po-alertmanager
+                type: public
+            name: alertmanager
+            tags:
+              - alerting
+              - observability
+          - ingress:
+              - auth: true
+                namespace: argocd
+                svc: argocd-server
+                type: public
+            isShared: true
+            name: argocd
+            ownHost: true
+            tags:
+              - cicd
+              - gitops
+          - name: cert-manager
+            tags:
+              - ingress
+              - security
+              - tls
+          - ingress:
+              - auth: true
+                namespace: drone
+                removeRequestHeaders:
+                  - authorization
+                svc: drone
+                type: public
+              - forwardPath: true
+                namespace: drone
+                paths:
+                  - /hook
+                  - /api/user
+                  - /api/repo
+                removeRequestHeaders:
+                  - authorization
+                svc: drone
+                type: public
+            isShared: true
+            name: drone
+            ownHost: true
+            tags:
+              - cicd
+              - deployment
+              - pipeline
+          - ingress:
+              - auth: true
+                namespace: ingress
+                svc: tty
+                type: public
+            isShared: true
+            name: tty
+            ownHost: true
+            tags:
+              - tty
+          - name: external-dns
+            tags:
+              - ingress
+              - security
+              - tls
+          - name: external-secrets
+            tags:
+              - secrets
+              - security
+              - tls
+          - deps:
+              - prometheus
+            ingress:
+              - auth: true
+                namespace: falco
+                port: 2802
+                svc: falco-falcosidekick-ui
+                type: public
+            isShared: true
+            name: falco
+            ownHost: true
+            tags:
+              - security
+          - name: gatekeeper
+            tags:
+              - security
+              - policies
+              - observability
+          - ingress:
+              - namespace: gitea
+                port: 3000
+                svc: gitea-http
+                type: public
+            isShared: true
+            name: gitea
+            ownHost: true
+            tags:
+              - git
+          - deps:
+              - prometheus
+            ingress:
+              - auth: true
+                namespace: grafana
+                removeRequestHeaders:
+                  - authorization
+                svc: po-grafana
+                type: public
+            name: grafana
+            ownHost: true
+            shortcuts:
+              - description: NGINX ingress controller metrics
+                path: /d/nginx/nginx-ingress-controller?orgId=1&refresh=5s
+                title: NGINX
+            tags:
+              - tracing
+              - telemetry
+              - observability
+          - ingress:
+              - auth: true
+                namespace: harbor
+                svc: harbor-portal
+                type: public
+              - auth: true
+                forwardPath: true
+                namespace: harbor
+                paths:
+                  - /api/
+                  - /c/
+                svc: harbor-core
+                type: public
+              - forwardPath: true
+                namespace: harbor
+                paths:
+                  - /chartrepo/
+                  - /service/
+                  - /v1/
+                  - /v2/
+                svc: harbor-core
+                type: public
+            isShared: true
+            name: harbor
+            ownHost: true
+            tags:
+              - security
+          - hide: true
+            name: hello
+            tags:
+              - demo
+          - ingress:
+              - auth: true
+                namespace: httpbin
+                svc: httpbin
+                type: public
+            isShared: true
+            name: httpbin
+            ownHost: true
+            tags:
+              - dev
+              - testing
+              - debugging
+          - name: ingress-nginx
+            tags:
+              - ingress
+              - auth
+          - name: istio
+            tags:
+              - ingress
+              - egress
+              - routing
+              - security
+              - tls
+              - observability
+              - policies
+          - deps:
+              - istio
+            ingress:
+              - auth: true
+                forwardPath: true
+                namespace: jaeger
+                port: 16686
+                svc: jaeger-operator-jaeger-query
+                type: public
+            isShared: true
+            name: jaeger
+            tags:
+              - ingress
+              - telemetry
+              - observability
+          - ingress:
+              - namespace: keycloak
+                svc: keycloak-http
+                type: public
+            name: keycloak
+            ownHost: true
+            shortcuts:
+              - description: Edit your account settings.
+                path: /realms/otomi/account/
+                title: Account
+            tags:
+              - auth
+              - sso
+          - deps:
+              - istio
+              - prometheus
+            ingress:
+              - auth: true
+                forwardPath: true
+                namespace: kiali
+                port: 20001
+                removeRequestHeaders:
+                  - authorization
+                svc: kiali
+                type: public
+            name: kiali
+            path: /api/auth/openid_redirect
+            tags:
+              - tracing
+              - telemetry
+              - observability
+          - deps:
+              - istio
+            name: knative
+            tags:
+              - serverless
+              - functions
+          - deps:
+              - operator-lifecycle-manager
+            ingress:
+              - namespace: kubeapps
+                svc: kubeapps
+                type: public
+            isShared: true
+            name: kubeapps
+            ownHost: true
+            tags:
+              - dev
+              - apps
+          - ingress:
+              - auth: true
+                namespace: kubeclarity
+                port: 8080
+                svc: kubeclarity
+                type: public
+            isShared: true
+            name: kubeclarity
+            ownHost: true
+            tags:
+              - security
+          - name: kured
+            tags:
+              - security
+          - name: tekton
+            tags:
+              - buildpacks
+          - deps:
+              - grafana
+              - prometheus
+              - minio
+            name: loki
+            path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
+            shortcuts:
+              - description: All logs generated in the "ingress" namespace
+                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D","refId":"A"%7D%5D
+                title: Ingress logs
+              - description: All OWASP rule violations
+                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D%20%7C%3D%5C"ModSecurity:%20%5C""%7D%5D
+                title: OWASP violations
+              - description: Kube API violations logged by OPA gatekepeer
+                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"gatekeeper-system%5C"%7D%20%7C%3D%5C"Policy:%20%5C""%7D%5D
+                title: Gatekeeper violations
+            tags:
+              - logging
+              - telemetry
+              - observability
+            useHost: grafana
+          - ingress:
+              - auth: true
+                namespace: minio
+                port: 9001
+                removeRequestHeaders:
+                  - authorization
+                svc: minio
+                type: public
+            name: minio
+            ownHost: true
+            tags:
+              - storage
+              - backup
+          - ingress:
+              - auth: true
+                namespace: opencost
+                port: 9090
+                svc: opencost
+                type: public
+            name: opencost
+            ownHost: true
+            tags:
+              - finops
+          - hide: true
+            ingress:
+              - auth: true
+                namespace: otomi
+                paths:
+                  - /api/
+                svc: otomi-api
+                type: public
+              - auth: true
+                namespace: otomi
+                svc: otomi-console
+                type: public
+            isShared: true
+            name: otomi
+            ownHost: true
+          - ingress:
+              - auth: true
+                namespace: monitoring
+                port: 9090
+                svc: po-prometheus
+                type: public
+            name: prometheus
+            tags:
+              - metrics
+              - observability
+          - deps:
+              - prometheus
+              - grafana
+              - minio
+            ingress:
+              - auth: true
+                forwardPath: true
+                namespace: monitoring
+                port: 9090
+                svc: thanos-query-frontend
+                type: public
+              - forwardPath: true
+                namespace: monitoring
+                paths:
+                  - /api/
+                port: 19291
+                svc: thanos-receive
+                type: public
+            name: thanos
+            ownHost: true
+            tags:
+              - metrics
+              - observability
+          - deps:
+              - prometheus
+              - grafana
+            name: trivy
+            tags:
+              - security
+          - deps:
+              - external-secrets
+            ingress:
+              - auth: true
+                namespace: vault
+                port: 8200
+                svc: vault
+                type: public
+            isShared: true
+            name: vault
+            ownHost: true
+            path: /ui/vault/auth?redirect_to=%2Fvault%2Fsecrets%2Fsecret%2Flist%2Fteams%2F#NS#%2F&with=oidc
+            tags:
+              - secrets
+              - security
+              - observability
+          - name: velero
+            tags:
+              - backup
+        alerts:
+          drone:
+            - slack
+          email:
+            critical: admins@yourdoma.in
+            nonCritical: admins@yourdoma.in
+          groupInterval: 5m
+          receivers:
+            - slack
+            - email
+          repeatInterval: 3h
+          slack:
+            url: https://hooks.slack.com/services/id
+        apps:
+          alertmanager:
+            enabled: true
+          argocd:
+            autoscaling:
+              enabled: false
+              maxReplicas: 3
+              minReplicas: 1
+              targetCPUUtilizationPercentage: 50
+            enabled: true
+          aws-alb-ingress-controller:
+            enabled: false
+          aws-ebs-csi-driver:
+            enabled: false
+          cert-manager:
+            customRootCA: |
+              -----BEGIN CERTIFICATE-----
+              MIIDdDCCAlygAwIBAgIBATANBgkqhkiG9w0BAQUFADBuMRUwEwYDVQQDEwxyZWRr
+              dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
+              EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
+              HhcNMjExMTAzMTAxOTAyWhcNMzExMTAzMTAxOTAyWjBuMRUwEwYDVQQDEwxyZWRr
+              dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
+              EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
+              ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD4quPwHrharZhmqVQx/75N
+              M7Vp3ZmSd3gR2u8Dc1PkmEa6W9CiheVAB5KCzdN5sWaOlFKTy5sHg/zvyYZjvNGX
+              xaHCa4i6OyRgiTOC4NCrxuN5010G0vAxYaM1aIFcqObXuLcaK6miOybDLRfDxoHl
+              g/TKqdiPOMEb2ZgphFxL7oYXjkobOggH+wzwwMIc/1nA3eBjEPsIkQehmb0R0Kxw
+              K5VHPCvbPQb3USVqUs+NmsuCxmqkTtI32WqR0IuNAVqjaD9oNqcsKBgUOPYLYXM8
+              xsTzIn0QPysJIKUCRn1quHwvCQc1RnQBB8UG6iJboVdRe0GNS13vu5ikhoCb0oyV
+              AgMBAAGjHTAbMAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MA0GCSqGSIb3DQEB
+              BQUAA4IBAQBJWHPGnTqXME/MGwG2nAG/JqiCQ0ZOOyKgwN97wrQIlbra2BaUT1K4
+              tMDOjZlft1Luipg/IkzzMXt4eAmqGMxLIweqbve6aLm8KTpHkLdxLm3VPnhK8zzg
+              ysRRRjtkMo9KUOSvrS2dFsY+fQnbGUzpRcK8RrzM6CpgIaf29neP1xLUWQuUsy5y
+              yKCb6OQ9vaJBf/uvz73rQq0ym4Kx0FCFssshaja6lbz/jqCJmppdZE5pe5jvMVVv
+              ae5UQLbva0JyLY8Rc1vSY/epIHMLrV90GEagSkF/ejgF3uh8cliLuUYFAFyU8TnN
+              FWG+enMJfR04aWjp8M3MQ1IoCPVxoXxI
+              -----END CERTIFICATE-----
+            customRootCAKey: |
+              -----BEGIN RSA PRIVATE KEY-----
+              MIIEpQIBAAKCAQEA+Krj8B64Wq2YZqlUMf++TTO1ad2Zknd4EdrvA3NT5JhGulvQ
+              ooXlQAeSgs3TebFmjpRSk8ubB4P878mGY7zRl8WhwmuIujskYIkzguDQq8bjedNd
+              BtLwMWGjNWiBXKjm17i3Giupojsmwy0Xw8aB5YP0yqnYjzjBG9mYKYRcS+6GF45K
+              GzoIB/sM8MDCHP9ZwN3gYxD7CJEHoZm9EdCscCuVRzwr2z0G91ElalLPjZrLgsZq
+              pE7SN9lqkdCLjQFao2g/aDanLCgYFDj2C2FzPMbE8yJ9ED8rCSClAkZ9arh8LwkH
+              NUZ0AQfFBuoiW6FXUXtBjUtd77uYpIaAm9KMlQIDAQABAoIBAQCTsIuotdYwpSH6
+              9172Qzq3h5qbwe3QO/yoPivvFLQi9P4s+RM1M+kw2k5+Odj8UgzjadyRwz/UeuPj
+              VwHmguLJDaxBWLTgRvgYDeT2Oqg1He9FD/AUeXwHGEJjGiqa6gYQ4bh+Zqhdnlwr
+              V8DhmijUNEdThwUEK2UmMVpabi6TOW/dfO6sbnOHYwx326qF3LhYcUrmdeowEGLT
+              UhxdXJQQUsfD+zft6dcPnqucIxd5OEsn3L8/pcumOxHUGFBHDMuB5nTpcZyDxKaN
+              joC0zQy0BDQIMN1F7wNRukSiSYqvRvmvztF2Ka0yEWAdvBBXVVN8nKQw69oGoe9B
+              EQ5HSkKBAoGBAP0KnCE19jW9jq1CWFkFwd1BALWA3GOuxJqSX6M5APM+JRBR4UOZ
+              AUOogvGlrc1ns58q7oNoc1CHiMHd2lNFgfqWqopfVz1Tt9qHqU6VoJnkmJlJRriE
+              57F08RTjslTFzYEsE9zMlL1xa5pq1aGAFB0/mYuxopRw39mS14ugxF1pAoGBAPuT
+              MFLfp2wttGe2WhVepOnhD13sEMGCS6GE16jinjP3qAWIPM/Wdy+Ab8n+KWQkYPLw
+              UsQVi+41LWFIexjzdrq9rG5LQbZdjDCyR4eomDGZhc0Vtsu79NbVrnSmjH8w6psa
+              DXB1uN9/VcCzae/hRpk2Q6zFiMcPE8utUU5RvFRNAoGBAJ19+wsYoPN11dW0k3Rl
+              BvKEwMI3P/SzFB74t5nJovPCXCM6MzB1jLnlqgppCjHsN3n7qJQVcKBQmye+w2JM
+              wseK+v5AtPWwo5/aC+CjdGAUTX4qg1/ZKLPkiyBrT9U/f9bD7mDg3DrE2yozEGAC
+              bYJ+0TyHBR/K2Sh8Irf/CfjxAoGBAM4wuwCRkpUVeLEwQfEV2zBdZ8zg+HLBqd8+
+              E8u1wVhyeOHf4YevDYx/RiBWEfKj5ln3Ir7XshKQvxrm3w16Liur3bGgOMGRNp+K
+              3xmO0v6EB6gpTeL5sBiMlinBf5GXtBFfbvhnZBi6Mrx30DHtf4F/ekQWup37+4uK
+              CAOa9jJZAoGAYbU4CoCxktBECxAVAjtpvYW5176cxiitd75s1ANhXGiOH1A6/y6H
+              rnZ+fMAuvPjrDXbtmqJsq0RXq1E07ng4ZDIjN+0pShVFQdakJRFo1y+d3b82lBYX
+              EZrfMBCWVj31dXeGEHfVvOpwrQ5ffTzs2lVmTh7Ft61gs4TJ7gNTDbE=
+              -----END RSA PRIVATE KEY-----
+            email: test@test.local
+            issuer: letsencrypt
+            resources:
+              limits:
+                cpu: 200m
+                memory: 384Mi
+              requests:
+                cpu: 50m
+                memory: 64Mi
+            stage: staging
+          cloudnative-pg:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+          cluster-autoscaler:
+            enabled: false
+          cluster-overprovisioner:
+            enabled: true
+          demo-tlspass:
+            enabled: false
+          drone:
+            adminUser: somesecretvalue
+            debug: false
+            enabled: true
+            githubAdmins:
+              org: redkubes
+              team: admins
+              token: somesecretvalue
+            orgsFilter: redkubes
+            repoFilter: redkubes
+            sharedSecret: somesecretvalue
+            sourceControl:
+              github:
+                clientID: somesecretvalue
+                clientSecretValue: somesecretvalue
+                server: https://github.com
+              provider: github
+              username: otomi-admin
+            trace: false
+          drone-admit-members:
+            enabled: true
+          external-dns:
+            enabled: true
+            logLevel: info
+          external-secrets:
+            enabled: true
+            logLevel: warn
+            pollingInterval: 60000
+          falco:
+            _rawValues:
+              customRules:
+                otomi-rules.yaml: >-
+                  - macro: k8s_containers
+                    condition: (
+                        container.image.repository in (
+                          docker.io/openpolicyagent/gatekeeper,
+                          docker.io/velero/velero,
+                          docker.io/weaveworks/kured,
+                          k8s.gcr.io/kube-state-metrics/kube-state-metrics,
+                          quay.io/jetstack/cert-manager-cainjector,
+                          quay.io/jetstack/cert-manager-controller,
+                          quay.io/jetstack/cert-manager-webhook,
+                          quay.io/prometheus-operator/prometheus-operator,
+                          quay.io/prometheus/prometheus,
+                          quay.io/kiwigrid/k8s-sidecar,
+                          docker.io/otomi/core,
+                          docker.io/otomi/tasks,
+                          docker.io/otomi/api,
+                          docker.io/drone/drone-runner-kube,
+                          docker.io/grafana/promtail,
+                          quay.io/argoprojlabs/argocd-image-updater
+                        ) or (k8s.ns.name = "kube-system")
+                          or (k8s.ns.name = "ingress")
+                      )
+                  - macro: user_known_write_below_etc_activities
+                    condition: (
+                        (container.image.repository = docker.io/goharbor/harbor-core and proc.name = cp) or
+                        (container.image.repository = docker.io/goharbor/harbor-registryctl and proc.name = cp) or
+                        (container.image.repository = docker.io/goharbor/registry-photon and proc.name = cp) or
+                        (container.image.repository = docker.io/goharbor/trivy-adapter-photon and proc.name = cp)
+                      )
+                  - macro: user_sensitive_mount_containers
+                    condition: (
+                        container.image.repository in (
+                          quay.io/prometheus/node-exporter
+                        )
+                      )
+                  - macro: user_trusted_containers
+                    condition: (
+                        container.image.repository in (
+                          docker.io/drone/drone-runner-kube,
+                          docker.io/otomi/api,
+                          docker.io/otomi/tasks
+                        )
+                      )
+                  - macro: user_known_package_manager_in_container
+                    condition: (
+                        container.image.repository in (
+                          docker.io/otomi/tasks
+                        )
+                      )
+                  - macro: user_known_k8s_client_container
+                    condition: (
+                        container.image.repository in (
+                          docker.io/otomi/tasks,
+                          ocker.io/otomi/core
+                        ) or (k8s.ns.name = "drone-pipelines")
+                      )
+                  - macro: user_known_non_sudo_setuid_conditions
+                    condition: (
+                        container.image.repository in (
+                          docker.io/otomi/tasks,
+                          docker.io/otomi/api,
+                          docker.io/otomi/console,
+                          docker.io/gitea/gitea,
+                          docker.io/grafana/grafana
+                        ) or (k8s.ns.name = "ingress")
+                          or (k8s.ns.name = "keycloak")
+                      )
+                  - macro: excessively_capable_container
+                    condition: (
+                        container.image.repository in (
+                          docker.io/otomi/console,
+                          docker.io/otomi/api
+                        ) or (k8s.ns.name = "keycloak")
+                      )
+                  - macro: user_known_write_below_root_activities
+                    condition: (
+                        k8s.ns.name = "drone-pipelines"
+                      )
+                  - macro: user_known_network_tool_activities
+                    condition: (
+                        container.image.repository in (
+                          docker.io/gitea/gitea
+                        ) or (k8s.ns.name = "keycloak")  
+                      )
+                  - macro: user_known_create_files_below_dev_activities
+                    condition: (
+                        container.image.repository in (
+                          quay.io/operatorhubio/catalog
+                        )
+                      )
+            enabled: false
+            falcoSidekick:
+              minPrio: informational
+              replicas: 1
+            resources:
+              falco:
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              falcoExporter:
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+                requests:
+                  cpu: 50m
+                  memory: 32Mi
+              falcoSidekick:
+                limits:
+                  cpu: 50m
+                  memory: 64Mi
+                requests:
+                  cpu: 20m
+                  memory: 32Mi
+          gatekeeper:
+            auditFromCache: false
+            auditInterval: 60
+            constraintViolationsLimit: 20
+            dataSync:
+              - kind: CronJob
+                version: v1
+              - kind: DaemonSet
+                version: v1
+              - kind: Deployment
+                version: v1
+              - kind: Job
+                version: v1
+              - kind: Pod
+                version: v1
+              - kind: StatefulSet
+                version: v1
+            disableValidatingWebhook: false
+            emitAdmissionEvents: false
+            emitAuditEvents: false
+            enabled: true
+            excludedNamespaces:
+              - sandbox
+            logLevel: INFO
+            replicas: 1
+          gitea:
+            adminPassword: bladibla
+            adminUsername: otomi-admin
+            enabled: false
+            postgresqlPassword: postgresqlPassword
+          grafana:
+            adminPassword: somesecretvalue
+            enabled: true
+          harbor:
+            adminPassword: bladibla
+            backup:
+              enabled: true
+              schedule: 0/3 * * * *
+            databasePassword: somesecretvalue
+            enabled: true
+            persistence:
+              imageChartStorage:
+                gcs:
+                  bucket: otomi-harbor
+                  encodedkey: somesecretvalue
+                  rootdirectory: /google/demo
+                type: gcs
+            registry:
+              credentials:
+                password: bladibla
+                username: otomi-admin
+            resources:
+              trivy:
+                limits:
+                  cpu: 400m
+                  memory: 512Mi
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+            secretKey: somesecretvalue
+          hello:
+            enabled: true
+          host-mods:
+            enabled: true
+          httpbin:
+            enabled: true
+          ingress-azure:
+            enabled: false
+          ingress-nginx:
+            autoscaling:
+              enabled: true
+              maxReplicas: 10
+              minReplicas: 2
+            enabled: true
+            modsecurity:
+              block: false
+              enabled: false
+              owasp: true
+            private:
+              autoscaling:
+                enabled: true
+                maxReplicas: 10
+                minReplicas: 2
+              enabled: false
+          ingress-nginx-net-a:
+            _rawValues:
+              controller:
+                config:
+                  modsecurity-snippet: |
+                    SecRuleRemoveById 911101
+            maxBodySize: 1024m
+            modsecurity:
+              enabled: true
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 192Mi
+          ingress-nginx-platform:
+            _rawValues:
+              controller:
+                config:
+                  modsecurity-snippet: |
+                    SecRuleRemoveById 911102
+            maxBodySize: 2048m
+            modsecurity:
+              enabled: true
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 192Mi
+          ingress-nginx-private:
+            _rawValues:
+              controller:
+                config:
+                  modsecurity-snippet: |
+                    SecRuleRemoveById 911103
+            maxBodySize: 4096m
+            modsecurity:
+              enabled: true
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 192Mi
+          istio:
+            autoscaling:
+              egressgateway:
+                maxReplicas: 10
+                minReplicas: 2
+              ingressgateway:
+                maxReplicas: 5
+                minReplicas: 1
+              pilot:
+                maxReplicas: 5
+                minReplicas: 1
+            egressGateway:
+              enabled: false
+            enabled: true
+            global:
+              logging:
+                level: default:warn
+            meshConfig:
+              accessLogFile: /dev/stdout
+              defaultConfig:
+                tracing:
+                  sampling: 0.1
+              enableAutoMtls: true
+              extensionProviders:
+                - envoyExtAuthzGrpc: null
+                  includeRequestBodyInCheck:
+                    maxRequestBytes: 1000000
+                  name: ext-authz-chain-grpc
+                  port: '80'
+                  service: s1.test.svc.cluster.local
+            resources:
+              ingressgateway:
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              pilot:
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+                requests:
+                  cpu: 10m
+                  memory: 100Mi
+              prometheus:
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                requests:
+                  cpu: 200m
+                  memory: 500Mi
+              proxy:
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                requests:
+                  cpu: 20m
+                  memory: 80Mi
+          jaeger:
+            enabled: true
+          keycloak:
+            address: https://keycloak.demo.eks.otomi.cloud
+            adminPassword: bladibla
+            adminUsername: otomi-admin
+            enabled: true
+            idp:
+              alias: redkubes-azure
+              clientID: otomi
+              clientSecret: somsecretvalue
+            postgresqlPassword: postgresqlPassword
+            theme: otomi
+          kiali:
+            enabled: true
+            resources:
+              operator:
+                limits:
+                  cpu: 200m
+                  memory: 1Gi
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+              pod:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+          knative:
+            enabled: false
+            serving:
+              replicas: 1
+          kube-descheduler:
+            enabled: false
+          kubeapps:
+            autoscaling:
+              dashboard:
+                maxReplicas: 10
+                minReplicas: 1
+              frontend:
+                maxReplicas: 10
+                minReplicas: 1
+              kubeops:
+                maxReplicas: 10
+                minReplicas: 1
+            enableCommonGround: false
+            enabled: true
+            postgresqlPassword: postgresqlPassword
+          kubeclarity:
+            databasePassword: 123jefkejoql
+            enabled: true
+            logLevel: warning
+            resources:
+              cdbScanner:
+                limits:
+                  cpu: '1'
+                  memory: 1Gi
+                requests:
+                  cpu: 50m
+                  memory: 50Mi
+              kubeclarity:
+                limits:
+                  cpu: '1'
+                  memory: 1Gi
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+              postgresql:
+                limits:
+                  cpu: '1'
+                  memory: 1Gi
+                requests:
+                  cpu: 251m
+                  memory: 256Mi
+              sbomDb:
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+                requests:
+                  cpu: 10m
+                  memory: 20Mi
+              trivyServer:
+                limits:
+                  cpu: '1'
+                  memory: 1Gi
+                requests:
+                  cpu: 200m
+                  memory: 200Mi
+              vulnerabilityScanner:
+                limits:
+                  cpu: '1'
+                  memory: 2Gi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+          kured:
+            _rawValues:
+              configuration:
+                endTime: 07:00
+                rebootDays:
+                  - su
+                startTime: 22:00
+                timeZone: CET
+            enabled: true
+            resources:
+              kuredDaemonSet:
+                limits:
+                  cpu: 50m
+                  memory: 32Mi
+                requests:
+                  cpu: 20m
+                  memory: 16Mi
+          loki:
+            adminPassword: somesecretvalue
+            autoscaling:
+              distributor:
+                enabled: true
+                maxReplicas: 3
+                minReplicas: 1
+                targetCPUUtilizationPercentage: 60
+                targetMemoryUtilizationPercentage: 80
+              gateway:
+                enabled: true
+                maxReplicas: 3
+                minReplicas: 1
+                targetCPUUtilizationPercentage: 60
+                targetMemoryUtilizationPercentage: 80
+              ingester:
+                enabled: true
+                maxReplicas: 3
+                minReplicas: 1
+                targetCPUUtilizationPercentage: 60
+                targetMemoryUtilizationPercentage: 80
+              querier:
+                enabled: true
+                maxReplicas: 3
+                minReplicas: 1
+                targetCPUUtilizationPercentage: 60
+                targetMemoryUtilizationPercentage: 80
+              queryFrontend:
+                enabled: true
+                maxReplicas: 3
+                minReplicas: 1
+                targetCPUUtilizationPercentage: 60
+                targetMemoryUtilizationPercentage: 80
+            enabled: true
+            persistence:
+              ingester:
+                size: 20Gi
+              querier:
+                size: 10Gi
+            resources:
+              compactor:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              distributor:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              gateway:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              ingester:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              querier:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              queryFrontend:
+                limits:
+                  cpu: 900m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+            retention:
+              duration: 24h
+              period: 24h
+            storage:
               azure:
-                  appgw:
-                      isManaged: true
-                  monitor:
-                      clientId: somesecretvalue
-                      clientSecret: somesecretvalue
-                      subscriptionId: somesecretvalue
-                      tenantId: somesecretvalue
-                  resourceGroup: somevalue
-                  subscriptionId: somevalue
-                  tenantId: somevalue
-              cloud:
-                  skipStorageClasses:
-                      - std
-                      - std-immediate
-              cluster:
-                  apiName: eks_otomi-cloud_eu-central-1_otomi-eks-demo
-                  apiServer: https://1.1.1.1:8443
-                  domainSuffix: demo.eks.otomi.cloud
-                  k8sContext: otomi-eks-demo
-                  k8sVersion: '1.25'
-                  name: demo
-                  owner: redkubes
-                  provider: custom
-                  region: eu-central-1
-              dns:
-                  domainFilters:
-                      - otomi.cloud
-                  provider:
-                      aws:
-                          credentials:
-                              accessKey: AAAAAAAAAAAAAAAAA
-                              secretKey: DuJ/T6fFYMysjRUxxxxxxxxxxxxxxxxx
-                          region: eu-central-1
-                  zoneIdFilters:
-                      - otomi
-              home:
-                  email:
-                      critical: admins@yourdoma.in
-                  receivers:
-                      - slack
-                  slack:
-                      channel: mon-otomi
-                      channelCrit: mon-otomi-crit
-                      url: https://hooks.slack.com/services/id
-              ingress:
-                  classes:
-                      - className: platform
-                        entrypoint: ''
-                        network: public
-                      - className: private
-                        entrypoint: ''
-                        loadBalancerSubnet: subnet
-                        network: private
-                      - className: net-a
-                        entrypoint: ''
-                        loadBalancerIP: 11.0.0.1
-                        loadBalancerRG: myrg
-                        network: public
-                        sourceIpAddressFiltering: 10.0.0.0/24
-                  platformClass:
-                      className: platform
-                      entrypoint: ''
-                      network: public
-              k8s:
-                  namespaces:
-                      - app: argocd
-                        name: argocd
-                      - disableIstioInjection: true
-                        name: cert-manager
-                      - app: cloudnative-pg
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: cnpg-system
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: default
-                      - name: drone
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: drone-pipelines
-                      - disableIstioInjection: true
-                        name: external-dns
-                      - disableIstioInjection: true
-                        name: external-secrets
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: falco
-                      - app: harbor
-                        name: harbor
-                      - app: gatekeeper
-                        disableIstioInjection: true
-                        name: gatekeeper-system
-                      - name: gitea
-                      - app: grafana
-                        name: grafana
-                      - disableIstioInjection: true
-                        name: istio-system
-                      - istio-injection: disabled
-                        istio-operator-managed: Reconcile
-                        name: istio-operator
-                      - app: httpbin
-                        name: httpbin
-                      - disableIstioInjection: true
-                        name: ingress
-                      - app: jaeger
-                        name: jaeger
-                      - app: jaeger
-                        disableIstioInjection: true
-                        name: jaeger-operator
-                      - name: keycloak
-                      - app: kiali
-                        name: kiali
-                      - app: kiali
-                        disableIstioInjection: true
-                        name: kiali-operator
-                      - app: knative
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: knative-serving
-                      - app: kubeapps
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: kubeapps
-                      - app: kured
-                        disableIstioInjection: true
-                        name: kured
-                      - app: kubeclarity
-                        disableIstioInjection: true
-                        name: kubeclarity
-                      - app: tekton
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: tekton
-                      - disableIstioInjection: true
-                        name: maintenance
-                      - app: minio
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: minio
-                      - disableIstioInjection: true
-                        name: monitoring
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: olm
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: opa-exporter
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: operators
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: opencost
-                      - name: otomi
-                      - app: cluster-overprovisioner
-                        disableIstioInjection: true
-                        name: cluster-overprovisioner
-                      - app: prometheus
-                        disableIstioInjection: true
-                        name: redis
-                      - name: team-admin
-                      - disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: tigera-operator
-                      - app: trivy
-                        disableIstioInjection: true
-                        disablePolicyChecks: true
-                        name: trivy-operator
-                      - app: vault
-                        name: vault
-                      - app: velero
-                        name: velero
-              kms:
-                  sops:
-                      azure:
-                          clientId: somesecretvalue
-                          clientSecret: somesecretvalue
-                          keys: somesecretvalue
-                          tenantId: somesecretvalue
-              letsencryptCA: |
-                  -----BEGIN CERTIFICATE-----
-                  MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
-                  MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-                  aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-                  ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
-                  BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
-                  Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
-                  AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
-                  gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
-                  L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
-                  nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
-                  nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
-                  biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
-                  DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
-                  BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
-                  ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
-                  MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
-                  HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
-                  MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
-                  DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
-                  vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
-                  y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
-                  Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
-                  yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
-                  xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
-                  Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
-                  zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
-                  qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
-                  xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
-                  hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
-                  -----END CERTIFICATE-----
-              letsencryptRootCA: |
-                  -----BEGIN CERTIFICATE-----
-                  MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-                  MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-                  aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-                  ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-                  BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-                  YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-                  AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-                  ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-                  jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-                  wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-                  oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-                  TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-                  fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-                  rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-                  FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-                  mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-                  GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-                  mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-                  Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-                  9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-                  nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-                  qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-                  qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-                  sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-                  CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-                  5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-                  xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-                  fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-                  gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-                  7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-                  -----END CERTIFICATE-----
-              license: license-in-jwt-format
-              oidc:
-                  adminGroupID: someAdminGroupID
-                  clientID: someClientID
-                  clientSecret: somesecretvalue
-                  issuer: https://login.microsoftonline.com/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-                  subClaimMapper: oid
-                  teamAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-              otomi:
-                  additionalClusters:
-                      - domainSuffix: demo.eks.otomi.cloud
-                        name: demo
-                        provider: aws
-                  adminPassword: bladibla
-                  globalPullSecret:
-                      password: blablabla
-                      username: otomi
-                  hasCloudLB: false
-                  hasExternalDNS: true
-                  hasExternalIDP: true
-                  isHomeMonitored: true
-                  isMultitenant: true
-                  nodeSelector:
-                      otomi: otomi-sys
-                  version: main
-              platformBackups:
-                  argo:
-                      enabled: false
-                  drone:
-                      enabled: false
-                  gitea:
-                      enabled: false
-                  harbor:
-                      enabled: false
-                  keycloak:
-                      enabled: false
-                  kubeapps:
-                      enabled: false
-                  minio:
-                      enabled: false
-                  vault:
-                      enabled: false
-              policies:
-                  banned-image-tags:
-                      enabled: false
-                      tags:
-                          - latest
-                  container-limits:
-                      cpu: '2'
-                      enabled: true
-                      memory: 2Gi
-                  psp-allowed-repos:
-                      enabled: false
-                      repos:
-                          - harbor.demo.gke.otomi.cloud
-                          - harbor.demo.aks.otomi.cloud
-                          - harbor.demo.eks.otomi.cloud
-                  psp-allowed-users:
-                      enabled: true
-                      fsGroup:
-                          ranges:
-                              - max: 65535
-                                min: 1
-                          rule: MayRunAs
-                      runAsGroup:
-                          ranges:
-                              - max: 65535
-                                min: 1
-                          rule: MayRunAs
-                      runAsUser:
-                          rule: MustRunAsNonRoot
-                      supplementalGroups:
-                          ranges:
-                              - max: 65535
-                                min: 1
-                          rule: MayRunAs
-                  psp-apparmor:
-                      allowedProfiles:
-                          - runtime/default
-                      enabled: true
-                  psp-capabilities:
-                      allowedCapabilities:
-                          - NET_BIND_SERVICE
-                          - NET_RAW
-                      enabled: false
-                      requiredDropCapabilities:
-                          - ALL
-                  psp-forbidden-sysctls:
-                      enabled: true
-                      forbiddenSysctls:
-                          - kernel.*
-                          - net.*
-                          - abi.*
-                          - fs.*
-                          - sunrpc.*
-                          - user.*
-                          - vm.*
-                  psp-host-filesystem:
-                      allowedHostPaths:
-                          - pathPrefix: /tmp/
-                            readOnly: false
-                      enabled: true
-                  psp-host-networking-ports:
-                      enabled: true
-                  psp-host-security:
-                      enabled: true
-                  psp-privileged:
-                      enabled: true
-                  psp-seccomp:
-                      allowedProfiles:
-                          - runtime/default
-                      enabled: false
-                  psp-selinux:
-                      enabled: false
-                      seLinuxContext: RunAsAny
-              smtp:
-                  auth_password: somesecretvalue
-                  auth_username: no-reply@doma.in
-                  from: no-reply@doma.in
-                  hello: doma.in
-                  smarthost: smtp-relay.gmail.com:587
-              status:
-                  helm:
-                      drone/drone:
-                          app_version: 1.6.1
-                          chart: drone-3.0.0
-                          name: drone
-                          namespace: drone
-                          revision: '1'
-                          status: deployed
-                          updated: 2023-05-31 09:54:32.168150254 +0000 UTC
-                      harbor/harbor:
-                          app_version: 1.6.1
-                          chart: drone-3.0.0
-                          name: drone
-                          namespace: drone
-                          revision: '1'
-                          status: deployed
-                          updated: 2023-05-31 09:54:32.168150254 +0000 UTC
-                  otomi:
-                      deployingTag: main
-                      deployingVersion: 0.21.0
-                      status: deployed
-                      version: 0.21.0
-              teamApps:
-                  - ingress:
-                        - auth: true
-                          hasPrefix: true
-                          port: 9093
-                          svc: po-alertmanager
-                          type: public
-                    name: alertmanager
-                  - ingress:
-                        - auth: true
-                          forwardPath: true
-                          hasPrefix: true
-                          removeRequestHeaders:
-                              - authorization
-                          svc: po-grafana
-                          type: public
-                    name: grafana
-                    ownHost: true
-                  - name: loki
-                    path: /explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22#NS#%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
-                    useHost: grafana
-                  - ingress:
-                        - auth: true
-                          hasPrefix: true
-                          port: 9090
-                          svc: po-prometheus
-                          type: public
-                    name: prometheus
-              teamConfig:
-                  admin:
-                      id: admin
-                      jobs: []
-                      secrets:
-                          - entries:
-                                - TARGET
-                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c387
-                            name: mysecret-generic-admin
-                            namespace: some-ns
-                            teamId: demo
-                            type: generic
-                          - clusterWide: true
-                            entries:
-                                - TARGET
-                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c388
-                            name: mysecret-generic-admin-clusterwide
-                            teamId: demo
-                            type: generic
-                          - entries:
-                                - TARGET
-                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c389
-                            name: mysecret-generic-admin-teamwide
-                            teamId: demo
-                            teamWide: true
-                            type: generic
-                      services:
-                          - auth: true
-                            domain: hello.team-admin.demo.eks.otomi.cloud
-                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd0
-                            name: hello-admin
-                            networkPolicy:
-                                ingressPrivate:
-                                    mode: AllowAll
-                            ownHost: true
-                            port: 80
-                            type: public
-                      workloads:
-                          - name: wa1
-                            path: /
-                            revision: HEAD
-                            url: https://myrepo.local/mychart.git
-                          - chart: mychart
-                            name: wa2
-                            revision: 1.2.3
-                            url: https://myregistry.local/mychart
-                          - chart: crossplane
-                            name: crossplane-custom-namespace
-                            namespace: crossplane
-                            revision: 1.11.2
-                            url: https://charts.crossplane.io/stable
-                          - chart: crossplane
-                            name: crossplane-team-namespace
-                            revision: 1.11.2
-                            url: https://charts.crossplane.io/stable
-                  demo:
-                      alerts:
-                          email:
-                              critical: admins@yourdoma.in
-                              nonCritical: admins@yourdoma.in
-                          receivers:
-                              - email
-                      backups:
-                          - name: bu1
-                            schedule: 0 0 0 * *
-                            snapshotVolumes: true
-                            ttl: 8h
-                          - labelSelector:
-                                - name: app
-                                  value: hello
-                                - name: backup
-                                  value: all
-                            name: bu2
-                            schedule: 0 0 0 * *
-                            snapshotVolumes: true
-                            ttl: 8h
-                      billingAlertQuotas:
-                          teamCpuMonthQuotaReached:
-                              quota: 150
-                          teamMemMonthQuotaReached:
-                              quota: 200
-                      builds:
-                          - mode:
-                                docker:
-                                    path: ./Docker
-                                    repoUrl: https://github.com/buildpacks/samples
-                                    revision: HEAD
-                                type: docker
-                            name: demo-java1
-                            tag: v.0.0.1
-                          - mode:
-                                buildpacks:
-                                    path: apps/java-maven
-                                    repoUrl: https://github.com/buildpacks/samples
-                                    revision: HEAD
-                                type: buildpacks
-                            name: demo-java2
-                            tag: v.0.0.1
-                          - mode:
-                                docker:
-                                    path: ./Docker
-                                    repoUrl: https://github.com/buildpacks/samples
-                                    revision: HEAD
-                                type: docker
-                            name: demo-java3
-                            tag: v.0.0.1
-                      id: demo
-                      jobs:
-                          - enabled: true
-                            env:
-                                receiver: world
-                            files:
-                                /config/some-file: someData
-                                /config/some-file3: |-
-                                    some data on another line
-                                    another line
-                                /config/some/file2: someData2
-                            image:
-                                pullPolicy: IfNotPresent
-                                repository: busybox
-                                tag: latest
-                            init:
-                                - command:
-                                      - echo
-                                      - hello foo $foo
-                                  env:
-                                      foo: bar
-                                  image:
-                                      pullPolicy: IfNotPresent
-                                      repository: busybox
-                                      tag: latest
-                                  resources:
-                                      limits:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                      requests:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                  secrets:
-                                      - mysecret-generic
-                                      - hello-otomi
-                            name: contains-everything
-                            podSecurityContext:
-                                fsGroup: 1002
-                                runAsGroup: 1002
-                                runAsNonRoot: true
-                                runAsUser: 1002
-                            resources:
-                                limits:
-                                    cpu: 50m
-                                    memory: 64Mi
-                                requests:
-                                    cpu: 50m
-                                    memory: 64Mi
-                            runPolicy: Always
-                            script: echo "hello $receiver"
-                            secretMounts:
-                                /config/some-folder: someSecret
-                            secrets:
-                                - mysecret-generic
-                                - hello-otomi
-                            securityContext:
-                                runAsGroup: 1002
-                                runAsNonRoot: true
-                                runAsUser: 1002
-                            type: Job
-                          - enabled: true
-                            env:
-                                receiver: world
-                            files:
-                                /some-file: someData
-                                /some-file2: someData2
-                                /some-file3: |-
-                                    some data on another line
-                                    another line
-                            image:
-                                pullPolicy: IfNotPresent
-                                repository: busybox
-                                tag: latest
-                            init:
-                                - env:
-                                      foo: bar
-                                  image:
-                                      pullPolicy: IfNotPresent
-                                      repository: busybox
-                                      tag: latest
-                                  resources:
-                                      limits:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                      requests:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                  script: |
-                                      echo "hello $receiver"
-                            name: also-contains-everything-and-cron
-                            resources:
-                                limits:
-                                    cpu: 50m
-                                    memory: 64Mi
-                                requests:
-                                    cpu: 50m
-                                    memory: 64Mi
-                            runPolicy: Always
-                            schedule: 0 1 * * *
-                            script: echo "hello $receiver"
-                            secrets:
-                                - generic-example
-                                - hello-otomi
-                            type: CronJob
-                          - enabled: true
-                            image:
-                                pullPolicy: IfNotPresent
-                                repository: busybox
-                                tag: latest
-                            name: base
-                            resources:
-                                limits:
-                                    cpu: 50m
-                                    memory: 64Mi
-                                requests:
-                                    cpu: 50m
-                                    memory: 64Mi
-                            script: echo "hello $receiver"
-                            type: Job
-                          - enabled: true
-                            image:
-                                pullPolicy: IfNotPresent
-                                repository: busybox
-                                tag: latest
-                            name: base-cronjob
-                            resources:
-                                limits:
-                                    cpu: 50m
-                                    memory: 64Mi
-                                requests:
-                                    cpu: 50m
-                                    memory: 64Mi
-                            schedule: 0 1 * * *
-                            script: echo "hello world"
-                            type: CronJob
-                          - enabled: true
-                            image:
-                                pullPolicy: IfNotPresent
-                                repository: busybox
-                                tag: latest
-                            init:
-                                - env:
-                                      foo: bar
-                                  image:
-                                      pullPolicy: IfNotPresent
-                                      repository: busybox
-                                      tag: latest
-                                  resources:
-                                      limits:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                      requests:
-                                          cpu: 50m
-                                          memory: 64Mi
-                                  script: echo "hello world"
-                            name: init-cronjob
-                            resources:
-                                limits:
-                                    cpu: 50m
-                                    memory: 64Mi
-                                requests:
-                                    cpu: 50m
-                                    memory: 64Mi
-                            schedule: 0 1 * * *
-                            script: echo "hello $receiver"
-                            type: CronJob
-                      networkPolicy:
-                          egressPublic: true
-                          ingressPrivate: true
-                      oidc:
-                          groupMapping: somesecretvalue
-                      password: somesecretvalue
-                      resourceQuota:
-                          services.loadbalancers: '1'
-                      secrets:
-                          - entries:
-                                - TARGET
-                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c378
-                            name: mysecret-generic
-                            teamId: demo
-                            type: generic
-                          - id: d29ab8f8-1281-4eba-81b0-be01baed03a6
-                            name: mysecret-registry
-                            teamId: demo
-                            type: docker-registry
-                          - ca: ca.crt
-                            crt: tls.crt
-                            id: efe80c21-cfb2-4436-a9dd-e6838ea9c4f9
-                            key: tls.key
-                            name: mysecret-tls
-                            teamId: demo
-                            type: tls
-                      selfService:
-                          apps: []
-                          service:
-                              - ingress
-                              - networkPolicy
-                          team:
-                              - alerts
-                      services:
-                          - auth: true
-                            domain: hello.team-demo.demo.eks.otomi.cloud
-                            headers:
-                                response:
-                                    set:
-                                        - name: X-Frame-Options
-                                          value: same-origin
-                                        - name: sander
-                                          value: same-origin
-                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd3
-                            ksvc:
-                                predeployed: true
-                            name: hello
-                            networkPolicy:
-                                ingressPrivate:
-                                    mode: AllowAll
-                            ownHost: true
-                            port: 80
-                            type: public
-                          - domain: tlspass.eks.dev.otomi.cloud
-                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd4
-                            ksvc:
-                                predeployed: true
-                            name: hello-auth
-                            ownHost: true
-                            paths: []
-                            port: 80
-                            type: public
-                          - id: cb5149c4-8ea5-4c5a-be04-a37258658bd5
-                            ksvc:
-                                predeployed: true
-                            name: tlspass
-                            port: 443
-                            tlsPass: true
-                            type: public
-                          - id: cb5149c4-8ea5-4c5a-be04-a37258658bd6
-                            name: some-svc
-                            networkPolicy:
-                                ingressPrivate:
-                                    mode: AllowAll
-                            port: 80
-                            type: cluster
-                          - hasCert: true
-                            name: has-cert-svc
-                            paths:
-                                - /jeho
-                            type: public
-                          - name: service-a
-                            networkPolicy:
-                                egressPublic:
-                                    - domain: domain1.com
-                                      ports:
-                                          - number: 8443
-                                            protocol: TCP
-                                    - domain: domain2.com
-                                      ports:
-                                          - number: 443
-                                            protocol: HTTPS
-                                    - domain: 185.199.110.153
-                                      ports:
-                                          - number: 443
-                                            protocol: TCP
-                                    - domain: ae::1
-                                      ports:
-                                          - number: 443
-                                            protocol: TCP
-                                ingressPrivate:
-                                    allow:
-                                        - team: team1
-                                        - service: service-x
-                                          team: team2
-                                    mode: AllowOnly
-                            type: cluster
-                          - name: service-b
-                            networkPolicy:
-                                egressPublic: []
-                                ingressPrivate:
-                                    mode: DenyAll
-                            type: cluster
-                          - name: service-d
-                            networkPolicy:
-                                ingressPrivate:
-                                    mode: AllowOnly
-                            type: cluster
-                          - headers:
-                                request:
-                                    set:
-                                        - name: someheader
-                                          value: somevalue
-                                response:
-                                    set:
-                                        - name: X-Frame-Options
-                                          value: same-origin
-                                        - name: sander
-                                          value: same-origin
-                            ingressClassName: net-a
-                            name: service-e
-                            type: public
-                      workloads:
-                          - name: wd1
-                            path: /
-                            url: https://myrepo.local/mychart.git
-                          - name: wd2
-                            path: /
-                            url: https://myrepo.local/mychart.git
-              version: 8
-              versions:
-                  api: main
-                  console: main
-                  core: main
-                  tasks: main
-                  tools: 1.4.25
+                account_key: account_key
+              type: minioLocal
+            v11StartDate: 2021-05-13
+          metrics-server:
+            apiServer:
+              create: true
+            enabled: true
+            extraArgs:
+              kubelet-preferred-address-types: InternalIP
+          minio:
+            enabled: true
+            persistence:
+              enabled: true
+              size: 20Gi
+            provisioning:
+              enabled: true
+            resources:
+              limits:
+                cpu: 1
+                memory: 1Gi
+              requests:
+                cpu: 500m
+                memory: 128Mi
+          oauth2-proxy:
+            config:
+              cookieSecret: gkhugxJsPjhbCybH
+          oauth2-proxy-redis:
+            password: gkhugxJsPjhbCybH
+          opa-exporter: {}
+          opencost:
+            alerts:
+              costOfAllNodesQuotaPerMonthReached:
+                quota: 500
+              enabled: true
+            enabled: true
+            resources:
+              exporter:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 128Mi
+              ui:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 128Mi
+          otomi-api:
+            editorInactivityTimeout: 5
+            git:
+              email: some@secret.value
+              password: somesecretvalue
+              repoUrl: github.com/redkubes/otomi-values-demo.git
+              user: someuser
+          otomi-console: {}
+          prometheus:
+            disabledRules:
+              - InfoInhibitor
+              - PrometheusOperatorListErrors
+            enabled: true
+            remoteWrite:
+              enabled: true
+              otomiThanos: false
+              rwConfig:
+                basicAuth:
+                  enabled: true
+                  password: blalalalalal
+                  username: testaccount
+                customConfig: |-
+                  writeRelabelConfigs:
+                    - targetLabel: tenant
+                      sourceLabels:
+                      - instance
+                      replacement: otomi-aks-ont
+                    - targetLabel: cluster
+                      sourceLabels:
+                      - instance
+                      replacement: otomi-aks-ont
+                    - targetLabel: customer_id
+                      sourceLabels:
+                      - instance
+                      replacement: "00001"
+                  queueConfig:
+                    capacity: 18000
+                    maxShards: 100
+                    maxSamplesPerSend: 6000
+                insecureSkipVerify: false
+                target: https://remote.target.io/api/v1/push
+            replicas: 1
+            retentionSize: 4GB
+            scrapeInterval: 60s
+            storageSize: 5Gi
+          prometheus-blackbox-exporter: {}
+          prometheus-msteams:
+            enabled: false
+          promtail:
+            enabled: false
+          redis-shared:
+            enabled: false
+            sizes:
+              master: 1Gi
+          snapshot-controller:
+            enabled: false
+          tekton:
+            enabled: true
+          thanos:
+            compactor:
+              retentionResolution1h: 0s
+              retentionResolution5m: 0s
+              retentionResolutionRaw: 0s
+            enabled: true
+            objstore:
+              storageProvider:
+                type: minioLocal
+            persistence:
+              compactor:
+                size: 8Gi
+              receiver:
+                size: 50Gi
+              ruler:
+                size: 8Gi
+              storegateway:
+                size: 8Gi
+            query:
+              replicaCount: 1
+            receiver:
+              mode: dual-mode
+              replicaCount: 2
+              replicationFactor: 1
+              tsdbRetention: 7d
+            receiverDistributor:
+              enabled: true
+            resources:
+              bucketweb:
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+              compactor:
+                limits:
+                  cpu: '1'
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              query:
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+              queryFrontend:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              receiver:
+                limits:
+                  cpu: '1'
+                  memory: 2Gi
+                requests:
+                  cpu: 200m
+                  memory: 512Mi
+              receiverDistributor:
+                limits:
+                  cpu: '1'
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              ruler:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+              storegateway:
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+            ruler:
+              enabled: false
+          tigera-operator:
+            enabled: false
+          trivy:
+            enabled: true
+            operator:
+              replicaCount: 1
+            resources:
+              operator:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              trivy:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 64M
+          vault:
+            enabled: true
+            logLevel: warn
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 256Mi
+          velero:
+            cloud:
+              google:
+                project: velero
+                saKeyJson: '{key in json format}'
+                serviceAccount: bla
+              type: google
+            enabled: true
+            logLevel: info
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 128Mi
+            restic:
+              enabled: false
+            storage:
+              gcs:
+                bucket: velero
+                serviceAccount: bla
+              type: gcs
+        azure:
+          appgw:
+            isManaged: true
+          monitor:
+            clientId: somesecretvalue
+            clientSecret: somesecretvalue
+            subscriptionId: somesecretvalue
+            tenantId: somesecretvalue
+          resourceGroup: somevalue
+          subscriptionId: somevalue
+          tenantId: somevalue
+        cloud:
+          skipStorageClasses:
+            - std
+            - std-immediate
+        cluster:
+          apiName: eks_otomi-cloud_eu-central-1_otomi-eks-demo
+          apiServer: https://1.1.1.1:8443
+          domainSuffix: demo.eks.otomi.cloud
+          k8sContext: otomi-eks-demo
+          k8sVersion: '1.25'
+          name: demo
+          owner: redkubes
+          provider: custom
+          region: eu-central-1
+        dns:
+          domainFilters:
+            - otomi.cloud
+          provider:
+            aws:
+              credentials:
+                accessKey: AAAAAAAAAAAAAAAAA
+                secretKey: DuJ/T6fFYMysjRUxxxxxxxxxxxxxxxxx
+              region: eu-central-1
+          zoneIdFilters:
+            - otomi
+        home:
+          email:
+            critical: admins@yourdoma.in
+          receivers:
+            - slack
+          slack:
+            channel: mon-otomi
+            channelCrit: mon-otomi-crit
+            url: https://hooks.slack.com/services/id
+        ingress:
+          classes:
+            - className: platform
+              entrypoint: ''
+              network: public
+            - className: private
+              entrypoint: ''
+              loadBalancerSubnet: subnet
+              network: private
+            - className: net-a
+              entrypoint: ''
+              loadBalancerIP: 11.0.0.1
+              loadBalancerRG: myrg
+              network: public
+              sourceIpAddressFiltering: 10.0.0.0/24
+          platformClass:
+            className: platform
+            entrypoint: ''
+            network: public
+        k8s:
+          namespaces:
+            - app: argocd
+              name: argocd
+            - disableIstioInjection: true
+              name: cert-manager
+            - app: cloudnative-pg
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: cnpg-system
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: default
+            - name: drone
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: drone-pipelines
+            - disableIstioInjection: true
+              name: external-dns
+            - disableIstioInjection: true
+              name: external-secrets
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: falco
+            - app: harbor
+              name: harbor
+            - app: gatekeeper
+              disableIstioInjection: true
+              name: gatekeeper-system
+            - name: gitea
+            - app: grafana
+              name: grafana
+            - disableIstioInjection: true
+              name: istio-system
+            - istio-injection: disabled
+              istio-operator-managed: Reconcile
+              name: istio-operator
+            - app: httpbin
+              name: httpbin
+            - disableIstioInjection: true
+              name: ingress
+            - app: jaeger
+              name: jaeger
+            - app: jaeger
+              disableIstioInjection: true
+              name: jaeger-operator
+            - name: keycloak
+            - app: kiali
+              name: kiali
+            - app: kiali
+              disableIstioInjection: true
+              name: kiali-operator
+            - app: knative
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: knative-serving
+            - app: kubeapps
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: kubeapps
+            - app: kured
+              disableIstioInjection: true
+              name: kured
+            - app: kubeclarity
+              disableIstioInjection: true
+              name: kubeclarity
+            - app: tekton
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: tekton
+            - disableIstioInjection: true
+              name: maintenance
+            - app: minio
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: minio
+            - disableIstioInjection: true
+              name: monitoring
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: olm
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: opa-exporter
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: operators
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: opencost
+            - name: otomi
+            - app: cluster-overprovisioner
+              disableIstioInjection: true
+              name: cluster-overprovisioner
+            - app: prometheus
+              disableIstioInjection: true
+              name: redis
+            - name: team-admin
+            - disableIstioInjection: true
+              disablePolicyChecks: true
+              name: tigera-operator
+            - app: trivy
+              disableIstioInjection: true
+              disablePolicyChecks: true
+              name: trivy-operator
+            - app: vault
+              name: vault
+            - app: velero
+              name: velero
+        kms:
+          sops:
+            azure:
+              clientId: somesecretvalue
+              clientSecret: somesecretvalue
+              keys: somesecretvalue
+              tenantId: somesecretvalue
+        letsencryptCA: |
+          -----BEGIN CERTIFICATE-----
+          MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
+          MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+          aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+          ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
+          BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
+          Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
+          AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
+          gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
+          L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
+          nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
+          nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
+          biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
+          DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
+          BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
+          ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
+          MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
+          HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
+          MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
+          DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
+          vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
+          y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
+          Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
+          yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
+          xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
+          Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
+          zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
+          qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
+          xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
+          hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
+          -----END CERTIFICATE-----
+        letsencryptRootCA: |
+          -----BEGIN CERTIFICATE-----
+          MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+          MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+          aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+          ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+          BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+          YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+          AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+          ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+          jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+          wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+          oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+          TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+          fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+          rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+          FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+          mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+          GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+          mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+          Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+          9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+          nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+          qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+          qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+          sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+          CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+          5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+          xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+          fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+          gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+          7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+          -----END CERTIFICATE-----
+        license: license-in-jwt-format
+        oidc:
+          adminGroupID: someAdminGroupID
+          clientID: someClientID
+          clientSecret: somesecretvalue
+          issuer: https://login.microsoftonline.com/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+          subClaimMapper: oid
+          teamAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        otomi:
+          additionalClusters:
+            - domainSuffix: demo.eks.otomi.cloud
+              name: demo
+              provider: aws
+          adminPassword: bladibla
+          globalPullSecret:
+            password: blablabla
+            username: otomi
+          hasCloudLB: false
+          hasExternalDNS: true
+          hasExternalIDP: true
+          isHomeMonitored: true
+          isMultitenant: true
+          nodeSelector:
+            otomi: otomi-sys
+          version: main
+        platformBackups:
+          argo:
+            enabled: false
+          drone:
+            enabled: false
+          gitea:
+            enabled: false
+          harbor:
+            enabled: false
+          keycloak:
+            enabled: false
+          kubeapps:
+            enabled: false
+          minio:
+            enabled: false
+          vault:
+            enabled: false
+        policies:
+          banned-image-tags:
+            enabled: false
+            tags:
+              - latest
+          container-limits:
+            cpu: '2'
+            enabled: true
+            memory: 2Gi
+          psp-allowed-repos:
+            enabled: false
+            repos:
+              - harbor.demo.gke.otomi.cloud
+              - harbor.demo.aks.otomi.cloud
+              - harbor.demo.eks.otomi.cloud
+          psp-allowed-users:
+            enabled: true
+            fsGroup:
+              ranges:
+                - max: 65535
+                  min: 1
+              rule: MayRunAs
+            runAsGroup:
+              ranges:
+                - max: 65535
+                  min: 1
+              rule: MayRunAs
+            runAsUser:
+              rule: MustRunAsNonRoot
+            supplementalGroups:
+              ranges:
+                - max: 65535
+                  min: 1
+              rule: MayRunAs
+          psp-apparmor:
+            allowedProfiles:
+              - runtime/default
+            enabled: true
+          psp-capabilities:
+            allowedCapabilities:
+              - NET_BIND_SERVICE
+              - NET_RAW
+            enabled: false
+            requiredDropCapabilities:
+              - ALL
+          psp-forbidden-sysctls:
+            enabled: true
+            forbiddenSysctls:
+              - kernel.*
+              - net.*
+              - abi.*
+              - fs.*
+              - sunrpc.*
+              - user.*
+              - vm.*
+          psp-host-filesystem:
+            allowedHostPaths:
+              - pathPrefix: /tmp/
+                readOnly: false
+            enabled: true
+          psp-host-networking-ports:
+            enabled: true
+          psp-host-security:
+            enabled: true
+          psp-privileged:
+            enabled: true
+          psp-seccomp:
+            allowedProfiles:
+              - runtime/default
+            enabled: false
+          psp-selinux:
+            enabled: false
+            seLinuxContext: RunAsAny
+        smtp:
+          auth_password: somesecretvalue
+          auth_username: no-reply@doma.in
+          from: no-reply@doma.in
+          hello: doma.in
+          smarthost: smtp-relay.gmail.com:587
+        status:
+          helm:
+            drone/drone:
+              app_version: 1.6.1
+              chart: drone-3.0.0
+              name: drone
+              namespace: drone
+              revision: '1'
+              status: deployed
+              updated: 2023-05-31 09:54:32.168150254 +0000 UTC
+            harbor/harbor:
+              app_version: 1.6.1
+              chart: drone-3.0.0
+              name: drone
+              namespace: drone
+              revision: '1'
+              status: deployed
+              updated: 2023-05-31 09:54:32.168150254 +0000 UTC
+          otomi:
+            deployingTag: main
+            deployingVersion: 0.21.0
+            status: deployed
+            version: 0.21.0
+        teamApps:
+          - ingress:
+              - auth: true
+                hasPrefix: true
+                port: 9093
+                svc: po-alertmanager
+                type: public
+            name: alertmanager
+          - ingress:
+              - auth: true
+                forwardPath: true
+                hasPrefix: true
+                removeRequestHeaders:
+                  - authorization
+                svc: po-grafana
+                type: public
+            name: grafana
+            ownHost: true
+          - name: loki
+            path: /explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22#NS#%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
+            useHost: grafana
+          - ingress:
+              - auth: true
+                hasPrefix: true
+                port: 9090
+                svc: po-prometheus
+                type: public
+            name: prometheus
+        teamConfig:
+          admin:
+            id: admin
+            jobs: []
+            secrets:
+              - entries:
+                  - TARGET
+                id: 15bb8ecf-1fef-474c-9143-a1f19c81c387
+                name: mysecret-generic-admin
+                namespace: some-ns
+                teamId: demo
+                type: generic
+              - clusterWide: true
+                entries:
+                  - TARGET
+                id: 15bb8ecf-1fef-474c-9143-a1f19c81c388
+                name: mysecret-generic-admin-clusterwide
+                teamId: demo
+                type: generic
+              - entries:
+                  - TARGET
+                id: 15bb8ecf-1fef-474c-9143-a1f19c81c389
+                name: mysecret-generic-admin-teamwide
+                teamId: demo
+                teamWide: true
+                type: generic
+            services:
+              - auth: true
+                domain: hello.team-admin.demo.eks.otomi.cloud
+                id: cb5149c4-8ea5-4c5a-be04-a37258658bd0
+                name: hello-admin
+                networkPolicy:
+                  ingressPrivate:
+                    mode: AllowAll
+                ownHost: true
+                port: 80
+                type: public
+            workloads:
+              - name: wa1
+                path: /
+                revision: HEAD
+                url: https://myrepo.local/mychart.git
+              - chart: mychart
+                name: wa2
+                revision: 1.2.3
+                url: https://myregistry.local/mychart
+              - chart: crossplane
+                name: crossplane-custom-namespace
+                namespace: crossplane
+                revision: 1.11.2
+                url: https://charts.crossplane.io/stable
+              - chart: crossplane
+                name: crossplane-team-namespace
+                revision: 1.11.2
+                url: https://charts.crossplane.io/stable
+          demo:
+            alerts:
+              email:
+                critical: admins@yourdoma.in
+                nonCritical: admins@yourdoma.in
+              receivers:
+                - email
+            backups:
+              - name: bu1
+                schedule: 0 0 0 * *
+                snapshotVolumes: true
+                ttl: 8h
+              - labelSelector:
+                  - name: app
+                    value: hello
+                  - name: backup
+                    value: all
+                name: bu2
+                schedule: 0 0 0 * *
+                snapshotVolumes: true
+                ttl: 8h
+            billingAlertQuotas:
+              teamCpuMonthQuotaReached:
+                quota: 150
+              teamMemMonthQuotaReached:
+                quota: 200
+            builds:
+              - mode:
+                  docker:
+                    path: ./Docker
+                    repoUrl: https://github.com/buildpacks/samples
+                    revision: HEAD
+                  type: docker
+                name: demo-java1
+                tag: v.0.0.1
+              - mode:
+                  buildpacks:
+                    path: apps/java-maven
+                    repoUrl: https://github.com/buildpacks/samples
+                    revision: HEAD
+                  type: buildpacks
+                name: demo-java2
+                tag: v.0.0.1
+              - mode:
+                  docker:
+                    path: ./Docker
+                    repoUrl: https://github.com/buildpacks/samples
+                    revision: HEAD
+                  type: docker
+                name: demo-java3
+                tag: v.0.0.1
+            id: demo
+            jobs:
+              - enabled: true
+                env:
+                  receiver: world
+                files:
+                  /config/some-file: someData
+                  /config/some-file3: |-
+                    some data on another line
+                    another line
+                  /config/some/file2: someData2
+                image:
+                  pullPolicy: IfNotPresent
+                  repository: busybox
+                  tag: latest
+                init:
+                  - command:
+                      - echo
+                      - hello foo $foo
+                    env:
+                      foo: bar
+                    image:
+                      pullPolicy: IfNotPresent
+                      repository: busybox
+                      tag: latest
+                    resources:
+                      limits:
+                        cpu: 50m
+                        memory: 64Mi
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                    secrets:
+                      - mysecret-generic
+                      - hello-otomi
+                name: contains-everything
+                podSecurityContext:
+                  fsGroup: 1002
+                  runAsGroup: 1002
+                  runAsNonRoot: true
+                  runAsUser: 1002
+                resources:
+                  limits:
+                    cpu: 50m
+                    memory: 64Mi
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                runPolicy: Always
+                script: echo "hello $receiver"
+                secretMounts:
+                  /config/some-folder: someSecret
+                secrets:
+                  - mysecret-generic
+                  - hello-otomi
+                securityContext:
+                  runAsGroup: 1002
+                  runAsNonRoot: true
+                  runAsUser: 1002
+                type: Job
+              - enabled: true
+                env:
+                  receiver: world
+                files:
+                  /some-file: someData
+                  /some-file2: someData2
+                  /some-file3: |-
+                    some data on another line
+                    another line
+                image:
+                  pullPolicy: IfNotPresent
+                  repository: busybox
+                  tag: latest
+                init:
+                  - env:
+                      foo: bar
+                    image:
+                      pullPolicy: IfNotPresent
+                      repository: busybox
+                      tag: latest
+                    resources:
+                      limits:
+                        cpu: 50m
+                        memory: 64Mi
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                    script: |
+                      echo "hello $receiver"
+                name: also-contains-everything-and-cron
+                resources:
+                  limits:
+                    cpu: 50m
+                    memory: 64Mi
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                runPolicy: Always
+                schedule: 0 1 * * *
+                script: echo "hello $receiver"
+                secrets:
+                  - generic-example
+                  - hello-otomi
+                type: CronJob
+              - enabled: true
+                image:
+                  pullPolicy: IfNotPresent
+                  repository: busybox
+                  tag: latest
+                name: base
+                resources:
+                  limits:
+                    cpu: 50m
+                    memory: 64Mi
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                script: echo "hello $receiver"
+                type: Job
+              - enabled: true
+                image:
+                  pullPolicy: IfNotPresent
+                  repository: busybox
+                  tag: latest
+                name: base-cronjob
+                resources:
+                  limits:
+                    cpu: 50m
+                    memory: 64Mi
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                schedule: 0 1 * * *
+                script: echo "hello world"
+                type: CronJob
+              - enabled: true
+                image:
+                  pullPolicy: IfNotPresent
+                  repository: busybox
+                  tag: latest
+                init:
+                  - env:
+                      foo: bar
+                    image:
+                      pullPolicy: IfNotPresent
+                      repository: busybox
+                      tag: latest
+                    resources:
+                      limits:
+                        cpu: 50m
+                        memory: 64Mi
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                    script: echo "hello world"
+                name: init-cronjob
+                resources:
+                  limits:
+                    cpu: 50m
+                    memory: 64Mi
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                schedule: 0 1 * * *
+                script: echo "hello $receiver"
+                type: CronJob
+            networkPolicy:
+              egressPublic: true
+              ingressPrivate: true
+            oidc:
+              groupMapping: somesecretvalue
+            password: somesecretvalue
+            resourceQuota:
+              services.loadbalancers: '1'
+            secrets:
+              - entries:
+                  - TARGET
+                id: 15bb8ecf-1fef-474c-9143-a1f19c81c378
+                name: mysecret-generic
+                teamId: demo
+                type: generic
+              - id: d29ab8f8-1281-4eba-81b0-be01baed03a6
+                name: mysecret-registry
+                teamId: demo
+                type: docker-registry
+              - ca: ca.crt
+                crt: tls.crt
+                id: efe80c21-cfb2-4436-a9dd-e6838ea9c4f9
+                key: tls.key
+                name: mysecret-tls
+                teamId: demo
+                type: tls
+            selfService:
+              apps: []
+              service:
+                - ingress
+                - networkPolicy
+              team:
+                - alerts
+            services:
+              - auth: true
+                domain: hello.team-demo.demo.eks.otomi.cloud
+                headers:
+                  response:
+                    set:
+                      - name: X-Frame-Options
+                        value: same-origin
+                      - name: sander
+                        value: same-origin
+                id: cb5149c4-8ea5-4c5a-be04-a37258658bd3
+                ksvc:
+                  predeployed: true
+                name: hello
+                networkPolicy:
+                  ingressPrivate:
+                    mode: AllowAll
+                ownHost: true
+                port: 80
+                type: public
+              - domain: tlspass.eks.dev.otomi.cloud
+                id: cb5149c4-8ea5-4c5a-be04-a37258658bd4
+                ksvc:
+                  predeployed: true
+                name: hello-auth
+                ownHost: true
+                paths: []
+                port: 80
+                type: public
+              - id: cb5149c4-8ea5-4c5a-be04-a37258658bd5
+                ksvc:
+                  predeployed: true
+                name: tlspass
+                port: 443
+                tlsPass: true
+                type: public
+              - id: cb5149c4-8ea5-4c5a-be04-a37258658bd6
+                name: some-svc
+                networkPolicy:
+                  ingressPrivate:
+                    mode: AllowAll
+                port: 80
+                type: cluster
+              - hasCert: true
+                name: has-cert-svc
+                paths:
+                  - /jeho
+                type: public
+              - name: service-a
+                networkPolicy:
+                  egressPublic:
+                    - domain: domain1.com
+                      ports:
+                        - number: 8443
+                          protocol: TCP
+                    - domain: domain2.com
+                      ports:
+                        - number: 443
+                          protocol: HTTPS
+                    - domain: 185.199.110.153
+                      ports:
+                        - number: 443
+                          protocol: TCP
+                    - domain: ae::1
+                      ports:
+                        - number: 443
+                          protocol: TCP
+                  ingressPrivate:
+                    allow:
+                      - team: team1
+                      - service: service-x
+                        team: team2
+                    mode: AllowOnly
+                type: cluster
+              - name: service-b
+                networkPolicy:
+                  egressPublic: []
+                  ingressPrivate:
+                    mode: DenyAll
+                type: cluster
+              - name: service-d
+                networkPolicy:
+                  ingressPrivate:
+                    mode: AllowOnly
+                type: cluster
+              - headers:
+                  request:
+                    set:
+                      - name: someheader
+                        value: somevalue
+                  response:
+                    set:
+                      - name: X-Frame-Options
+                        value: same-origin
+                      - name: sander
+                        value: same-origin
+                ingressClassName: net-a
+                name: service-e
+                type: public
+            workloads:
+              - name: wd1
+                path: /
+                url: https://myrepo.local/mychart.git
+              - name: wd2
+                path: /
+                url: https://myrepo.local/mychart.git
+        version: 8
+        versions:
+          api: main
+          console: main
+          core: main
+          tasks: main
+          tools: 1.4.25

--- a/tests/fixtures/rendered-values.yaml
+++ b/tests/fixtures/rendered-values.yaml
@@ -1,2227 +1,2216 @@
 helmDefaults:
-  atomic: true
-  historyMax: 3
-  wait: true
-  timeout: 1200
-  force: false
-  cleanupOnFail: false
-  skipDeps: true
+    atomic: true
+    historyMax: 3
+    wait: true
+    timeout: 1200
+    force: false
+    cleanupOnFail: false
+    skipDeps: true
 environments:
-  default:
-    values:
-      - _derived:
-          caCert: |
-            -----BEGIN CERTIFICATE-----
-            MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-            ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-            BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-            YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-            AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-            ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-            jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-            wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-            oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-            TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-            fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-            rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-            FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-            mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-            GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-            mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-            Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-            9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-            nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-            qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-            qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-            sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-            CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-            5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-            xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-            fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-            gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-            7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-            -----END CERTIFICATE-----
+    default:
+        values:
+            - _derived:
+                  caCert: |
+                      -----BEGIN CERTIFICATE-----
+                      MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+                      ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+                      BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+                      YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+                      AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+                      ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+                      jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+                      wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+                      oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+                      TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+                      fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+                      rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+                      FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+                      mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+                      GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+                      mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+                      Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+                      9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+                      nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+                      qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+                      qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+                      sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+                      CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+                      5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+                      xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+                      fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+                      gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+                      7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+                      -----END CERTIFICATE-----
 
-            -----BEGIN CERTIFICATE-----
-            MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
-            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-            ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
-            BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
-            Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
-            AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
-            gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
-            L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
-            nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
-            nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
-            biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
-            DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
-            BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
-            ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
-            MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
-            HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
-            MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
-            DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
-            vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
-            y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
-            Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
-            yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
-            xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
-            Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
-            zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
-            qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
-            xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
-            hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
-            -----END CERTIFICATE-----
-          caCertRoot: |
-            -----BEGIN CERTIFICATE-----
-            MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-            MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-            aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-            ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-            BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-            YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-            AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-            ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-            jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-            wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-            oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-            TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-            fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-            rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-            FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-            mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-            GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-            mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-            Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-            9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-            nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-            qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-            qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-            sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-            CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-            5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-            xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-            fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-            gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-            7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-            -----END CERTIFICATE-----
-          isInitialDeployment: false
-          oidcBaseUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi
-          oidcBaseUrlBackchannel: http://keycloak-http.keycloak/realms/otomi
-          oidcWellKnownUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi/.well-known/openid-configuration
-          oidcWellKnownUrlBackchannel: http://keycloak-http.keycloak/realms/otomi/.well-known/openid-configuration
-          supportedCloud: false
-          untrustedCA: true
-        adminApps:
-          - deps:
-              - prometheus
-            ingress:
-              - auth: true
-                namespace: monitoring
-                port: 9093
-                svc: po-alertmanager
-                type: public
-            name: alertmanager
-            tags:
-              - alerting
-              - observability
-          - ingress:
-              - auth: true
-                namespace: argocd
-                svc: argocd-server
-                type: public
-            isShared: true
-            name: argocd
-            ownHost: true
-            tags:
-              - cicd
-              - gitops
-          - name: cert-manager
-            tags:
-              - ingress
-              - security
-              - tls
-          - ingress:
-              - auth: true
-                namespace: drone
-                removeRequestHeaders:
-                  - authorization
-                svc: drone
-                type: public
-              - forwardPath: true
-                namespace: drone
-                paths:
-                  - /hook
-                  - /api/user
-                  - /api/repo
-                removeRequestHeaders:
-                  - authorization
-                svc: drone
-                type: public
-            isShared: true
-            name: drone
-            ownHost: true
-            tags:
-              - cicd
-              - deployment
-              - pipeline
-          - ingress:
-              - auth: true
-                namespace: ingress
-                svc: tty
-                type: public
-            isShared: true
-            name: tty
-            ownHost: true
-            tags:
-              - tty
-          - name: external-dns
-            tags:
-              - ingress
-              - security
-              - tls
-          - name: external-secrets
-            tags:
-              - secrets
-              - security
-              - tls
-          - deps:
-              - prometheus
-            ingress:
-              - auth: true
-                namespace: falco
-                port: 2802
-                svc: falco-falcosidekick-ui
-                type: public
-            isShared: true
-            name: falco
-            ownHost: true
-            tags:
-              - security
-          - name: gatekeeper
-            tags:
-              - security
-              - policies
-              - observability
-          - ingress:
-              - namespace: gitea
-                port: 3000
-                svc: gitea-http
-                type: public
-            isShared: true
-            name: gitea
-            ownHost: true
-            tags:
-              - git
-          - deps:
-              - prometheus
-            ingress:
-              - auth: true
-                namespace: grafana
-                removeRequestHeaders:
-                  - authorization
-                svc: po-grafana
-                type: public
-            name: grafana
-            ownHost: true
-            shortcuts:
-              - description: NGINX ingress controller metrics
-                path: /d/nginx/nginx-ingress-controller?orgId=1&refresh=5s
-                title: NGINX
-            tags:
-              - tracing
-              - telemetry
-              - observability
-          - ingress:
-              - auth: true
-                namespace: harbor
-                svc: harbor-portal
-                type: public
-              - auth: true
-                forwardPath: true
-                namespace: harbor
-                paths:
-                  - /api/
-                  - /c/
-                svc: harbor-core
-                type: public
-              - forwardPath: true
-                namespace: harbor
-                paths:
-                  - /chartrepo/
-                  - /service/
-                  - /v1/
-                  - /v2/
-                svc: harbor-core
-                type: public
-            isShared: true
-            name: harbor
-            ownHost: true
-            tags:
-              - security
-          - hide: true
-            name: hello
-            tags:
-              - demo
-          - ingress:
-              - auth: true
-                namespace: httpbin
-                svc: httpbin
-                type: public
-            isShared: true
-            name: httpbin
-            ownHost: true
-            tags:
-              - dev
-              - testing
-              - debugging
-          - name: ingress-nginx
-            tags:
-              - ingress
-              - auth
-          - name: istio
-            tags:
-              - ingress
-              - egress
-              - routing
-              - security
-              - tls
-              - observability
-              - policies
-          - deps:
-              - istio
-            ingress:
-              - auth: true
-                forwardPath: true
-                namespace: jaeger
-                port: 16686
-                svc: jaeger-operator-jaeger-query
-                type: public
-            isShared: true
-            name: jaeger
-            tags:
-              - ingress
-              - telemetry
-              - observability
-          - ingress:
-              - namespace: keycloak
-                svc: keycloak-http
-                type: public
-            name: keycloak
-            ownHost: true
-            shortcuts:
-              - description: Edit your account settings.
-                path: /realms/otomi/account/
-                title: Account
-            tags:
-              - auth
-              - sso
-          - deps:
-              - istio
-              - prometheus
-            ingress:
-              - auth: true
-                forwardPath: true
-                namespace: kiali
-                port: 20001
-                removeRequestHeaders:
-                  - authorization
-                svc: kiali
-                type: public
-            name: kiali
-            path: /api/auth/openid_redirect
-            tags:
-              - tracing
-              - telemetry
-              - observability
-          - deps:
-              - istio
-            name: knative
-            tags:
-              - serverless
-              - functions
-          - deps:
-              - operator-lifecycle-manager
-            ingress:
-              - namespace: kubeapps
-                svc: kubeapps
-                type: public
-            isShared: true
-            name: kubeapps
-            ownHost: true
-            tags:
-              - dev
-              - apps
-          - ingress:
-              - auth: true
-                namespace: kubeclarity
-                port: 8080
-                svc: kubeclarity
-                type: public
-            isShared: true
-            name: kubeclarity
-            ownHost: true
-            tags:
-              - security
-          - name: kured
-            tags:
-              - security
-          - name: tekton
-            tags:
-              - buildpacks
-          - deps:
-              - grafana
-              - prometheus
-              - minio
-            name: loki
-            path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
-            shortcuts:
-              - description: All logs generated in the "ingress" namespace
-                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D","refId":"A"%7D%5D
-                title: Ingress logs
-              - description: All OWASP rule violations
-                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D%20%7C%3D%5C"ModSecurity:%20%5C""%7D%5D
-                title: OWASP violations
-              - description: Kube API violations logged by OPA gatekepeer
-                path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"gatekeeper-system%5C"%7D%20%7C%3D%5C"Policy:%20%5C""%7D%5D
-                title: Gatekeeper violations
-            tags:
-              - logging
-              - telemetry
-              - observability
-            useHost: grafana
-          - ingress:
-              - auth: true
-                namespace: minio
-                port: 9001
-                removeRequestHeaders:
-                  - authorization
-                svc: minio
-                type: public
-            name: minio
-            ownHost: true
-            tags:
-              - storage
-              - backup
-          - ingress:
-              - auth: true
-                namespace: opencost
-                port: 9090
-                svc: opencost
-                type: public
-            name: opencost
-            ownHost: true
-            tags:
-              - finops
-          - hide: true
-            ingress:
-              - auth: true
-                namespace: otomi
-                paths:
-                  - /api/
-                svc: otomi-api
-                type: public
-              - auth: true
-                namespace: otomi
-                svc: otomi-console
-                type: public
-            isShared: true
-            name: otomi
-            ownHost: true
-          - ingress:
-              - auth: true
-                namespace: monitoring
-                port: 9090
-                svc: po-prometheus
-                type: public
-            name: prometheus
-            tags:
-              - metrics
-              - observability
-          - deps:
-              - prometheus
-              - grafana
-              - minio
-            ingress:
-              - auth: true
-                forwardPath: true
-                namespace: monitoring
-                port: 9090
-                svc: thanos-query-frontend
-                type: public
-              - forwardPath: true
-                namespace: monitoring
-                paths:
-                  - /api/
-                port: 19291
-                svc: thanos-receive
-                type: public
-            name: thanos
-            ownHost: true
-            tags:
-              - metrics
-              - observability
-          - deps:
-              - prometheus
-              - grafana
-            name: trivy
-            tags:
-              - security
-          - deps:
-              - external-secrets
-            ingress:
-              - auth: true
-                namespace: vault
-                port: 8200
-                svc: vault
-                type: public
-            isShared: true
-            name: vault
-            ownHost: true
-            path: /ui/vault/auth?redirect_to=%2Fvault%2Fsecrets%2Fsecret%2Flist%2Fteams%2F#NS#%2F&with=oidc
-            tags:
-              - secrets
-              - security
-              - observability
-          - name: velero
-            tags:
-              - backup
-        alerts:
-          drone:
-            - slack
-          email:
-            critical: admins@yourdoma.in
-            nonCritical: admins@yourdoma.in
-          groupInterval: 5m
-          receivers:
-            - slack
-            - email
-          repeatInterval: 3h
-          slack:
-            url: https://hooks.slack.com/services/id
-        apps:
-          alertmanager:
-            enabled: true
-          argocd:
-            autoscaling:
-              enabled: false
-              maxReplicas: 3
-              minReplicas: 1
-              targetCPUUtilizationPercentage: 50
-            enabled: true
-          aws-alb-ingress-controller:
-            enabled: false
-          aws-ebs-csi-driver:
-            enabled: false
-          cert-manager:
-            customRootCA: |
-              -----BEGIN CERTIFICATE-----
-              MIIDdDCCAlygAwIBAgIBATANBgkqhkiG9w0BAQUFADBuMRUwEwYDVQQDEwxyZWRr
-              dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
-              EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
-              HhcNMjExMTAzMTAxOTAyWhcNMzExMTAzMTAxOTAyWjBuMRUwEwYDVQQDEwxyZWRr
-              dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
-              EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
-              ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD4quPwHrharZhmqVQx/75N
-              M7Vp3ZmSd3gR2u8Dc1PkmEa6W9CiheVAB5KCzdN5sWaOlFKTy5sHg/zvyYZjvNGX
-              xaHCa4i6OyRgiTOC4NCrxuN5010G0vAxYaM1aIFcqObXuLcaK6miOybDLRfDxoHl
-              g/TKqdiPOMEb2ZgphFxL7oYXjkobOggH+wzwwMIc/1nA3eBjEPsIkQehmb0R0Kxw
-              K5VHPCvbPQb3USVqUs+NmsuCxmqkTtI32WqR0IuNAVqjaD9oNqcsKBgUOPYLYXM8
-              xsTzIn0QPysJIKUCRn1quHwvCQc1RnQBB8UG6iJboVdRe0GNS13vu5ikhoCb0oyV
-              AgMBAAGjHTAbMAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MA0GCSqGSIb3DQEB
-              BQUAA4IBAQBJWHPGnTqXME/MGwG2nAG/JqiCQ0ZOOyKgwN97wrQIlbra2BaUT1K4
-              tMDOjZlft1Luipg/IkzzMXt4eAmqGMxLIweqbve6aLm8KTpHkLdxLm3VPnhK8zzg
-              ysRRRjtkMo9KUOSvrS2dFsY+fQnbGUzpRcK8RrzM6CpgIaf29neP1xLUWQuUsy5y
-              yKCb6OQ9vaJBf/uvz73rQq0ym4Kx0FCFssshaja6lbz/jqCJmppdZE5pe5jvMVVv
-              ae5UQLbva0JyLY8Rc1vSY/epIHMLrV90GEagSkF/ejgF3uh8cliLuUYFAFyU8TnN
-              FWG+enMJfR04aWjp8M3MQ1IoCPVxoXxI
-              -----END CERTIFICATE-----
-            customRootCAKey: |
-              -----BEGIN RSA PRIVATE KEY-----
-              MIIEpQIBAAKCAQEA+Krj8B64Wq2YZqlUMf++TTO1ad2Zknd4EdrvA3NT5JhGulvQ
-              ooXlQAeSgs3TebFmjpRSk8ubB4P878mGY7zRl8WhwmuIujskYIkzguDQq8bjedNd
-              BtLwMWGjNWiBXKjm17i3Giupojsmwy0Xw8aB5YP0yqnYjzjBG9mYKYRcS+6GF45K
-              GzoIB/sM8MDCHP9ZwN3gYxD7CJEHoZm9EdCscCuVRzwr2z0G91ElalLPjZrLgsZq
-              pE7SN9lqkdCLjQFao2g/aDanLCgYFDj2C2FzPMbE8yJ9ED8rCSClAkZ9arh8LwkH
-              NUZ0AQfFBuoiW6FXUXtBjUtd77uYpIaAm9KMlQIDAQABAoIBAQCTsIuotdYwpSH6
-              9172Qzq3h5qbwe3QO/yoPivvFLQi9P4s+RM1M+kw2k5+Odj8UgzjadyRwz/UeuPj
-              VwHmguLJDaxBWLTgRvgYDeT2Oqg1He9FD/AUeXwHGEJjGiqa6gYQ4bh+Zqhdnlwr
-              V8DhmijUNEdThwUEK2UmMVpabi6TOW/dfO6sbnOHYwx326qF3LhYcUrmdeowEGLT
-              UhxdXJQQUsfD+zft6dcPnqucIxd5OEsn3L8/pcumOxHUGFBHDMuB5nTpcZyDxKaN
-              joC0zQy0BDQIMN1F7wNRukSiSYqvRvmvztF2Ka0yEWAdvBBXVVN8nKQw69oGoe9B
-              EQ5HSkKBAoGBAP0KnCE19jW9jq1CWFkFwd1BALWA3GOuxJqSX6M5APM+JRBR4UOZ
-              AUOogvGlrc1ns58q7oNoc1CHiMHd2lNFgfqWqopfVz1Tt9qHqU6VoJnkmJlJRriE
-              57F08RTjslTFzYEsE9zMlL1xa5pq1aGAFB0/mYuxopRw39mS14ugxF1pAoGBAPuT
-              MFLfp2wttGe2WhVepOnhD13sEMGCS6GE16jinjP3qAWIPM/Wdy+Ab8n+KWQkYPLw
-              UsQVi+41LWFIexjzdrq9rG5LQbZdjDCyR4eomDGZhc0Vtsu79NbVrnSmjH8w6psa
-              DXB1uN9/VcCzae/hRpk2Q6zFiMcPE8utUU5RvFRNAoGBAJ19+wsYoPN11dW0k3Rl
-              BvKEwMI3P/SzFB74t5nJovPCXCM6MzB1jLnlqgppCjHsN3n7qJQVcKBQmye+w2JM
-              wseK+v5AtPWwo5/aC+CjdGAUTX4qg1/ZKLPkiyBrT9U/f9bD7mDg3DrE2yozEGAC
-              bYJ+0TyHBR/K2Sh8Irf/CfjxAoGBAM4wuwCRkpUVeLEwQfEV2zBdZ8zg+HLBqd8+
-              E8u1wVhyeOHf4YevDYx/RiBWEfKj5ln3Ir7XshKQvxrm3w16Liur3bGgOMGRNp+K
-              3xmO0v6EB6gpTeL5sBiMlinBf5GXtBFfbvhnZBi6Mrx30DHtf4F/ekQWup37+4uK
-              CAOa9jJZAoGAYbU4CoCxktBECxAVAjtpvYW5176cxiitd75s1ANhXGiOH1A6/y6H
-              rnZ+fMAuvPjrDXbtmqJsq0RXq1E07ng4ZDIjN+0pShVFQdakJRFo1y+d3b82lBYX
-              EZrfMBCWVj31dXeGEHfVvOpwrQ5ffTzs2lVmTh7Ft61gs4TJ7gNTDbE=
-              -----END RSA PRIVATE KEY-----
-            email: test@test.local
-            issuer: letsencrypt
-            resources:
-              limits:
-                cpu: 200m
-                memory: 384Mi
-              requests:
-                cpu: 50m
-                memory: 64Mi
-            stage: staging
-          cloudnative-pg:
-            resources:
-              limits:
-                cpu: 500m
-                memory: 512Mi
-              requests:
-                cpu: 100m
-                memory: 100Mi
-          cluster-autoscaler:
-            enabled: false
-          cluster-overprovisioner:
-            enabled: true
-          demo-tlspass:
-            enabled: false
-          drone:
-            adminUser: somesecretvalue
-            debug: false
-            enabled: true
-            githubAdmins:
-              org: redkubes
-              team: admins
-              token: somesecretvalue
-            orgsFilter: redkubes
-            repoFilter: redkubes
-            sharedSecret: somesecretvalue
-            sourceControl:
-              github:
-                clientID: somesecretvalue
-                clientSecretValue: somesecretvalue
-                server: https://github.com
-              provider: github
-              username: otomi-admin
-            trace: false
-          drone-admit-members:
-            enabled: true
-          external-dns:
-            enabled: true
-            logLevel: info
-          external-secrets:
-            enabled: true
-            logLevel: warn
-            pollingInterval: 60000
-          falco:
-            _rawValues:
-              customRules:
-                otomi-rules.yaml: >-
-                  - macro: k8s_containers
-                    condition: (
-                        container.image.repository in (
-                          docker.io/openpolicyagent/gatekeeper,
-                          docker.io/velero/velero,
-                          docker.io/weaveworks/kured,
-                          k8s.gcr.io/kube-state-metrics/kube-state-metrics,
-                          quay.io/jetstack/cert-manager-cainjector,
-                          quay.io/jetstack/cert-manager-controller,
-                          quay.io/jetstack/cert-manager-webhook,
-                          quay.io/prometheus-operator/prometheus-operator,
-                          quay.io/prometheus/prometheus,
-                          quay.io/kiwigrid/k8s-sidecar,
-                          docker.io/otomi/core,
-                          docker.io/otomi/tasks,
-                          docker.io/otomi/api,
-                          docker.io/drone/drone-runner-kube,
-                          docker.io/grafana/promtail,
-                          quay.io/argoprojlabs/argocd-image-updater
-                        ) or (k8s.ns.name = "kube-system")
-                          or (k8s.ns.name = "ingress")
-                      )
-                  - macro: user_known_write_below_etc_activities
-                    condition: (
-                        (container.image.repository = docker.io/goharbor/harbor-core and proc.name = cp) or
-                        (container.image.repository = docker.io/goharbor/harbor-registryctl and proc.name = cp) or
-                        (container.image.repository = docker.io/goharbor/registry-photon and proc.name = cp) or
-                        (container.image.repository = docker.io/goharbor/trivy-adapter-photon and proc.name = cp)
-                      )
-                  - macro: user_sensitive_mount_containers
-                    condition: (
-                        container.image.repository in (
-                          quay.io/prometheus/node-exporter
-                        )
-                      )
-                  - macro: user_trusted_containers
-                    condition: (
-                        container.image.repository in (
-                          docker.io/drone/drone-runner-kube,
-                          docker.io/otomi/api,
-                          docker.io/otomi/tasks
-                        )
-                      )
-                  - macro: user_known_package_manager_in_container
-                    condition: (
-                        container.image.repository in (
-                          docker.io/otomi/tasks
-                        )
-                      )
-                  - macro: user_known_k8s_client_container
-                    condition: (
-                        container.image.repository in (
-                          docker.io/otomi/tasks,
-                          ocker.io/otomi/core
-                        ) or (k8s.ns.name = "drone-pipelines")
-                      )
-                  - macro: user_known_non_sudo_setuid_conditions
-                    condition: (
-                        container.image.repository in (
-                          docker.io/otomi/tasks,
-                          docker.io/otomi/api,
-                          docker.io/otomi/console,
-                          docker.io/gitea/gitea,
-                          docker.io/grafana/grafana
-                        ) or (k8s.ns.name = "ingress")
-                          or (k8s.ns.name = "keycloak")
-                      )
-                  - macro: excessively_capable_container
-                    condition: (
-                        container.image.repository in (
-                          docker.io/otomi/console,
-                          docker.io/otomi/api
-                        ) or (k8s.ns.name = "keycloak")
-                      )
-                  - macro: user_known_write_below_root_activities
-                    condition: (
-                        k8s.ns.name = "drone-pipelines"
-                      )
-                  - macro: user_known_network_tool_activities
-                    condition: (
-                        container.image.repository in (
-                          docker.io/gitea/gitea
-                        ) or (k8s.ns.name = "keycloak")  
-                      )
-                  - macro: user_known_create_files_below_dev_activities
-                    condition: (
-                        container.image.repository in (
-                          quay.io/operatorhubio/catalog
-                        )
-                      )
-            enabled: false
-            falcoSidekick:
-              minPrio: informational
-              replicas: 1
-            resources:
-              falco:
-                limits:
-                  cpu: 500m
-                  memory: 256Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              falcoExporter:
-                limits:
-                  cpu: 100m
-                  memory: 64Mi
-                requests:
-                  cpu: 50m
-                  memory: 32Mi
-              falcoSidekick:
-                limits:
-                  cpu: 50m
-                  memory: 64Mi
-                requests:
-                  cpu: 20m
-                  memory: 32Mi
-          gatekeeper:
-            auditFromCache: false
-            auditInterval: 60
-            constraintViolationsLimit: 20
-            dataSync:
-              - kind: CronJob
-                version: v1
-              - kind: DaemonSet
-                version: v1
-              - kind: Deployment
-                version: v1
-              - kind: Job
-                version: v1
-              - kind: Pod
-                version: v1
-              - kind: StatefulSet
-                version: v1
-            disableValidatingWebhook: false
-            emitAdmissionEvents: false
-            emitAuditEvents: false
-            enabled: true
-            excludedNamespaces:
-              - sandbox
-            logLevel: INFO
-            replicas: 1
-          gitea:
-            adminPassword: bladibla
-            adminUsername: otomi-admin
-            enabled: false
-            postgresqlPassword: postgresqlPassword
-          grafana:
-            adminPassword: somesecretvalue
-            enabled: true
-          harbor:
-            adminPassword: bladibla
-            backup:
-              enabled: true
-              schedule: 0/3 * * * *
-            databasePassword: somesecretvalue
-            enabled: true
-            persistence:
-              imageChartStorage:
-                gcs:
-                  bucket: otomi-harbor
-                  encodedkey: somesecretvalue
-                  rootdirectory: /google/demo
-                type: gcs
-            registry:
-              credentials:
-                password: bladibla
-                username: otomi-admin
-            resources:
-              trivy:
-                limits:
-                  cpu: 400m
-                  memory: 512Mi
-                requests:
-                  cpu: 200m
-                  memory: 256Mi
-            secretKey: somesecretvalue
-          hello:
-            enabled: true
-          host-mods:
-            enabled: true
-          httpbin:
-            enabled: true
-          ingress-azure:
-            enabled: false
-          ingress-nginx:
-            autoscaling:
-              enabled: true
-              maxReplicas: 10
-              minReplicas: 2
-            enabled: true
-            modsecurity:
-              block: false
-              enabled: false
-              owasp: true
-            private:
-              autoscaling:
-                enabled: true
-                maxReplicas: 10
-                minReplicas: 2
-              enabled: false
-          ingress-nginx-net-a:
-            _rawValues:
-              controller:
-                config:
-                  modsecurity-snippet: |
-                    SecRuleRemoveById 911101
-            maxBodySize: 1024m
-            modsecurity:
-              enabled: true
-            resources:
-              limits:
-                cpu: 200m
-                memory: 256Mi
-              requests:
-                cpu: 100m
-                memory: 192Mi
-          ingress-nginx-platform:
-            _rawValues:
-              controller:
-                config:
-                  modsecurity-snippet: |
-                    SecRuleRemoveById 911102
-            maxBodySize: 2048m
-            modsecurity:
-              enabled: true
-            resources:
-              limits:
-                cpu: 200m
-                memory: 256Mi
-              requests:
-                cpu: 100m
-                memory: 192Mi
-          ingress-nginx-private:
-            _rawValues:
-              controller:
-                config:
-                  modsecurity-snippet: |
-                    SecRuleRemoveById 911103
-            maxBodySize: 4096m
-            modsecurity:
-              enabled: true
-            resources:
-              limits:
-                cpu: 200m
-                memory: 256Mi
-              requests:
-                cpu: 100m
-                memory: 192Mi
-          istio:
-            autoscaling:
-              egressgateway:
-                maxReplicas: 10
-                minReplicas: 2
-              ingressgateway:
-                maxReplicas: 5
-                minReplicas: 1
-              pilot:
-                maxReplicas: 5
-                minReplicas: 1
-            egressGateway:
-              enabled: false
-            enabled: true
-            global:
-              logging:
-                level: default:warn
-            meshConfig:
-              accessLogFile: /dev/stdout
-              defaultConfig:
-                tracing:
-                  sampling: 0.1
-              enableAutoMtls: true
-              extensionProviders:
-                - envoyExtAuthzGrpc: null
-                  includeRequestBodyInCheck:
-                    maxRequestBytes: 1000000
-                  name: ext-authz-chain-grpc
-                  port: '80'
-                  service: s1.test.svc.cluster.local
-            resources:
-              ingressgateway:
-                limits:
-                  cpu: 500m
-                  memory: 256Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              pilot:
-                limits:
-                  cpu: 100m
-                  memory: 256Mi
-                requests:
-                  cpu: 10m
-                  memory: 100Mi
-              prometheus:
-                limits:
-                  cpu: 500m
-                  memory: 1Gi
-                requests:
-                  cpu: 200m
-                  memory: 500Mi
-              proxy:
-                limits:
-                  cpu: 500m
-                  memory: 1Gi
-                requests:
-                  cpu: 20m
-                  memory: 80Mi
-          jaeger:
-            enabled: true
-          keycloak:
-            address: https://keycloak.demo.eks.otomi.cloud
-            adminPassword: bladibla
-            adminUsername: otomi-admin
-            enabled: true
-            idp:
-              alias: redkubes-azure
-              clientID: otomi
-              clientSecret: somsecretvalue
-            postgresqlPassword: postgresqlPassword
-            theme: otomi
-          kiali:
-            enabled: true
-            resources:
-              operator:
-                limits:
-                  cpu: 200m
-                  memory: 1Gi
-                requests:
-                  cpu: 50m
-                  memory: 256Mi
-              pod:
-                limits:
-                  cpu: 200m
-                  memory: 256Mi
-                requests:
-                  cpu: 50m
-                  memory: 128Mi
-          knative:
-            enabled: false
-            serving:
-              replicas: 1
-          kube-descheduler:
-            enabled: false
-          kubeapps:
-            autoscaling:
-              dashboard:
-                maxReplicas: 10
-                minReplicas: 1
-              frontend:
-                maxReplicas: 10
-                minReplicas: 1
-              kubeops:
-                maxReplicas: 10
-                minReplicas: 1
-            enableCommonGround: false
-            enabled: true
-            postgresqlPassword: postgresqlPassword
-          kubeclarity:
-            databasePassword: 123jefkejoql
-            enabled: true
-            logLevel: warning
-            resources:
-              cdbScanner:
-                limits:
-                  cpu: '1'
-                  memory: 1Gi
-                requests:
-                  cpu: 50m
-                  memory: 50Mi
-              kubeclarity:
-                limits:
-                  cpu: '1'
-                  memory: 1Gi
-                requests:
-                  cpu: 100m
-                  memory: 200Mi
-              postgresql:
-                limits:
-                  cpu: '1'
-                  memory: 1Gi
-                requests:
-                  cpu: 251m
-                  memory: 256Mi
-              sbomDb:
-                limits:
-                  cpu: 100m
-                  memory: 100Mi
-                requests:
-                  cpu: 10m
-                  memory: 20Mi
-              trivyServer:
-                limits:
-                  cpu: '1'
-                  memory: 1Gi
-                requests:
-                  cpu: 200m
-                  memory: 200Mi
-              vulnerabilityScanner:
-                limits:
-                  cpu: '1'
-                  memory: 2Gi
-                requests:
-                  cpu: 100m
-                  memory: 256Mi
-          kured:
-            _rawValues:
-              configuration:
-                endTime: 07:00
-                rebootDays:
-                  - su
-                startTime: 22:00
-                timeZone: CET
-            enabled: true
-            resources:
-              kuredDaemonSet:
-                limits:
-                  cpu: 50m
-                  memory: 32Mi
-                requests:
-                  cpu: 20m
-                  memory: 16Mi
-          loki:
-            adminPassword: somesecretvalue
-            autoscaling:
-              distributor:
-                enabled: true
-                maxReplicas: 3
-                minReplicas: 1
-                targetCPUUtilizationPercentage: 60
-                targetMemoryUtilizationPercentage: 80
-              gateway:
-                enabled: true
-                maxReplicas: 3
-                minReplicas: 1
-                targetCPUUtilizationPercentage: 60
-                targetMemoryUtilizationPercentage: 80
-              ingester:
-                enabled: true
-                maxReplicas: 3
-                minReplicas: 1
-                targetCPUUtilizationPercentage: 60
-                targetMemoryUtilizationPercentage: 80
-              querier:
-                enabled: true
-                maxReplicas: 3
-                minReplicas: 1
-                targetCPUUtilizationPercentage: 60
-                targetMemoryUtilizationPercentage: 80
-              queryFrontend:
-                enabled: true
-                maxReplicas: 3
-                minReplicas: 1
-                targetCPUUtilizationPercentage: 60
-                targetMemoryUtilizationPercentage: 80
-            enabled: true
-            persistence:
-              ingester:
-                size: 20Gi
-              querier:
-                size: 10Gi
-            resources:
-              compactor:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              distributor:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              gateway:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              ingester:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              querier:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              queryFrontend:
-                limits:
-                  cpu: 900m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-            retention:
-              duration: 24h
-              period: 24h
-            storage:
+                      -----BEGIN CERTIFICATE-----
+                      MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
+                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+                      ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
+                      BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
+                      Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
+                      AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
+                      gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
+                      L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
+                      nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
+                      nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
+                      biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
+                      DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
+                      BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
+                      ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
+                      MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
+                      HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
+                      MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
+                      DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
+                      vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
+                      y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
+                      Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
+                      yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
+                      xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
+                      Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
+                      zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
+                      qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
+                      xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
+                      hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
+                      -----END CERTIFICATE-----
+                  caCertRoot: |
+                      -----BEGIN CERTIFICATE-----
+                      MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+                      MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+                      aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+                      ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+                      BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+                      YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+                      AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+                      ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+                      jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+                      wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+                      oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+                      TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+                      fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+                      rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+                      FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+                      mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+                      GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+                      mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+                      Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+                      9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+                      nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+                      qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+                      qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+                      sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+                      CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+                      5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+                      xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+                      fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+                      gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+                      7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+                      -----END CERTIFICATE-----
+                  isInitialDeployment: false
+                  oidcBaseUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi
+                  oidcBaseUrlBackchannel: http://keycloak-http.keycloak/realms/otomi
+                  oidcWellKnownUrl: https://keycloak.demo.eks.otomi.cloud/realms/otomi/.well-known/openid-configuration
+                  oidcWellKnownUrlBackchannel: http://keycloak-http.keycloak/realms/otomi/.well-known/openid-configuration
+                  supportedCloud: false
+                  untrustedCA: true
+              adminApps:
+                  - deps:
+                        - prometheus
+                    ingress:
+                        - auth: true
+                          namespace: monitoring
+                          port: 9093
+                          svc: po-alertmanager
+                          type: public
+                    name: alertmanager
+                    tags:
+                        - alerting
+                        - observability
+                  - ingress:
+                        - auth: true
+                          namespace: argocd
+                          svc: argocd-server
+                          type: public
+                    isShared: true
+                    name: argocd
+                    ownHost: true
+                    tags:
+                        - cicd
+                        - gitops
+                  - name: cert-manager
+                    tags:
+                        - ingress
+                        - security
+                        - tls
+                  - ingress:
+                        - auth: true
+                          namespace: drone
+                          removeRequestHeaders:
+                              - authorization
+                          svc: drone
+                          type: public
+                        - forwardPath: true
+                          namespace: drone
+                          paths:
+                              - /hook
+                              - /api/user
+                              - /api/repo
+                          removeRequestHeaders:
+                              - authorization
+                          svc: drone
+                          type: public
+                    isShared: true
+                    name: drone
+                    ownHost: true
+                    tags:
+                        - cicd
+                        - deployment
+                        - pipeline
+                  - ingress:
+                        - auth: true
+                          namespace: ingress
+                          svc: tty
+                          type: public
+                    isShared: true
+                    name: tty
+                    ownHost: true
+                    tags:
+                        - tty
+                  - name: external-dns
+                    tags:
+                        - ingress
+                        - security
+                        - tls
+                  - name: external-secrets
+                    tags:
+                        - secrets
+                        - security
+                        - tls
+                  - deps:
+                        - prometheus
+                    ingress:
+                        - auth: true
+                          namespace: falco
+                          port: 2802
+                          svc: falco-falcosidekick-ui
+                          type: public
+                    isShared: true
+                    name: falco
+                    ownHost: true
+                    tags:
+                        - security
+                  - name: gatekeeper
+                    tags:
+                        - security
+                        - policies
+                        - observability
+                  - ingress:
+                        - namespace: gitea
+                          port: 3000
+                          svc: gitea-http
+                          type: public
+                    isShared: true
+                    name: gitea
+                    ownHost: true
+                    tags:
+                        - git
+                  - deps:
+                        - prometheus
+                    ingress:
+                        - auth: true
+                          namespace: grafana
+                          removeRequestHeaders:
+                              - authorization
+                          svc: po-grafana
+                          type: public
+                    name: grafana
+                    ownHost: true
+                    shortcuts:
+                        - description: NGINX ingress controller metrics
+                          path: /d/nginx/nginx-ingress-controller?orgId=1&refresh=5s
+                          title: NGINX
+                    tags:
+                        - tracing
+                        - telemetry
+                        - observability
+                  - ingress:
+                        - auth: true
+                          namespace: harbor
+                          svc: harbor-portal
+                          type: public
+                        - auth: true
+                          forwardPath: true
+                          namespace: harbor
+                          paths:
+                              - /api/
+                              - /c/
+                          svc: harbor-core
+                          type: public
+                        - forwardPath: true
+                          namespace: harbor
+                          paths:
+                              - /chartrepo/
+                              - /service/
+                              - /v1/
+                              - /v2/
+                          svc: harbor-core
+                          type: public
+                    isShared: true
+                    name: harbor
+                    ownHost: true
+                    tags:
+                        - security
+                  - hide: true
+                    name: hello
+                    tags:
+                        - demo
+                  - ingress:
+                        - auth: true
+                          namespace: httpbin
+                          svc: httpbin
+                          type: public
+                    isShared: true
+                    name: httpbin
+                    ownHost: true
+                    tags:
+                        - dev
+                        - testing
+                        - debugging
+                  - name: ingress-nginx
+                    tags:
+                        - ingress
+                        - auth
+                  - name: istio
+                    tags:
+                        - ingress
+                        - egress
+                        - routing
+                        - security
+                        - tls
+                        - observability
+                        - policies
+                  - deps:
+                        - istio
+                    ingress:
+                        - auth: true
+                          forwardPath: true
+                          namespace: jaeger
+                          port: 16686
+                          svc: jaeger-operator-jaeger-query
+                          type: public
+                    isShared: true
+                    name: jaeger
+                    tags:
+                        - ingress
+                        - telemetry
+                        - observability
+                  - ingress:
+                        - namespace: keycloak
+                          svc: keycloak-http
+                          type: public
+                    name: keycloak
+                    ownHost: true
+                    shortcuts:
+                        - description: Edit your account settings.
+                          path: /realms/otomi/account/
+                          title: Account
+                    tags:
+                        - auth
+                        - sso
+                  - deps:
+                        - istio
+                        - prometheus
+                    ingress:
+                        - auth: true
+                          forwardPath: true
+                          namespace: kiali
+                          port: 20001
+                          removeRequestHeaders:
+                              - authorization
+                          svc: kiali
+                          type: public
+                    name: kiali
+                    path: /api/auth/openid_redirect
+                    tags:
+                        - tracing
+                        - telemetry
+                        - observability
+                  - deps:
+                        - istio
+                    name: knative
+                    tags:
+                        - serverless
+                        - functions
+                  - deps:
+                        - operator-lifecycle-manager
+                    ingress:
+                        - namespace: kubeapps
+                          svc: kubeapps
+                          type: public
+                    isShared: true
+                    name: kubeapps
+                    ownHost: true
+                    tags:
+                        - dev
+                        - apps
+                  - ingress:
+                        - auth: true
+                          namespace: kubeclarity
+                          port: 8080
+                          svc: kubeclarity
+                          type: public
+                    isShared: true
+                    name: kubeclarity
+                    ownHost: true
+                    tags:
+                        - security
+                  - name: kured
+                    tags:
+                        - security
+                  - name: tekton
+                    tags:
+                        - buildpacks
+                  - deps:
+                        - grafana
+                        - prometheus
+                        - minio
+                    name: loki
+                    path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
+                    shortcuts:
+                        - description: All logs generated in the "ingress" namespace
+                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D","refId":"A"%7D%5D
+                          title: Ingress logs
+                        - description: All OWASP rule violations
+                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"ingress%5C"%7D%20%7C%3D%5C"ModSecurity:%20%5C""%7D%5D
+                          title: OWASP violations
+                        - description: Kube API violations logged by OPA gatekepeer
+                          path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B"expr":"%7Bnamespace%3D%5C"gatekeeper-system%5C"%7D%20%7C%3D%5C"Policy:%20%5C""%7D%5D
+                          title: Gatekeeper violations
+                    tags:
+                        - logging
+                        - telemetry
+                        - observability
+                    useHost: grafana
+                  - ingress:
+                        - auth: true
+                          namespace: minio
+                          port: 9001
+                          removeRequestHeaders:
+                              - authorization
+                          svc: minio
+                          type: public
+                    name: minio
+                    ownHost: true
+                    tags:
+                        - storage
+                        - backup
+                  - ingress:
+                        - auth: true
+                          namespace: opencost
+                          port: 9090
+                          svc: opencost
+                          type: public
+                    name: opencost
+                    ownHost: true
+                    tags:
+                        - finops
+                  - hide: true
+                    ingress:
+                        - auth: true
+                          namespace: otomi
+                          paths:
+                              - /api/
+                          svc: otomi-api
+                          type: public
+                        - auth: true
+                          namespace: otomi
+                          svc: otomi-console
+                          type: public
+                    isShared: true
+                    name: otomi
+                    ownHost: true
+                  - ingress:
+                        - auth: true
+                          namespace: monitoring
+                          port: 9090
+                          svc: po-prometheus
+                          type: public
+                    name: prometheus
+                    tags:
+                        - metrics
+                        - observability
+                  - deps:
+                        - prometheus
+                        - grafana
+                        - minio
+                    ingress:
+                        - auth: true
+                          forwardPath: true
+                          namespace: monitoring
+                          port: 9090
+                          svc: thanos-query-frontend
+                          type: public
+                        - forwardPath: true
+                          namespace: monitoring
+                          paths:
+                              - /api/
+                          port: 19291
+                          svc: thanos-receive
+                          type: public
+                    name: thanos
+                    ownHost: true
+                    tags:
+                        - metrics
+                        - observability
+                  - deps:
+                        - prometheus
+                        - grafana
+                    name: trivy
+                    tags:
+                        - security
+                  - deps:
+                        - external-secrets
+                    ingress:
+                        - auth: true
+                          namespace: vault
+                          port: 8200
+                          svc: vault
+                          type: public
+                    isShared: true
+                    name: vault
+                    ownHost: true
+                    path: /ui/vault/auth?redirect_to=%2Fvault%2Fsecrets%2Fsecret%2Flist%2Fteams%2F#NS#%2F&with=oidc
+                    tags:
+                        - secrets
+                        - security
+                        - observability
+                  - name: velero
+                    tags:
+                        - backup
+              alerts:
+                  drone:
+                      - slack
+                  email:
+                      critical: admins@yourdoma.in
+                      nonCritical: admins@yourdoma.in
+                  groupInterval: 5m
+                  receivers:
+                      - slack
+                      - email
+                  repeatInterval: 3h
+                  slack:
+                      url: https://hooks.slack.com/services/id
+              apps:
+                  alertmanager:
+                      enabled: true
+                  argocd:
+                      autoscaling:
+                          enabled: false
+                          maxReplicas: 3
+                          minReplicas: 1
+                          targetCPUUtilizationPercentage: 50
+                      enabled: true
+                  aws-alb-ingress-controller:
+                      enabled: false
+                  aws-ebs-csi-driver:
+                      enabled: false
+                  cert-manager:
+                      customRootCA: |
+                          -----BEGIN CERTIFICATE-----
+                          MIIDdDCCAlygAwIBAgIBATANBgkqhkiG9w0BAQUFADBuMRUwEwYDVQQDEwxyZWRr
+                          dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
+                          EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
+                          HhcNMjExMTAzMTAxOTAyWhcNMzExMTAzMTAxOTAyWjBuMRUwEwYDVQQDEwxyZWRr
+                          dWJlcy5jb20xCzAJBgNVBAYTAk5MMRAwDgYDVQQIEwdVdHJlY2h0MRAwDgYDVQQH
+                          EwdVdHJlY2h0MQ4wDAYDVQQKEwVPdG9taTEUMBIGA1UECxMLU2VsZi1TaWduZWQw
+                          ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD4quPwHrharZhmqVQx/75N
+                          M7Vp3ZmSd3gR2u8Dc1PkmEa6W9CiheVAB5KCzdN5sWaOlFKTy5sHg/zvyYZjvNGX
+                          xaHCa4i6OyRgiTOC4NCrxuN5010G0vAxYaM1aIFcqObXuLcaK6miOybDLRfDxoHl
+                          g/TKqdiPOMEb2ZgphFxL7oYXjkobOggH+wzwwMIc/1nA3eBjEPsIkQehmb0R0Kxw
+                          K5VHPCvbPQb3USVqUs+NmsuCxmqkTtI32WqR0IuNAVqjaD9oNqcsKBgUOPYLYXM8
+                          xsTzIn0QPysJIKUCRn1quHwvCQc1RnQBB8UG6iJboVdRe0GNS13vu5ikhoCb0oyV
+                          AgMBAAGjHTAbMAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MA0GCSqGSIb3DQEB
+                          BQUAA4IBAQBJWHPGnTqXME/MGwG2nAG/JqiCQ0ZOOyKgwN97wrQIlbra2BaUT1K4
+                          tMDOjZlft1Luipg/IkzzMXt4eAmqGMxLIweqbve6aLm8KTpHkLdxLm3VPnhK8zzg
+                          ysRRRjtkMo9KUOSvrS2dFsY+fQnbGUzpRcK8RrzM6CpgIaf29neP1xLUWQuUsy5y
+                          yKCb6OQ9vaJBf/uvz73rQq0ym4Kx0FCFssshaja6lbz/jqCJmppdZE5pe5jvMVVv
+                          ae5UQLbva0JyLY8Rc1vSY/epIHMLrV90GEagSkF/ejgF3uh8cliLuUYFAFyU8TnN
+                          FWG+enMJfR04aWjp8M3MQ1IoCPVxoXxI
+                          -----END CERTIFICATE-----
+                      customRootCAKey: |
+                          -----BEGIN RSA PRIVATE KEY-----
+                          MIIEpQIBAAKCAQEA+Krj8B64Wq2YZqlUMf++TTO1ad2Zknd4EdrvA3NT5JhGulvQ
+                          ooXlQAeSgs3TebFmjpRSk8ubB4P878mGY7zRl8WhwmuIujskYIkzguDQq8bjedNd
+                          BtLwMWGjNWiBXKjm17i3Giupojsmwy0Xw8aB5YP0yqnYjzjBG9mYKYRcS+6GF45K
+                          GzoIB/sM8MDCHP9ZwN3gYxD7CJEHoZm9EdCscCuVRzwr2z0G91ElalLPjZrLgsZq
+                          pE7SN9lqkdCLjQFao2g/aDanLCgYFDj2C2FzPMbE8yJ9ED8rCSClAkZ9arh8LwkH
+                          NUZ0AQfFBuoiW6FXUXtBjUtd77uYpIaAm9KMlQIDAQABAoIBAQCTsIuotdYwpSH6
+                          9172Qzq3h5qbwe3QO/yoPivvFLQi9P4s+RM1M+kw2k5+Odj8UgzjadyRwz/UeuPj
+                          VwHmguLJDaxBWLTgRvgYDeT2Oqg1He9FD/AUeXwHGEJjGiqa6gYQ4bh+Zqhdnlwr
+                          V8DhmijUNEdThwUEK2UmMVpabi6TOW/dfO6sbnOHYwx326qF3LhYcUrmdeowEGLT
+                          UhxdXJQQUsfD+zft6dcPnqucIxd5OEsn3L8/pcumOxHUGFBHDMuB5nTpcZyDxKaN
+                          joC0zQy0BDQIMN1F7wNRukSiSYqvRvmvztF2Ka0yEWAdvBBXVVN8nKQw69oGoe9B
+                          EQ5HSkKBAoGBAP0KnCE19jW9jq1CWFkFwd1BALWA3GOuxJqSX6M5APM+JRBR4UOZ
+                          AUOogvGlrc1ns58q7oNoc1CHiMHd2lNFgfqWqopfVz1Tt9qHqU6VoJnkmJlJRriE
+                          57F08RTjslTFzYEsE9zMlL1xa5pq1aGAFB0/mYuxopRw39mS14ugxF1pAoGBAPuT
+                          MFLfp2wttGe2WhVepOnhD13sEMGCS6GE16jinjP3qAWIPM/Wdy+Ab8n+KWQkYPLw
+                          UsQVi+41LWFIexjzdrq9rG5LQbZdjDCyR4eomDGZhc0Vtsu79NbVrnSmjH8w6psa
+                          DXB1uN9/VcCzae/hRpk2Q6zFiMcPE8utUU5RvFRNAoGBAJ19+wsYoPN11dW0k3Rl
+                          BvKEwMI3P/SzFB74t5nJovPCXCM6MzB1jLnlqgppCjHsN3n7qJQVcKBQmye+w2JM
+                          wseK+v5AtPWwo5/aC+CjdGAUTX4qg1/ZKLPkiyBrT9U/f9bD7mDg3DrE2yozEGAC
+                          bYJ+0TyHBR/K2Sh8Irf/CfjxAoGBAM4wuwCRkpUVeLEwQfEV2zBdZ8zg+HLBqd8+
+                          E8u1wVhyeOHf4YevDYx/RiBWEfKj5ln3Ir7XshKQvxrm3w16Liur3bGgOMGRNp+K
+                          3xmO0v6EB6gpTeL5sBiMlinBf5GXtBFfbvhnZBi6Mrx30DHtf4F/ekQWup37+4uK
+                          CAOa9jJZAoGAYbU4CoCxktBECxAVAjtpvYW5176cxiitd75s1ANhXGiOH1A6/y6H
+                          rnZ+fMAuvPjrDXbtmqJsq0RXq1E07ng4ZDIjN+0pShVFQdakJRFo1y+d3b82lBYX
+                          EZrfMBCWVj31dXeGEHfVvOpwrQ5ffTzs2lVmTh7Ft61gs4TJ7gNTDbE=
+                          -----END RSA PRIVATE KEY-----
+                      email: test@test.local
+                      issuer: letsencrypt
+                      resources:
+                          limits:
+                              cpu: 200m
+                              memory: 384Mi
+                          requests:
+                              cpu: 50m
+                              memory: 64Mi
+                      stage: staging
+                  cloudnative-pg:
+                      resources:
+                          limits:
+                              cpu: 500m
+                              memory: 512Mi
+                          requests:
+                              cpu: 100m
+                              memory: 100Mi
+                  cluster-autoscaler:
+                      enabled: false
+                  cluster-overprovisioner:
+                      enabled: true
+                  demo-tlspass:
+                      enabled: false
+                  drone:
+                      adminUser: somesecretvalue
+                      debug: false
+                      enabled: true
+                      githubAdmins:
+                          org: redkubes
+                          team: admins
+                          token: somesecretvalue
+                      orgsFilter: redkubes
+                      repoFilter: redkubes
+                      sharedSecret: somesecretvalue
+                      sourceControl:
+                          github:
+                              clientID: somesecretvalue
+                              clientSecretValue: somesecretvalue
+                              server: https://github.com
+                          provider: github
+                          username: otomi-admin
+                      trace: false
+                  drone-admit-members:
+                      enabled: true
+                  external-dns:
+                      enabled: true
+                      logLevel: info
+                  external-secrets:
+                      enabled: true
+                      logLevel: warn
+                      pollingInterval: 60000
+                  falco:
+                      _rawValues:
+                          customRules:
+                              otomi-rules.yaml: >-
+                                  - macro: k8s_containers
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/openpolicyagent/gatekeeper,
+                                          docker.io/velero/velero,
+                                          docker.io/weaveworks/kured,
+                                          k8s.gcr.io/kube-state-metrics/kube-state-metrics,
+                                          quay.io/jetstack/cert-manager-cainjector,
+                                          quay.io/jetstack/cert-manager-controller,
+                                          quay.io/jetstack/cert-manager-webhook,
+                                          quay.io/prometheus-operator/prometheus-operator,
+                                          quay.io/prometheus/prometheus,
+                                          quay.io/kiwigrid/k8s-sidecar,
+                                          docker.io/otomi/core,
+                                          docker.io/otomi/tasks,
+                                          docker.io/otomi/api,
+                                          docker.io/drone/drone-runner-kube,
+                                          docker.io/grafana/promtail,
+                                          quay.io/argoprojlabs/argocd-image-updater
+                                        ) or (k8s.ns.name = "kube-system")
+                                          or (k8s.ns.name = "ingress")
+                                      )
+                                  - macro: user_known_write_below_etc_activities
+                                    condition: (
+                                        (container.image.repository = docker.io/goharbor/harbor-core and proc.name = cp) or
+                                        (container.image.repository = docker.io/goharbor/harbor-registryctl and proc.name = cp) or
+                                        (container.image.repository = docker.io/goharbor/registry-photon and proc.name = cp) or
+                                        (container.image.repository = docker.io/goharbor/trivy-adapter-photon and proc.name = cp)
+                                      )
+                                  - macro: user_sensitive_mount_containers
+                                    condition: (
+                                        container.image.repository in (
+                                          quay.io/prometheus/node-exporter
+                                        )
+                                      )
+                                  - macro: user_trusted_containers
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/drone/drone-runner-kube,
+                                          docker.io/otomi/api,
+                                          docker.io/otomi/tasks
+                                        )
+                                      )
+                                  - macro: user_known_package_manager_in_container
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/otomi/tasks
+                                        )
+                                      )
+                                  - macro: user_known_k8s_client_container
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/otomi/tasks,
+                                          ocker.io/otomi/core
+                                        ) or (k8s.ns.name = "drone-pipelines")
+                                      )
+                                  - macro: user_known_non_sudo_setuid_conditions
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/otomi/tasks,
+                                          docker.io/otomi/api,
+                                          docker.io/otomi/console,
+                                          docker.io/gitea/gitea,
+                                          docker.io/grafana/grafana
+                                        ) or (k8s.ns.name = "ingress")
+                                          or (k8s.ns.name = "keycloak")
+                                      )
+                                  - macro: excessively_capable_container
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/otomi/console,
+                                          docker.io/otomi/api
+                                        ) or (k8s.ns.name = "keycloak")
+                                      )
+                                  - macro: user_known_write_below_root_activities
+                                    condition: (
+                                        k8s.ns.name = "drone-pipelines"
+                                      )
+                                  - macro: user_known_network_tool_activities
+                                    condition: (
+                                        container.image.repository in (
+                                          docker.io/gitea/gitea
+                                        ) or (k8s.ns.name = "keycloak")  
+                                      )
+                                  - macro: user_known_create_files_below_dev_activities
+                                    condition: (
+                                        container.image.repository in (
+                                          quay.io/operatorhubio/catalog
+                                        )
+                                      )
+                      enabled: false
+                      falcoSidekick:
+                          minPrio: informational
+                          replicas: 1
+                      resources:
+                          falco:
+                              limits:
+                                  cpu: 500m
+                                  memory: 256Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          falcoExporter:
+                              limits:
+                                  cpu: 100m
+                                  memory: 64Mi
+                              requests:
+                                  cpu: 50m
+                                  memory: 32Mi
+                          falcoSidekick:
+                              limits:
+                                  cpu: 50m
+                                  memory: 64Mi
+                              requests:
+                                  cpu: 20m
+                                  memory: 32Mi
+                  gatekeeper:
+                      auditFromCache: false
+                      auditInterval: 60
+                      constraintViolationsLimit: 20
+                      dataSync:
+                          - kind: CronJob
+                            version: v1
+                          - kind: DaemonSet
+                            version: v1
+                          - kind: Deployment
+                            version: v1
+                          - kind: Job
+                            version: v1
+                          - kind: Pod
+                            version: v1
+                          - kind: StatefulSet
+                            version: v1
+                      disableValidatingWebhook: false
+                      emitAdmissionEvents: false
+                      emitAuditEvents: false
+                      enabled: true
+                      excludedNamespaces:
+                          - sandbox
+                      logLevel: INFO
+                      replicas: 1
+                  gitea:
+                      adminPassword: bladibla
+                      adminUsername: otomi-admin
+                      enabled: false
+                      postgresqlPassword: postgresqlPassword
+                  grafana:
+                      adminPassword: somesecretvalue
+                      enabled: true
+                  harbor:
+                      adminPassword: bladibla
+                      backup:
+                          enabled: true
+                          schedule: 0/3 * * * *
+                      databasePassword: somesecretvalue
+                      enabled: true
+                      persistence:
+                          imageChartStorage:
+                              gcs:
+                                  bucket: otomi-harbor
+                                  encodedkey: somesecretvalue
+                                  rootdirectory: /google/demo
+                              type: gcs
+                      registry:
+                          credentials:
+                              password: bladibla
+                              username: otomi-admin
+                      resources:
+                          trivy:
+                              limits:
+                                  cpu: 400m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 200m
+                                  memory: 256Mi
+                      secretKey: somesecretvalue
+                  hello:
+                      enabled: true
+                  host-mods:
+                      enabled: true
+                  httpbin:
+                      enabled: true
+                  ingress-azure:
+                      enabled: false
+                  ingress-nginx:
+                      autoscaling:
+                          enabled: true
+                          maxReplicas: 10
+                          minReplicas: 2
+                      enabled: true
+                      modsecurity:
+                          block: false
+                          enabled: false
+                          owasp: true
+                      private:
+                          autoscaling:
+                              enabled: true
+                              maxReplicas: 10
+                              minReplicas: 2
+                          enabled: false
+                  ingress-nginx-net-a:
+                      _rawValues:
+                          controller:
+                              config:
+                                  modsecurity-snippet: |
+                                      SecRuleRemoveById 911101
+                      maxBodySize: 1024m
+                      modsecurity:
+                          enabled: true
+                      resources:
+                          limits:
+                              cpu: 200m
+                              memory: 256Mi
+                          requests:
+                              cpu: 100m
+                              memory: 192Mi
+                  ingress-nginx-platform:
+                      _rawValues:
+                          controller:
+                              config:
+                                  modsecurity-snippet: |
+                                      SecRuleRemoveById 911102
+                      maxBodySize: 2048m
+                      modsecurity:
+                          enabled: true
+                      resources:
+                          limits:
+                              cpu: 200m
+                              memory: 256Mi
+                          requests:
+                              cpu: 100m
+                              memory: 192Mi
+                  ingress-nginx-private:
+                      _rawValues:
+                          controller:
+                              config:
+                                  modsecurity-snippet: |
+                                      SecRuleRemoveById 911103
+                      maxBodySize: 4096m
+                      modsecurity:
+                          enabled: true
+                      resources:
+                          limits:
+                              cpu: 200m
+                              memory: 256Mi
+                          requests:
+                              cpu: 100m
+                              memory: 192Mi
+                  istio:
+                      autoscaling:
+                          egressgateway:
+                              maxReplicas: 10
+                              minReplicas: 2
+                          ingressgateway:
+                              maxReplicas: 5
+                              minReplicas: 1
+                          pilot:
+                              maxReplicas: 5
+                              minReplicas: 1
+                      egressGateway:
+                          enabled: false
+                      enabled: true
+                      global:
+                          logging:
+                              level: default:warn
+                      meshConfig:
+                          accessLogFile: /dev/stdout
+                          defaultConfig:
+                              tracing:
+                                  sampling: 0.1
+                          enableAutoMtls: true
+                          extensionProviders:
+                              - envoyExtAuthzGrpc: null
+                                includeRequestBodyInCheck:
+                                    maxRequestBytes: 1000000
+                                name: ext-authz-chain-grpc
+                                port: '80'
+                                service: s1.test.svc.cluster.local
+                      resources:
+                          ingressgateway:
+                              limits:
+                                  cpu: 500m
+                                  memory: 256Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          pilot:
+                              limits:
+                                  cpu: 100m
+                                  memory: 256Mi
+                              requests:
+                                  cpu: 10m
+                                  memory: 100Mi
+                          prometheus:
+                              limits:
+                                  cpu: 500m
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 200m
+                                  memory: 500Mi
+                          proxy:
+                              limits:
+                                  cpu: 500m
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 20m
+                                  memory: 80Mi
+                  jaeger:
+                      enabled: true
+                  keycloak:
+                      address: https://keycloak.demo.eks.otomi.cloud
+                      adminPassword: bladibla
+                      adminUsername: otomi-admin
+                      enabled: true
+                      idp:
+                          alias: redkubes-azure
+                          clientID: otomi
+                          clientSecret: somsecretvalue
+                      postgresqlPassword: postgresqlPassword
+                      theme: otomi
+                  kiali:
+                      enabled: true
+                      resources:
+                          operator:
+                              limits:
+                                  cpu: 200m
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 50m
+                                  memory: 256Mi
+                          pod:
+                              limits:
+                                  cpu: 200m
+                                  memory: 256Mi
+                              requests:
+                                  cpu: 50m
+                                  memory: 128Mi
+                  knative:
+                      enabled: false
+                      serving:
+                          replicas: 1
+                  kube-descheduler:
+                      enabled: false
+                  kubeapps:
+                      autoscaling:
+                          dashboard:
+                              maxReplicas: 10
+                              minReplicas: 1
+                          frontend:
+                              maxReplicas: 10
+                              minReplicas: 1
+                          kubeops:
+                              maxReplicas: 10
+                              minReplicas: 1
+                      enableCommonGround: false
+                      enabled: true
+                      postgresqlPassword: postgresqlPassword
+                  kubeclarity:
+                      databasePassword: 123jefkejoql
+                      enabled: true
+                      logLevel: warning
+                      resources:
+                          cdbScanner:
+                              limits:
+                                  cpu: '1'
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 50m
+                                  memory: 50Mi
+                          kubeclarity:
+                              limits:
+                                  cpu: '1'
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 100m
+                                  memory: 200Mi
+                          postgresql:
+                              limits:
+                                  cpu: '1'
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 251m
+                                  memory: 256Mi
+                          sbomDb:
+                              limits:
+                                  cpu: 100m
+                                  memory: 100Mi
+                              requests:
+                                  cpu: 10m
+                                  memory: 20Mi
+                          trivyServer:
+                              limits:
+                                  cpu: '1'
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 200m
+                                  memory: 200Mi
+                          vulnerabilityScanner:
+                              limits:
+                                  cpu: '1'
+                                  memory: 2Gi
+                              requests:
+                                  cpu: 100m
+                                  memory: 256Mi
+                  kured:
+                      _rawValues:
+                          configuration:
+                              endTime: 07:00
+                              rebootDays:
+                                  - su
+                              startTime: 22:00
+                              timeZone: CET
+                      enabled: true
+                      resources:
+                          kuredDaemonSet:
+                              limits:
+                                  cpu: 50m
+                                  memory: 32Mi
+                              requests:
+                                  cpu: 20m
+                                  memory: 16Mi
+                  loki:
+                      adminPassword: somesecretvalue
+                      autoscaling:
+                          distributor:
+                              enabled: true
+                              maxReplicas: 3
+                              minReplicas: 1
+                              targetCPUUtilizationPercentage: 60
+                              targetMemoryUtilizationPercentage: 80
+                          gateway:
+                              enabled: true
+                              maxReplicas: 3
+                              minReplicas: 1
+                              targetCPUUtilizationPercentage: 60
+                              targetMemoryUtilizationPercentage: 80
+                          ingester:
+                              enabled: true
+                              maxReplicas: 3
+                              minReplicas: 1
+                              targetCPUUtilizationPercentage: 60
+                              targetMemoryUtilizationPercentage: 80
+                          querier:
+                              enabled: true
+                              maxReplicas: 3
+                              minReplicas: 1
+                              targetCPUUtilizationPercentage: 60
+                              targetMemoryUtilizationPercentage: 80
+                          queryFrontend:
+                              enabled: true
+                              maxReplicas: 3
+                              minReplicas: 1
+                              targetCPUUtilizationPercentage: 60
+                              targetMemoryUtilizationPercentage: 80
+                      enabled: true
+                      persistence:
+                          ingester:
+                              size: 20Gi
+                          querier:
+                              size: 10Gi
+                      resources:
+                          compactor:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          distributor:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          gateway:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          ingester:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          querier:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          queryFrontend:
+                              limits:
+                                  cpu: 900m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                      retention:
+                          duration: 24h
+                          period: 24h
+                      storage:
+                          azure:
+                              account_key: account_key
+                          type: minioLocal
+                      v11StartDate: 2021-05-13
+                  metrics-server:
+                      apiServer:
+                          create: true
+                      enabled: true
+                      extraArgs:
+                          kubelet-preferred-address-types: InternalIP
+                  minio:
+                      enabled: true
+                      persistence:
+                          enabled: true
+                          size: 20Gi
+                      provisioning:
+                          enabled: true
+                      resources:
+                          limits:
+                              cpu: 1
+                              memory: 1Gi
+                          requests:
+                              cpu: 500m
+                              memory: 128Mi
+                  oauth2-proxy:
+                      config:
+                          cookieSecret: gkhugxJsPjhbCybH
+                  oauth2-proxy-redis:
+                      password: gkhugxJsPjhbCybH
+                  opa-exporter: {}
+                  opencost:
+                      alerts:
+                          costOfAllNodesQuotaPerMonthReached:
+                              quota: 500
+                          enabled: true
+                      enabled: true
+                      resources:
+                          exporter:
+                              limits:
+                                  cpu: 1
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 500m
+                                  memory: 128Mi
+                          ui:
+                              limits:
+                                  cpu: 1
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 500m
+                                  memory: 128Mi
+                  otomi-api:
+                      editorInactivityTimeout: 5
+                      git:
+                          email: some@secret.value
+                          password: somesecretvalue
+                          repoUrl: github.com/redkubes/otomi-values-demo.git
+                          user: someuser
+                  otomi-console: {}
+                  prometheus:
+                      disabledRules:
+                          - InfoInhibitor
+                          - PrometheusOperatorListErrors
+                      enabled: true
+                      remoteWrite:
+                          enabled: true
+                          otomiThanos: false
+                          rwConfig:
+                              basicAuth:
+                                  enabled: true
+                                  password: blalalalalal
+                                  username: testaccount
+                              customConfig: |-
+                                  writeRelabelConfigs:
+                                    - targetLabel: tenant
+                                      sourceLabels:
+                                      - instance
+                                      replacement: otomi-aks-ont
+                                    - targetLabel: cluster
+                                      sourceLabels:
+                                      - instance
+                                      replacement: otomi-aks-ont
+                                    - targetLabel: customer_id
+                                      sourceLabels:
+                                      - instance
+                                      replacement: "00001"
+                                  queueConfig:
+                                    capacity: 18000
+                                    maxShards: 100
+                                    maxSamplesPerSend: 6000
+                              insecureSkipVerify: false
+                              target: https://remote.target.io/api/v1/push
+                      replicas: 1
+                      retentionSize: 4GB
+                      scrapeInterval: 60s
+                      storageSize: 5Gi
+                  prometheus-blackbox-exporter: {}
+                  prometheus-msteams:
+                      enabled: false
+                  promtail:
+                      enabled: false
+                  redis-shared:
+                      enabled: false
+                      sizes:
+                          master: 1Gi
+                  snapshot-controller:
+                      enabled: false
+                  tekton:
+                      enabled: true
+                  thanos:
+                      compactor:
+                          retentionResolution1h: 0s
+                          retentionResolution5m: 0s
+                          retentionResolutionRaw: 0s
+                      enabled: true
+                      objstore:
+                          storageProvider:
+                              type: minioLocal
+                      persistence:
+                          compactor:
+                              size: 8Gi
+                          receiver:
+                              size: 50Gi
+                          ruler:
+                              size: 8Gi
+                          storegateway:
+                              size: 8Gi
+                      query:
+                          replicaCount: 1
+                      receiver:
+                          mode: dual-mode
+                          replicaCount: 2
+                          replicationFactor: 1
+                          tsdbRetention: 7d
+                      receiverDistributor:
+                          enabled: true
+                      resources:
+                          bucketweb:
+                              limits:
+                                  cpu: 100m
+                                  memory: 128Mi
+                              requests:
+                                  cpu: 50m
+                                  memory: 64Mi
+                          compactor:
+                              limits:
+                                  cpu: '1'
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          query:
+                              limits:
+                                  cpu: 500m
+                                  memory: 1Gi
+                              requests:
+                                  cpu: 100m
+                                  memory: 256Mi
+                          queryFrontend:
+                              limits:
+                                  cpu: 500m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          receiver:
+                              limits:
+                                  cpu: '1'
+                                  memory: 2Gi
+                              requests:
+                                  cpu: 200m
+                                  memory: 512Mi
+                          receiverDistributor:
+                              limits:
+                                  cpu: '1'
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                          ruler:
+                              limits:
+                                  cpu: 500m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 256Mi
+                          storegateway:
+                              limits:
+                                  cpu: 500m
+                                  memory: 256Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 128Mi
+                      ruler:
+                          enabled: false
+                  tigera-operator:
+                      enabled: false
+                  trivy:
+                      enabled: true
+                      operator:
+                          replicaCount: 1
+                      resources:
+                          operator:
+                              limits:
+                                  cpu: 500m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 64Mi
+                          trivy:
+                              limits:
+                                  cpu: 500m
+                                  memory: 512Mi
+                              requests:
+                                  cpu: 100m
+                                  memory: 64M
+                  vault:
+                      enabled: true
+                      logLevel: warn
+                      resources:
+                          limits:
+                              cpu: 1000m
+                              memory: 512Mi
+                          requests:
+                              cpu: 500m
+                              memory: 256Mi
+                  velero:
+                      cloud:
+                          google:
+                              project: velero
+                              saKeyJson: '{key in json format}'
+                              serviceAccount: bla
+                          type: google
+                      enabled: true
+                      logLevel: info
+                      resources:
+                          limits:
+                              cpu: 1000m
+                              memory: 512Mi
+                          requests:
+                              cpu: 500m
+                              memory: 128Mi
+                      restic:
+                          enabled: false
+                      storage:
+                          gcs:
+                              bucket: velero
+                              serviceAccount: bla
+                          type: gcs
               azure:
-                account_key: account_key
-              type: minioLocal
-            v11StartDate: 2021-05-13
-          metrics-server:
-            apiServer:
-              create: true
-            enabled: true
-            extraArgs:
-              kubelet-preferred-address-types: InternalIP
-          minio:
-            enabled: true
-            persistence:
-              enabled: true
-              size: 20Gi
-            provisioning:
-              enabled: true
-            resources:
-              limits:
-                cpu: 1
-                memory: 1Gi
-              requests:
-                cpu: 500m
-                memory: 128Mi
-          oauth2-proxy:
-            config:
-              cookieSecret: gkhugxJsPjhbCybH
-          oauth2-proxy-redis:
-            password: gkhugxJsPjhbCybH
-          opa-exporter: {}
-          opencost:
-            alerts:
-              costOfAllNodesQuotaPerMonthReached:
-                quota: 500
-              enabled: true
-            enabled: true
-            resources:
-              exporter:
-                limits:
-                  cpu: 1
-                  memory: 1Gi
-                requests:
-                  cpu: 500m
-                  memory: 128Mi
-              ui:
-                limits:
-                  cpu: 1
-                  memory: 1Gi
-                requests:
-                  cpu: 500m
-                  memory: 128Mi
-          otomi-api:
-            editorInactivityTimeout: 5
-            git:
-              email: some@secret.value
-              password: somesecretvalue
-              repoUrl: github.com/redkubes/otomi-values-demo.git
-              user: someuser
-          otomi-console: {}
-          prometheus:
-            disabledRules:
-              - InfoInhibitor
-              - PrometheusOperatorListErrors
-            enabled: true
-            remoteWrite:
-              enabled: true
-              otomiThanos: false
-              rwConfig:
-                basicAuth:
-                  enabled: true
-                  password: blalalalalal
-                  username: testaccount
-                customConfig: |-
-                  writeRelabelConfigs:
-                    - targetLabel: tenant
-                      sourceLabels:
-                      - instance
-                      replacement: otomi-aks-ont
-                    - targetLabel: cluster
-                      sourceLabels:
-                      - instance
-                      replacement: otomi-aks-ont
-                    - targetLabel: customer_id
-                      sourceLabels:
-                      - instance
-                      replacement: "00001"
-                  queueConfig:
-                    capacity: 18000
-                    maxShards: 100
-                    maxSamplesPerSend: 6000
-                insecureSkipVerify: false
-                target: https://remote.target.io/api/v1/push
-            replicas: 1
-            retentionSize: 4GB
-            scrapeInterval: 60s
-            storageSize: 5Gi
-          prometheus-blackbox-exporter: {}
-          prometheus-msteams:
-            enabled: false
-          promtail:
-            enabled: false
-          redis-shared:
-            enabled: false
-            sizes:
-              master: 1Gi
-          snapshot-controller:
-            enabled: false
-          tekton:
-            enabled: true
-          thanos:
-            compactor:
-              retentionResolution1h: 0s
-              retentionResolution5m: 0s
-              retentionResolutionRaw: 0s
-            enabled: true
-            objstore:
-              storageProvider:
-                type: minioLocal
-            persistence:
-              compactor:
-                size: 8Gi
-              receiver:
-                size: 50Gi
-              ruler:
-                size: 8Gi
-              storegateway:
-                size: 8Gi
-            query:
-              replicaCount: 1
-            receiver:
-              mode: dual-mode
-              replicaCount: 2
-              replicationFactor: 1
-              tsdbRetention: 7d
-            receiverDistributor:
-              enabled: true
-            resources:
-              bucketweb:
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-                requests:
-                  cpu: 50m
-                  memory: 64Mi
-              compactor:
-                limits:
-                  cpu: '1'
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              query:
-                limits:
-                  cpu: 500m
-                  memory: 1Gi
-                requests:
-                  cpu: 100m
-                  memory: 256Mi
-              queryFrontend:
-                limits:
-                  cpu: 500m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              receiver:
-                limits:
-                  cpu: '1'
-                  memory: 2Gi
-                requests:
-                  cpu: 200m
-                  memory: 512Mi
-              receiverDistributor:
-                limits:
-                  cpu: '1'
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-              ruler:
-                limits:
-                  cpu: 500m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 256Mi
-              storegateway:
-                limits:
-                  cpu: 500m
-                  memory: 256Mi
-                requests:
-                  cpu: 100m
-                  memory: 128Mi
-            ruler:
-              enabled: false
-          tigera-operator:
-            enabled: false
-          trivy:
-            enabled: true
-            operator:
-              replicaCount: 1
-            resources:
-              operator:
-                limits:
-                  cpu: 500m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              trivy:
-                limits:
-                  cpu: 500m
-                  memory: 512Mi
-                requests:
-                  cpu: 100m
-                  memory: 64M
-          vault:
-            enabled: true
-            logLevel: warn
-            resources:
-              limits:
-                cpu: 1000m
-                memory: 512Mi
-              requests:
-                cpu: 500m
-                memory: 256Mi
-          velero:
-            cloud:
-              google:
-                project: velero
-                saKeyJson: '{key in json format}'
-                serviceAccount: bla
-              type: google
-            enabled: true
-            logLevel: info
-            resources:
-              limits:
-                cpu: 1000m
-                memory: 512Mi
-              requests:
-                cpu: 500m
-                memory: 128Mi
-            restic:
-              enabled: false
-            storage:
-              gcs:
-                bucket: velero
-                serviceAccount: bla
-              type: gcs
-        azure:
-          appgw:
-            isManaged: true
-          monitor:
-            clientId: somesecretvalue
-            clientSecret: somesecretvalue
-            subscriptionId: somesecretvalue
-            tenantId: somesecretvalue
-          resourceGroup: somevalue
-          subscriptionId: somevalue
-          tenantId: somevalue
-        cloud:
-          skipStorageClasses:
-            - std
-            - std-immediate
-        cluster:
-          apiName: eks_otomi-cloud_eu-central-1_otomi-eks-demo
-          apiServer: https://1.1.1.1:8443
-          domainSuffix: demo.eks.otomi.cloud
-          k8sContext: otomi-eks-demo
-          k8sVersion: '1.25'
-          name: demo
-          owner: redkubes
-          provider: custom
-          region: eu-central-1
-        dns:
-          domainFilters:
-            - otomi.cloud
-          provider:
-            aws:
-              credentials:
-                accessKey: AAAAAAAAAAAAAAAAA
-                secretKey: DuJ/T6fFYMysjRUxxxxxxxxxxxxxxxxx
-              region: eu-central-1
-          zoneIdFilters:
-            - otomi
-        home:
-          email:
-            critical: admins@yourdoma.in
-          receivers:
-            - slack
-          slack:
-            channel: mon-otomi
-            channelCrit: mon-otomi-crit
-            url: https://hooks.slack.com/services/id
-        ingress:
-          classes:
-            - className: platform
-              entrypoint: ''
-              network: public
-            - className: private
-              entrypoint: ''
-              loadBalancerSubnet: subnet
-              network: private
-            - className: net-a
-              entrypoint: ''
-              loadBalancerIP: 11.0.0.1
-              loadBalancerRG: myrg
-              network: public
-              sourceIpAddressFiltering: 10.0.0.0/24
-          platformClass:
-            className: platform
-            entrypoint: ''
-            network: public
-        k8s:
-          namespaces:
-            - app: argocd
-              name: argocd
-            - disableIstioInjection: true
-              name: cert-manager
-            - app: cloudnative-pg
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: cnpg-system
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: default
-            - name: drone
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: drone-pipelines
-            - disableIstioInjection: true
-              name: external-dns
-            - disableIstioInjection: true
-              name: external-secrets
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: falco
-            - app: harbor
-              name: harbor
-            - app: gatekeeper
-              disableIstioInjection: true
-              name: gatekeeper-system
-            - name: gitea
-            - app: grafana
-              name: grafana
-            - disableIstioInjection: true
-              name: istio-system
-            - istio-injection: disabled
-              istio-operator-managed: Reconcile
-              name: istio-operator
-            - app: httpbin
-              name: httpbin
-            - disableIstioInjection: true
-              name: ingress
-            - app: jaeger
-              name: jaeger
-            - app: jaeger
-              disableIstioInjection: true
-              name: jaeger-operator
-            - name: keycloak
-            - app: kiali
-              name: kiali
-            - app: kiali
-              disableIstioInjection: true
-              name: kiali-operator
-            - app: knative
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: knative-serving
-            - app: kubeapps
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: kubeapps
-            - app: kured
-              disableIstioInjection: true
-              name: kured
-            - app: kubeclarity
-              disableIstioInjection: true
-              name: kubeclarity
-            - app: tekton
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: tekton
-            - disableIstioInjection: true
-              name: maintenance
-            - app: minio
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: minio
-            - disableIstioInjection: true
-              name: monitoring
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: olm
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: opa-exporter
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: operators
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: opencost
-            - name: otomi
-            - app: cluster-overprovisioner
-              disableIstioInjection: true
-              name: cluster-overprovisioner
-            - app: prometheus
-              disableIstioInjection: true
-              name: redis
-            - name: team-admin
-            - disableIstioInjection: true
-              disablePolicyChecks: true
-              name: tigera-operator
-            - app: trivy
-              disableIstioInjection: true
-              disablePolicyChecks: true
-              name: trivy-operator
-            - app: vault
-              name: vault
-            - app: velero
-              name: velero
-        kms:
-          sops:
-            azure:
-              clientId: somesecretvalue
-              clientSecret: somesecretvalue
-              keys: somesecretvalue
-              tenantId: somesecretvalue
-        letsencryptCA: |
-          -----BEGIN CERTIFICATE-----
-          MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
-          MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-          aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-          ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
-          BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
-          Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
-          AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
-          gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
-          L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
-          nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
-          nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
-          biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
-          DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
-          BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
-          ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
-          MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
-          HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
-          MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
-          DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
-          vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
-          y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
-          Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
-          yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
-          xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
-          Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
-          zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
-          qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
-          xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
-          hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
-          -----END CERTIFICATE-----
-        letsencryptRootCA: |
-          -----BEGIN CERTIFICATE-----
-          MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
-          MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
-          aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
-          ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
-          BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
-          YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
-          AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
-          ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
-          jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
-          wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
-          oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
-          TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
-          fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
-          rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
-          FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
-          mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
-          GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
-          mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
-          Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
-          9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
-          nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
-          qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
-          qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
-          sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
-          CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
-          5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
-          xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
-          fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
-          gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
-          7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
-          -----END CERTIFICATE-----
-        license: license-in-jwt-format
-        oidc:
-          adminGroupID: someAdminGroupID
-          clientID: someClientID
-          clientSecret: somesecretvalue
-          issuer: https://login.microsoftonline.com/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-          subClaimMapper: oid
-          teamAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-        otomi:
-          additionalClusters:
-            - domainSuffix: demo.eks.otomi.cloud
-              name: demo
-              provider: aws
-          adminPassword: bladibla
-          globalPullSecret:
-            password: blablabla
-            username: otomi
-          hasCloudLB: false
-          hasExternalDNS: true
-          hasExternalIDP: true
-          isHomeMonitored: true
-          isMultitenant: true
-          nodeSelector:
-            otomi: otomi-sys
-          version: main
-        platformBackups:
-          argo:
-            enabled: false
-          drone:
-            enabled: false
-          gitea:
-            enabled: false
-          harbor:
-            enabled: false
-          keycloak:
-            enabled: false
-          kubeapps:
-            enabled: false
-          minio:
-            enabled: false
-          vault:
-            enabled: false
-        policies:
-          banned-image-tags:
-            enabled: false
-            tags:
-              - latest
-          container-limits:
-            cpu: '2'
-            enabled: true
-            memory: 2Gi
-          psp-allowed-repos:
-            enabled: false
-            repos:
-              - harbor.demo.gke.otomi.cloud
-              - harbor.demo.aks.otomi.cloud
-              - harbor.demo.eks.otomi.cloud
-          psp-allowed-users:
-            enabled: true
-            fsGroup:
-              ranges:
-                - max: 65535
-                  min: 1
-              rule: MayRunAs
-            runAsGroup:
-              ranges:
-                - max: 65535
-                  min: 1
-              rule: MayRunAs
-            runAsUser:
-              rule: MustRunAsNonRoot
-            supplementalGroups:
-              ranges:
-                - max: 65535
-                  min: 1
-              rule: MayRunAs
-          psp-apparmor:
-            allowedProfiles:
-              - runtime/default
-            enabled: true
-          psp-capabilities:
-            allowedCapabilities:
-              - NET_BIND_SERVICE
-              - NET_RAW
-            enabled: false
-            requiredDropCapabilities:
-              - ALL
-          psp-forbidden-sysctls:
-            enabled: true
-            forbiddenSysctls:
-              - kernel.*
-              - net.*
-              - abi.*
-              - fs.*
-              - sunrpc.*
-              - user.*
-              - vm.*
-          psp-host-filesystem:
-            allowedHostPaths:
-              - pathPrefix: /tmp/
-                readOnly: false
-            enabled: true
-          psp-host-networking-ports:
-            enabled: true
-          psp-host-security:
-            enabled: true
-          psp-privileged:
-            enabled: true
-          psp-seccomp:
-            allowedProfiles:
-              - runtime/default
-            enabled: false
-          psp-selinux:
-            enabled: false
-            seLinuxContext: RunAsAny
-        smtp:
-          auth_password: somesecretvalue
-          auth_username: no-reply@doma.in
-          from: no-reply@doma.in
-          hello: doma.in
-          smarthost: smtp-relay.gmail.com:587
-        status:
-          helm:
-            drone/drone:
-              app_version: 1.6.1
-              chart: drone-3.0.0
-              name: drone
-              namespace: drone
-              revision: '1'
-              status: deployed
-              updated: 2023-05-31 09:54:32.168150254 +0000 UTC
-            harbor/harbor:
-              app_version: 1.6.1
-              chart: drone-3.0.0
-              name: drone
-              namespace: drone
-              revision: '1'
-              status: deployed
-              updated: 2023-05-31 09:54:32.168150254 +0000 UTC
-          otomi:
-            deployingTag: main
-            deployingVersion: 0.21.0
-            status: deployed
-            version: 0.21.0
-        teamApps:
-          - ingress:
-              - auth: true
-                hasPrefix: true
-                port: 9093
-                svc: po-alertmanager
-                type: public
-            name: alertmanager
-          - ingress:
-              - auth: true
-                forwardPath: true
-                hasPrefix: true
-                removeRequestHeaders:
-                  - authorization
-                svc: po-grafana
-                type: public
-            name: grafana
-            ownHost: true
-          - name: loki
-            path: /explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22#NS#%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
-            useHost: grafana
-          - ingress:
-              - auth: true
-                hasPrefix: true
-                port: 9090
-                svc: po-prometheus
-                type: public
-            name: prometheus
-        teamConfig:
-          admin:
-            id: admin
-            jobs: []
-            secrets:
-              - entries:
-                  - TARGET
-                id: 15bb8ecf-1fef-474c-9143-a1f19c81c387
-                name: mysecret-generic-admin
-                namespace: some-ns
-                teamId: demo
-                type: generic
-              - clusterWide: true
-                entries:
-                  - TARGET
-                id: 15bb8ecf-1fef-474c-9143-a1f19c81c388
-                name: mysecret-generic-admin-clusterwide
-                teamId: demo
-                type: generic
-              - entries:
-                  - TARGET
-                id: 15bb8ecf-1fef-474c-9143-a1f19c81c389
-                name: mysecret-generic-admin-teamwide
-                teamId: demo
-                teamWide: true
-                type: generic
-            services:
-              - auth: true
-                domain: hello.team-admin.demo.eks.otomi.cloud
-                id: cb5149c4-8ea5-4c5a-be04-a37258658bd0
-                name: hello-admin
-                networkPolicy:
-                  ingressPrivate:
-                    mode: AllowAll
-                ownHost: true
-                port: 80
-                type: public
-            workloads:
-              - name: wa1
-                path: /
-                revision: HEAD
-                url: https://myrepo.local/mychart.git
-              - chart: mychart
-                name: wa2
-                revision: 1.2.3
-                url: https://myregistry.local/mychart
-              - chart: crossplane
-                name: crossplane-custom-namespace
-                namespace: crossplane
-                revision: 1.11.2
-                url: https://charts.crossplane.io/stable
-              - chart: crossplane
-                name: crossplane-team-namespace
-                revision: 1.11.2
-                url: https://charts.crossplane.io/stable
-          demo:
-            alerts:
-              email:
-                critical: admins@yourdoma.in
-                nonCritical: admins@yourdoma.in
-              receivers:
-                - email
-            backups:
-              - name: bu1
-                schedule: 0 0 0 * *
-                snapshotVolumes: true
-                ttl: 8h
-              - labelSelector:
-                  - name: app
-                    value: hello
-                  - name: backup
-                    value: all
-                name: bu2
-                schedule: 0 0 0 * *
-                snapshotVolumes: true
-                ttl: 8h
-            billingAlertQuotas:
-              teamCpuMonthQuotaReached:
-                quota: 150
-              teamMemMonthQuotaReached:
-                quota: 200
-            builds:
-              - mode:
-                  docker:
-                    path: ./Docker
-                    repoUrl: https://github.com/buildpacks/samples
-                    revision: HEAD
-                  type: docker
-                name: demo-java1
-                repoAccess:
-                  otomiGit: true
-                  privateGit: false
-                tag: v.0.0.1
-              - mode:
-                  buildpacks:
-                    path: apps/java-maven
-                    repoUrl: https://github.com/buildpacks/samples
-                    revision: HEAD
-                  type: buildpacks
-                name: demo-java2
-                repoAccess:
-                  otomiGit: true
-                  privateGit: true
-                tag: v.0.0.1
-              - mode:
-                  docker:
-                    path: ./Docker
-                    repoUrl: https://github.com/buildpacks/samples
-                    revision: HEAD
-                  type: docker
-                name: demo-java3
-                repoAccess:
-                  otomiGit: false
-                  privateGit: true
-                  repoPassword: bla1111111
-                  repoUserName: bla
-                tag: v.0.0.1
-            id: demo
-            jobs:
-              - enabled: true
-                env:
-                  receiver: world
-                files:
-                  /config/some-file: someData
-                  /config/some-file3: |-
-                    some data on another line
-                    another line
-                  /config/some/file2: someData2
-                image:
-                  pullPolicy: IfNotPresent
-                  repository: busybox
-                  tag: latest
-                init:
-                  - command:
-                      - echo
-                      - hello foo $foo
-                    env:
-                      foo: bar
-                    image:
-                      pullPolicy: IfNotPresent
-                      repository: busybox
-                      tag: latest
-                    resources:
-                      limits:
-                        cpu: 50m
-                        memory: 64Mi
-                      requests:
-                        cpu: 50m
-                        memory: 64Mi
-                    secrets:
-                      - mysecret-generic
-                      - hello-otomi
-                name: contains-everything
-                podSecurityContext:
-                  fsGroup: 1002
-                  runAsGroup: 1002
-                  runAsNonRoot: true
-                  runAsUser: 1002
-                resources:
-                  limits:
-                    cpu: 50m
-                    memory: 64Mi
-                  requests:
-                    cpu: 50m
-                    memory: 64Mi
-                runPolicy: Always
-                script: echo "hello $receiver"
-                secretMounts:
-                  /config/some-folder: someSecret
-                secrets:
-                  - mysecret-generic
-                  - hello-otomi
-                securityContext:
-                  runAsGroup: 1002
-                  runAsNonRoot: true
-                  runAsUser: 1002
-                type: Job
-              - enabled: true
-                env:
-                  receiver: world
-                files:
-                  /some-file: someData
-                  /some-file2: someData2
-                  /some-file3: |-
-                    some data on another line
-                    another line
-                image:
-                  pullPolicy: IfNotPresent
-                  repository: busybox
-                  tag: latest
-                init:
-                  - env:
-                      foo: bar
-                    image:
-                      pullPolicy: IfNotPresent
-                      repository: busybox
-                      tag: latest
-                    resources:
-                      limits:
-                        cpu: 50m
-                        memory: 64Mi
-                      requests:
-                        cpu: 50m
-                        memory: 64Mi
-                    script: |
-                      echo "hello $receiver"
-                name: also-contains-everything-and-cron
-                resources:
-                  limits:
-                    cpu: 50m
-                    memory: 64Mi
-                  requests:
-                    cpu: 50m
-                    memory: 64Mi
-                runPolicy: Always
-                schedule: 0 1 * * *
-                script: echo "hello $receiver"
-                secrets:
-                  - generic-example
-                  - hello-otomi
-                type: CronJob
-              - enabled: true
-                image:
-                  pullPolicy: IfNotPresent
-                  repository: busybox
-                  tag: latest
-                name: base
-                resources:
-                  limits:
-                    cpu: 50m
-                    memory: 64Mi
-                  requests:
-                    cpu: 50m
-                    memory: 64Mi
-                script: echo "hello $receiver"
-                type: Job
-              - enabled: true
-                image:
-                  pullPolicy: IfNotPresent
-                  repository: busybox
-                  tag: latest
-                name: base-cronjob
-                resources:
-                  limits:
-                    cpu: 50m
-                    memory: 64Mi
-                  requests:
-                    cpu: 50m
-                    memory: 64Mi
-                schedule: 0 1 * * *
-                script: echo "hello world"
-                type: CronJob
-              - enabled: true
-                image:
-                  pullPolicy: IfNotPresent
-                  repository: busybox
-                  tag: latest
-                init:
-                  - env:
-                      foo: bar
-                    image:
-                      pullPolicy: IfNotPresent
-                      repository: busybox
-                      tag: latest
-                    resources:
-                      limits:
-                        cpu: 50m
-                        memory: 64Mi
-                      requests:
-                        cpu: 50m
-                        memory: 64Mi
-                    script: echo "hello world"
-                name: init-cronjob
-                resources:
-                  limits:
-                    cpu: 50m
-                    memory: 64Mi
-                  requests:
-                    cpu: 50m
-                    memory: 64Mi
-                schedule: 0 1 * * *
-                script: echo "hello $receiver"
-                type: CronJob
-            networkPolicy:
-              egressPublic: true
-              ingressPrivate: true
-            oidc:
-              groupMapping: somesecretvalue
-            password: somesecretvalue
-            resourceQuota:
-              services.loadbalancers: '1'
-            secrets:
-              - entries:
-                  - TARGET
-                id: 15bb8ecf-1fef-474c-9143-a1f19c81c378
-                name: mysecret-generic
-                teamId: demo
-                type: generic
-              - id: d29ab8f8-1281-4eba-81b0-be01baed03a6
-                name: mysecret-registry
-                teamId: demo
-                type: docker-registry
-              - ca: ca.crt
-                crt: tls.crt
-                id: efe80c21-cfb2-4436-a9dd-e6838ea9c4f9
-                key: tls.key
-                name: mysecret-tls
-                teamId: demo
-                type: tls
-            selfService:
-              apps: []
-              service:
-                - ingress
-                - networkPolicy
-              team:
-                - alerts
-            services:
-              - auth: true
-                domain: hello.team-demo.demo.eks.otomi.cloud
-                headers:
-                  response:
-                    set:
-                      - name: X-Frame-Options
-                        value: same-origin
-                      - name: sander
-                        value: same-origin
-                id: cb5149c4-8ea5-4c5a-be04-a37258658bd3
-                ksvc:
-                  predeployed: true
-                name: hello
-                networkPolicy:
-                  ingressPrivate:
-                    mode: AllowAll
-                ownHost: true
-                port: 80
-                type: public
-              - domain: tlspass.eks.dev.otomi.cloud
-                id: cb5149c4-8ea5-4c5a-be04-a37258658bd4
-                ksvc:
-                  predeployed: true
-                name: hello-auth
-                ownHost: true
-                paths: []
-                port: 80
-                type: public
-              - id: cb5149c4-8ea5-4c5a-be04-a37258658bd5
-                ksvc:
-                  predeployed: true
-                name: tlspass
-                port: 443
-                tlsPass: true
-                type: public
-              - id: cb5149c4-8ea5-4c5a-be04-a37258658bd6
-                name: some-svc
-                networkPolicy:
-                  ingressPrivate:
-                    mode: AllowAll
-                port: 80
-                type: cluster
-              - hasCert: true
-                name: has-cert-svc
-                paths:
-                  - /jeho
-                type: public
-              - name: service-a
-                networkPolicy:
-                  egressPublic:
-                    - domain: domain1.com
-                      ports:
-                        - number: 8443
-                          protocol: TCP
-                    - domain: domain2.com
-                      ports:
-                        - number: 443
-                          protocol: HTTPS
-                    - domain: 185.199.110.153
-                      ports:
-                        - number: 443
-                          protocol: TCP
-                    - domain: ae::1
-                      ports:
-                        - number: 443
-                          protocol: TCP
-                  ingressPrivate:
-                    allow:
-                      - team: team1
-                      - service: service-x
-                        team: team2
-                    mode: AllowOnly
-                type: cluster
-              - name: service-b
-                networkPolicy:
-                  egressPublic: []
-                  ingressPrivate:
-                    mode: DenyAll
-                type: cluster
-              - name: service-d
-                networkPolicy:
-                  ingressPrivate:
-                    mode: AllowOnly
-                type: cluster
-              - headers:
-                  request:
-                    set:
-                      - name: someheader
-                        value: somevalue
-                  response:
-                    set:
-                      - name: X-Frame-Options
-                        value: same-origin
-                      - name: sander
-                        value: same-origin
-                ingressClassName: net-a
-                name: service-e
-                type: public
-            workloads:
-              - name: wd1
-                path: /
-                url: https://myrepo.local/mychart.git
-              - name: wd2
-                path: /
-                url: https://myrepo.local/mychart.git
-        version: 8
-        versions:
-          api: main
-          console: main
-          core: main
-          tasks: main
-          tools: 1.4.25
+                  appgw:
+                      isManaged: true
+                  monitor:
+                      clientId: somesecretvalue
+                      clientSecret: somesecretvalue
+                      subscriptionId: somesecretvalue
+                      tenantId: somesecretvalue
+                  resourceGroup: somevalue
+                  subscriptionId: somevalue
+                  tenantId: somevalue
+              cloud:
+                  skipStorageClasses:
+                      - std
+                      - std-immediate
+              cluster:
+                  apiName: eks_otomi-cloud_eu-central-1_otomi-eks-demo
+                  apiServer: https://1.1.1.1:8443
+                  domainSuffix: demo.eks.otomi.cloud
+                  k8sContext: otomi-eks-demo
+                  k8sVersion: '1.25'
+                  name: demo
+                  owner: redkubes
+                  provider: custom
+                  region: eu-central-1
+              dns:
+                  domainFilters:
+                      - otomi.cloud
+                  provider:
+                      aws:
+                          credentials:
+                              accessKey: AAAAAAAAAAAAAAAAA
+                              secretKey: DuJ/T6fFYMysjRUxxxxxxxxxxxxxxxxx
+                          region: eu-central-1
+                  zoneIdFilters:
+                      - otomi
+              home:
+                  email:
+                      critical: admins@yourdoma.in
+                  receivers:
+                      - slack
+                  slack:
+                      channel: mon-otomi
+                      channelCrit: mon-otomi-crit
+                      url: https://hooks.slack.com/services/id
+              ingress:
+                  classes:
+                      - className: platform
+                        entrypoint: ''
+                        network: public
+                      - className: private
+                        entrypoint: ''
+                        loadBalancerSubnet: subnet
+                        network: private
+                      - className: net-a
+                        entrypoint: ''
+                        loadBalancerIP: 11.0.0.1
+                        loadBalancerRG: myrg
+                        network: public
+                        sourceIpAddressFiltering: 10.0.0.0/24
+                  platformClass:
+                      className: platform
+                      entrypoint: ''
+                      network: public
+              k8s:
+                  namespaces:
+                      - app: argocd
+                        name: argocd
+                      - disableIstioInjection: true
+                        name: cert-manager
+                      - app: cloudnative-pg
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: cnpg-system
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: default
+                      - name: drone
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: drone-pipelines
+                      - disableIstioInjection: true
+                        name: external-dns
+                      - disableIstioInjection: true
+                        name: external-secrets
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: falco
+                      - app: harbor
+                        name: harbor
+                      - app: gatekeeper
+                        disableIstioInjection: true
+                        name: gatekeeper-system
+                      - name: gitea
+                      - app: grafana
+                        name: grafana
+                      - disableIstioInjection: true
+                        name: istio-system
+                      - istio-injection: disabled
+                        istio-operator-managed: Reconcile
+                        name: istio-operator
+                      - app: httpbin
+                        name: httpbin
+                      - disableIstioInjection: true
+                        name: ingress
+                      - app: jaeger
+                        name: jaeger
+                      - app: jaeger
+                        disableIstioInjection: true
+                        name: jaeger-operator
+                      - name: keycloak
+                      - app: kiali
+                        name: kiali
+                      - app: kiali
+                        disableIstioInjection: true
+                        name: kiali-operator
+                      - app: knative
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: knative-serving
+                      - app: kubeapps
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: kubeapps
+                      - app: kured
+                        disableIstioInjection: true
+                        name: kured
+                      - app: kubeclarity
+                        disableIstioInjection: true
+                        name: kubeclarity
+                      - app: tekton
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: tekton
+                      - disableIstioInjection: true
+                        name: maintenance
+                      - app: minio
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: minio
+                      - disableIstioInjection: true
+                        name: monitoring
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: olm
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: opa-exporter
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: operators
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: opencost
+                      - name: otomi
+                      - app: cluster-overprovisioner
+                        disableIstioInjection: true
+                        name: cluster-overprovisioner
+                      - app: prometheus
+                        disableIstioInjection: true
+                        name: redis
+                      - name: team-admin
+                      - disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: tigera-operator
+                      - app: trivy
+                        disableIstioInjection: true
+                        disablePolicyChecks: true
+                        name: trivy-operator
+                      - app: vault
+                        name: vault
+                      - app: velero
+                        name: velero
+              kms:
+                  sops:
+                      azure:
+                          clientId: somesecretvalue
+                          clientSecret: somesecretvalue
+                          keys: somesecretvalue
+                          tenantId: somesecretvalue
+              letsencryptCA: |
+                  -----BEGIN CERTIFICATE-----
+                  MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
+                  MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+                  aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+                  ZWFyIFgxMB4XDTIwMDkwNDAwMDAwMFoXDTI1MDkxNTE2MDAwMFowWTELMAkGA1UE
+                  BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSgwJgYDVQQD
+                  Ex8oU1RBR0lORykgQXJ0aWZpY2lhbCBBcHJpY290IFIzMIIBIjANBgkqhkiG9w0B
+                  AQEFAAOCAQ8AMIIBCgKCAQEAu6TR8+74b46mOE1FUwBrvxzEYLck3iasmKrcQkb+
+                  gy/z9Jy7QNIAl0B9pVKp4YU76JwxF5DOZZhi7vK7SbCkK6FbHlyU5BiDYIxbbfvO
+                  L/jVGqdsSjNaJQTg3C3XrJja/HA4WCFEMVoT2wDZm8ABC1N+IQe7Q6FEqc8NwmTS
+                  nmmRQm4TQvr06DP+zgFK/MNubxWWDSbSKKTH5im5j2fZfg+j/tM1bGaczFWw8/lS
+                  nukyn5J2L+NJYnclzkXoh9nMFnyPmVbfyDPOc4Y25aTzVoeBKXa/cZ5MM+WddjdL
+                  biWvm19f1sYn1aRaAIrkppv7kkn83vcth8XCG39qC2ZvaQIDAQABo4IBEDCCAQww
+                  DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAS
+                  BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTecnpI3zHDplDfn4Uj31c3S10u
+                  ZTAfBgNVHSMEGDAWgBS182Xy/rAKkh/7PH3zRKCsYyXDFDA2BggrBgEFBQcBAQQq
+                  MCgwJgYIKwYBBQUHMAKGGmh0dHA6Ly9zdGcteDEuaS5sZW5jci5vcmcvMCsGA1Ud
+                  HwQkMCIwIKAeoByGGmh0dHA6Ly9zdGcteDEuYy5sZW5jci5vcmcvMCIGA1UdIAQb
+                  MBkwCAYGZ4EMAQIBMA0GCysGAQQBgt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCN
+                  DLam9yN0EFxxn/3p+ruWO6n/9goCAM5PT6cC6fkjMs4uas6UGXJjr5j7PoTQf3C1
+                  vuxiIGRJC6qxV7yc6U0X+w0Mj85sHI5DnQVWN5+D1er7mp13JJA0xbAbHa3Rlczn
+                  y2Q82XKui8WHuWra0gb2KLpfboYj1Ghgkhr3gau83pC/WQ8HfkwcvSwhIYqTqxoZ
+                  Uq8HIf3M82qS9aKOZE0CEmSyR1zZqQxJUT7emOUapkUN9poJ9zGc+FgRZvdro0XB
+                  yphWXDaqMYph0DxW/10ig5j4xmmNDjCRmqIKsKoWA52wBTKKXK1na2ty/lW5dhtA
+                  xkz5rVZFd4sgS4J0O+zm6d5GRkWsNJ4knotGXl8vtS3X40KXeb3A5+/3p0qaD215
+                  Xq8oSNORfB2oI1kQuyEAJ5xvPTdfwRlyRG3lFYodrRg6poUBD/8fNTXMtzydpRgy
+                  zUQZh/18F6B/iW6cbiRN9r2Hkh05Om+q0/6w0DdZe+8YrNpfhSObr/1eVZbKGMIY
+                  qKmyZbBNu5ysENIK5MPc14mUeKmFjpN840VR5zunoU52lqpLDua/qIM8idk86xGW
+                  xx2ml43DO/Ya/tVZVok0mO0TUjzJIfPqyvr455IsIut4RlCR9Iq0EDTve2/ZwCuG
+                  hSjpTUFGSiQrR2JK2Evp+o6AETUkBCO1aw0PpQBPDQ==
+                  -----END CERTIFICATE-----
+              letsencryptRootCA: |
+                  -----BEGIN CERTIFICATE-----
+                  MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+                  MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+                  aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+                  ZWFyIFgxMB4XDTE1MDYwNDExMDQzOFoXDTM1MDYwNDExMDQzOFowZjELMAkGA1UE
+                  BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+                  YXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQgUGVhciBYMTCC
+                  AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALbagEdDTa1QgGBWSYkyMhsc
+                  ZXENOBaVRTMX1hceJENgsL0Ma49D3MilI4KS38mtkmdF6cPWnL++fgehT0FbRHZg
+                  jOEr8UAN4jH6omjrbTD++VZneTsMVaGamQmDdFl5g1gYaigkkmx8OiCO68a4QXg4
+                  wSyn6iDipKP8utsE+x1E28SA75HOYqpdrk4HGxuULvlr03wZGTIf/oRt2/c+dYmD
+                  oaJhge+GOrLAEQByO7+8+vzOwpNAPEx6LW+crEEZ7eBXih6VP19sTGy3yfqK5tPt
+                  TdXXCOQMKAp+gCj/VByhmIr+0iNDC540gtvV303WpcbwnkkLYC0Ft2cYUyHtkstO
+                  fRcRO+K2cZozoSwVPyB8/J9RpcRK3jgnX9lujfwA/pAbP0J2UPQFxmWFRQnFjaq6
+                  rkqbNEBgLy+kFL1NEsRbvFbKrRi5bYy2lNms2NJPZvdNQbT/2dBZKmJqxHkxCuOQ
+                  FjhJQNeO+Njm1Z1iATS/3rts2yZlqXKsxQUzN6vNbD8KnXRMEeOXUYvbV4lqfCf8
+                  mS14WEbSiMy87GB5S9ucSV1XUrlTG5UGcMSZOBcEUpisRPEmQWUOTWIoDQ5FOia/
+                  GI+Ki523r2ruEmbmG37EBSBXdxIdndqrjy+QVAmCebyDx9eVEGOIpn26bW5LKeru
+                  mJxa/CFBaKi4bRvmdJRLAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
+                  Af8EBTADAQH/MB0GA1UdDgQWBBS182Xy/rAKkh/7PH3zRKCsYyXDFDANBgkqhkiG
+                  9w0BAQsFAAOCAgEAncDZNytDbrrVe68UT6py1lfF2h6Tm2p8ro42i87WWyP2LK8Y
+                  nLHC0hvNfWeWmjZQYBQfGC5c7aQRezak+tHLdmrNKHkn5kn+9E9LCjCaEsyIIn2j
+                  qdHlAkepu/C3KnNtVx5tW07e5bvIjJScwkCDbP3akWQixPpRFAsnP+ULx7k0aO1x
+                  qAeaAhQ2rgo1F58hcflgqKTXnpPM02intVfiVVkX5GXpJjK5EoQtLceyGOrkxlM/
+                  sTPq4UrnypmsqSagWV3HcUlYtDinc+nukFk6eR4XkzXBbwKajl0YjztfrCIHOn5Q
+                  CJL6TERVDbM/aAPly8kJ1sWGLuvvWYzMYgLzDul//rUF10gEMWaXVZV51KpS9DY/
+                  5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+                  xUuXY4xRdh45tMJnLTUDdC9FIU0flTeO9/vNpVA8OPU1i14vCz+MU8KX1bV3GXm/
+                  fxlB7VBBjX9v5oUep0o/j68R/iDlCOM4VVfRa8gX6T2FU7fNdatvGro7uQzIvWof
+                  gN9WUwCbEMBy/YhBSrXycKA8crgGg3x1mIsopn88JKwmMBa68oS7EHM9w7C4y71M
+                  7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+                  -----END CERTIFICATE-----
+              license: license-in-jwt-format
+              oidc:
+                  adminGroupID: someAdminGroupID
+                  clientID: someClientID
+                  clientSecret: somesecretvalue
+                  issuer: https://login.microsoftonline.com/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                  subClaimMapper: oid
+                  teamAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+              otomi:
+                  additionalClusters:
+                      - domainSuffix: demo.eks.otomi.cloud
+                        name: demo
+                        provider: aws
+                  adminPassword: bladibla
+                  globalPullSecret:
+                      password: blablabla
+                      username: otomi
+                  hasCloudLB: false
+                  hasExternalDNS: true
+                  hasExternalIDP: true
+                  isHomeMonitored: true
+                  isMultitenant: true
+                  nodeSelector:
+                      otomi: otomi-sys
+                  version: main
+              platformBackups:
+                  argo:
+                      enabled: false
+                  drone:
+                      enabled: false
+                  gitea:
+                      enabled: false
+                  harbor:
+                      enabled: false
+                  keycloak:
+                      enabled: false
+                  kubeapps:
+                      enabled: false
+                  minio:
+                      enabled: false
+                  vault:
+                      enabled: false
+              policies:
+                  banned-image-tags:
+                      enabled: false
+                      tags:
+                          - latest
+                  container-limits:
+                      cpu: '2'
+                      enabled: true
+                      memory: 2Gi
+                  psp-allowed-repos:
+                      enabled: false
+                      repos:
+                          - harbor.demo.gke.otomi.cloud
+                          - harbor.demo.aks.otomi.cloud
+                          - harbor.demo.eks.otomi.cloud
+                  psp-allowed-users:
+                      enabled: true
+                      fsGroup:
+                          ranges:
+                              - max: 65535
+                                min: 1
+                          rule: MayRunAs
+                      runAsGroup:
+                          ranges:
+                              - max: 65535
+                                min: 1
+                          rule: MayRunAs
+                      runAsUser:
+                          rule: MustRunAsNonRoot
+                      supplementalGroups:
+                          ranges:
+                              - max: 65535
+                                min: 1
+                          rule: MayRunAs
+                  psp-apparmor:
+                      allowedProfiles:
+                          - runtime/default
+                      enabled: true
+                  psp-capabilities:
+                      allowedCapabilities:
+                          - NET_BIND_SERVICE
+                          - NET_RAW
+                      enabled: false
+                      requiredDropCapabilities:
+                          - ALL
+                  psp-forbidden-sysctls:
+                      enabled: true
+                      forbiddenSysctls:
+                          - kernel.*
+                          - net.*
+                          - abi.*
+                          - fs.*
+                          - sunrpc.*
+                          - user.*
+                          - vm.*
+                  psp-host-filesystem:
+                      allowedHostPaths:
+                          - pathPrefix: /tmp/
+                            readOnly: false
+                      enabled: true
+                  psp-host-networking-ports:
+                      enabled: true
+                  psp-host-security:
+                      enabled: true
+                  psp-privileged:
+                      enabled: true
+                  psp-seccomp:
+                      allowedProfiles:
+                          - runtime/default
+                      enabled: false
+                  psp-selinux:
+                      enabled: false
+                      seLinuxContext: RunAsAny
+              smtp:
+                  auth_password: somesecretvalue
+                  auth_username: no-reply@doma.in
+                  from: no-reply@doma.in
+                  hello: doma.in
+                  smarthost: smtp-relay.gmail.com:587
+              status:
+                  helm:
+                      drone/drone:
+                          app_version: 1.6.1
+                          chart: drone-3.0.0
+                          name: drone
+                          namespace: drone
+                          revision: '1'
+                          status: deployed
+                          updated: 2023-05-31 09:54:32.168150254 +0000 UTC
+                      harbor/harbor:
+                          app_version: 1.6.1
+                          chart: drone-3.0.0
+                          name: drone
+                          namespace: drone
+                          revision: '1'
+                          status: deployed
+                          updated: 2023-05-31 09:54:32.168150254 +0000 UTC
+                  otomi:
+                      deployingTag: main
+                      deployingVersion: 0.21.0
+                      status: deployed
+                      version: 0.21.0
+              teamApps:
+                  - ingress:
+                        - auth: true
+                          hasPrefix: true
+                          port: 9093
+                          svc: po-alertmanager
+                          type: public
+                    name: alertmanager
+                  - ingress:
+                        - auth: true
+                          forwardPath: true
+                          hasPrefix: true
+                          removeRequestHeaders:
+                              - authorization
+                          svc: po-grafana
+                          type: public
+                    name: grafana
+                    ownHost: true
+                  - name: loki
+                    path: /explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22#NS#%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
+                    useHost: grafana
+                  - ingress:
+                        - auth: true
+                          hasPrefix: true
+                          port: 9090
+                          svc: po-prometheus
+                          type: public
+                    name: prometheus
+              teamConfig:
+                  admin:
+                      id: admin
+                      jobs: []
+                      secrets:
+                          - entries:
+                                - TARGET
+                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c387
+                            name: mysecret-generic-admin
+                            namespace: some-ns
+                            teamId: demo
+                            type: generic
+                          - clusterWide: true
+                            entries:
+                                - TARGET
+                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c388
+                            name: mysecret-generic-admin-clusterwide
+                            teamId: demo
+                            type: generic
+                          - entries:
+                                - TARGET
+                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c389
+                            name: mysecret-generic-admin-teamwide
+                            teamId: demo
+                            teamWide: true
+                            type: generic
+                      services:
+                          - auth: true
+                            domain: hello.team-admin.demo.eks.otomi.cloud
+                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd0
+                            name: hello-admin
+                            networkPolicy:
+                                ingressPrivate:
+                                    mode: AllowAll
+                            ownHost: true
+                            port: 80
+                            type: public
+                      workloads:
+                          - name: wa1
+                            path: /
+                            revision: HEAD
+                            url: https://myrepo.local/mychart.git
+                          - chart: mychart
+                            name: wa2
+                            revision: 1.2.3
+                            url: https://myregistry.local/mychart
+                          - chart: crossplane
+                            name: crossplane-custom-namespace
+                            namespace: crossplane
+                            revision: 1.11.2
+                            url: https://charts.crossplane.io/stable
+                          - chart: crossplane
+                            name: crossplane-team-namespace
+                            revision: 1.11.2
+                            url: https://charts.crossplane.io/stable
+                  demo:
+                      alerts:
+                          email:
+                              critical: admins@yourdoma.in
+                              nonCritical: admins@yourdoma.in
+                          receivers:
+                              - email
+                      backups:
+                          - name: bu1
+                            schedule: 0 0 0 * *
+                            snapshotVolumes: true
+                            ttl: 8h
+                          - labelSelector:
+                                - name: app
+                                  value: hello
+                                - name: backup
+                                  value: all
+                            name: bu2
+                            schedule: 0 0 0 * *
+                            snapshotVolumes: true
+                            ttl: 8h
+                      billingAlertQuotas:
+                          teamCpuMonthQuotaReached:
+                              quota: 150
+                          teamMemMonthQuotaReached:
+                              quota: 200
+                      builds:
+                          - mode:
+                                docker:
+                                    path: ./Docker
+                                    repoUrl: https://github.com/buildpacks/samples
+                                    revision: HEAD
+                                type: docker
+                            name: demo-java1
+                            tag: v.0.0.1
+                          - mode:
+                                buildpacks:
+                                    path: apps/java-maven
+                                    repoUrl: https://github.com/buildpacks/samples
+                                    revision: HEAD
+                                type: buildpacks
+                            name: demo-java2
+                            tag: v.0.0.1
+                          - mode:
+                                docker:
+                                    path: ./Docker
+                                    repoUrl: https://github.com/buildpacks/samples
+                                    revision: HEAD
+                                type: docker
+                            name: demo-java3
+                            tag: v.0.0.1
+                      id: demo
+                      jobs:
+                          - enabled: true
+                            env:
+                                receiver: world
+                            files:
+                                /config/some-file: someData
+                                /config/some-file3: |-
+                                    some data on another line
+                                    another line
+                                /config/some/file2: someData2
+                            image:
+                                pullPolicy: IfNotPresent
+                                repository: busybox
+                                tag: latest
+                            init:
+                                - command:
+                                      - echo
+                                      - hello foo $foo
+                                  env:
+                                      foo: bar
+                                  image:
+                                      pullPolicy: IfNotPresent
+                                      repository: busybox
+                                      tag: latest
+                                  resources:
+                                      limits:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                      requests:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                  secrets:
+                                      - mysecret-generic
+                                      - hello-otomi
+                            name: contains-everything
+                            podSecurityContext:
+                                fsGroup: 1002
+                                runAsGroup: 1002
+                                runAsNonRoot: true
+                                runAsUser: 1002
+                            resources:
+                                limits:
+                                    cpu: 50m
+                                    memory: 64Mi
+                                requests:
+                                    cpu: 50m
+                                    memory: 64Mi
+                            runPolicy: Always
+                            script: echo "hello $receiver"
+                            secretMounts:
+                                /config/some-folder: someSecret
+                            secrets:
+                                - mysecret-generic
+                                - hello-otomi
+                            securityContext:
+                                runAsGroup: 1002
+                                runAsNonRoot: true
+                                runAsUser: 1002
+                            type: Job
+                          - enabled: true
+                            env:
+                                receiver: world
+                            files:
+                                /some-file: someData
+                                /some-file2: someData2
+                                /some-file3: |-
+                                    some data on another line
+                                    another line
+                            image:
+                                pullPolicy: IfNotPresent
+                                repository: busybox
+                                tag: latest
+                            init:
+                                - env:
+                                      foo: bar
+                                  image:
+                                      pullPolicy: IfNotPresent
+                                      repository: busybox
+                                      tag: latest
+                                  resources:
+                                      limits:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                      requests:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                  script: |
+                                      echo "hello $receiver"
+                            name: also-contains-everything-and-cron
+                            resources:
+                                limits:
+                                    cpu: 50m
+                                    memory: 64Mi
+                                requests:
+                                    cpu: 50m
+                                    memory: 64Mi
+                            runPolicy: Always
+                            schedule: 0 1 * * *
+                            script: echo "hello $receiver"
+                            secrets:
+                                - generic-example
+                                - hello-otomi
+                            type: CronJob
+                          - enabled: true
+                            image:
+                                pullPolicy: IfNotPresent
+                                repository: busybox
+                                tag: latest
+                            name: base
+                            resources:
+                                limits:
+                                    cpu: 50m
+                                    memory: 64Mi
+                                requests:
+                                    cpu: 50m
+                                    memory: 64Mi
+                            script: echo "hello $receiver"
+                            type: Job
+                          - enabled: true
+                            image:
+                                pullPolicy: IfNotPresent
+                                repository: busybox
+                                tag: latest
+                            name: base-cronjob
+                            resources:
+                                limits:
+                                    cpu: 50m
+                                    memory: 64Mi
+                                requests:
+                                    cpu: 50m
+                                    memory: 64Mi
+                            schedule: 0 1 * * *
+                            script: echo "hello world"
+                            type: CronJob
+                          - enabled: true
+                            image:
+                                pullPolicy: IfNotPresent
+                                repository: busybox
+                                tag: latest
+                            init:
+                                - env:
+                                      foo: bar
+                                  image:
+                                      pullPolicy: IfNotPresent
+                                      repository: busybox
+                                      tag: latest
+                                  resources:
+                                      limits:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                      requests:
+                                          cpu: 50m
+                                          memory: 64Mi
+                                  script: echo "hello world"
+                            name: init-cronjob
+                            resources:
+                                limits:
+                                    cpu: 50m
+                                    memory: 64Mi
+                                requests:
+                                    cpu: 50m
+                                    memory: 64Mi
+                            schedule: 0 1 * * *
+                            script: echo "hello $receiver"
+                            type: CronJob
+                      networkPolicy:
+                          egressPublic: true
+                          ingressPrivate: true
+                      oidc:
+                          groupMapping: somesecretvalue
+                      password: somesecretvalue
+                      resourceQuota:
+                          services.loadbalancers: '1'
+                      secrets:
+                          - entries:
+                                - TARGET
+                            id: 15bb8ecf-1fef-474c-9143-a1f19c81c378
+                            name: mysecret-generic
+                            teamId: demo
+                            type: generic
+                          - id: d29ab8f8-1281-4eba-81b0-be01baed03a6
+                            name: mysecret-registry
+                            teamId: demo
+                            type: docker-registry
+                          - ca: ca.crt
+                            crt: tls.crt
+                            id: efe80c21-cfb2-4436-a9dd-e6838ea9c4f9
+                            key: tls.key
+                            name: mysecret-tls
+                            teamId: demo
+                            type: tls
+                      selfService:
+                          apps: []
+                          service:
+                              - ingress
+                              - networkPolicy
+                          team:
+                              - alerts
+                      services:
+                          - auth: true
+                            domain: hello.team-demo.demo.eks.otomi.cloud
+                            headers:
+                                response:
+                                    set:
+                                        - name: X-Frame-Options
+                                          value: same-origin
+                                        - name: sander
+                                          value: same-origin
+                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd3
+                            ksvc:
+                                predeployed: true
+                            name: hello
+                            networkPolicy:
+                                ingressPrivate:
+                                    mode: AllowAll
+                            ownHost: true
+                            port: 80
+                            type: public
+                          - domain: tlspass.eks.dev.otomi.cloud
+                            id: cb5149c4-8ea5-4c5a-be04-a37258658bd4
+                            ksvc:
+                                predeployed: true
+                            name: hello-auth
+                            ownHost: true
+                            paths: []
+                            port: 80
+                            type: public
+                          - id: cb5149c4-8ea5-4c5a-be04-a37258658bd5
+                            ksvc:
+                                predeployed: true
+                            name: tlspass
+                            port: 443
+                            tlsPass: true
+                            type: public
+                          - id: cb5149c4-8ea5-4c5a-be04-a37258658bd6
+                            name: some-svc
+                            networkPolicy:
+                                ingressPrivate:
+                                    mode: AllowAll
+                            port: 80
+                            type: cluster
+                          - hasCert: true
+                            name: has-cert-svc
+                            paths:
+                                - /jeho
+                            type: public
+                          - name: service-a
+                            networkPolicy:
+                                egressPublic:
+                                    - domain: domain1.com
+                                      ports:
+                                          - number: 8443
+                                            protocol: TCP
+                                    - domain: domain2.com
+                                      ports:
+                                          - number: 443
+                                            protocol: HTTPS
+                                    - domain: 185.199.110.153
+                                      ports:
+                                          - number: 443
+                                            protocol: TCP
+                                    - domain: ae::1
+                                      ports:
+                                          - number: 443
+                                            protocol: TCP
+                                ingressPrivate:
+                                    allow:
+                                        - team: team1
+                                        - service: service-x
+                                          team: team2
+                                    mode: AllowOnly
+                            type: cluster
+                          - name: service-b
+                            networkPolicy:
+                                egressPublic: []
+                                ingressPrivate:
+                                    mode: DenyAll
+                            type: cluster
+                          - name: service-d
+                            networkPolicy:
+                                ingressPrivate:
+                                    mode: AllowOnly
+                            type: cluster
+                          - headers:
+                                request:
+                                    set:
+                                        - name: someheader
+                                          value: somevalue
+                                response:
+                                    set:
+                                        - name: X-Frame-Options
+                                          value: same-origin
+                                        - name: sander
+                                          value: same-origin
+                            ingressClassName: net-a
+                            name: service-e
+                            type: public
+                      workloads:
+                          - name: wd1
+                            path: /
+                            url: https://myrepo.local/mychart.git
+                          - name: wd2
+                            path: /
+                            url: https://myrepo.local/mychart.git
+              version: 8
+              versions:
+                  api: main
+                  console: main
+                  core: main
+                  tasks: main
+                  tools: 1.4.25

--- a/tests/integration/minimal-with-team.yaml
+++ b/tests/integration/minimal-with-team.yaml
@@ -25,9 +25,6 @@ teamConfig:
     builds:
       - name: nodejs-hello-world
         tag: v0.0.1
-        repoAccess:
-          otomiGit: false
-          privateGit: false
         mode:
           docker:
             repoUrl: https://github.com/redkubes/nodejs-helloworld
@@ -36,9 +33,6 @@ teamConfig:
           type: docker
       - name: demo-java-maven
         tag: v0.0.1
-        repoAccess:
-          otomiGit: false
-          privateGit: false
         mode:
           buildpacks:
             repoUrl: https://github.com/buildpacks/samples

--- a/tests/integration/upgrade.yaml
+++ b/tests/integration/upgrade.yaml
@@ -69,9 +69,6 @@ teamConfig:
     builds:
       - name: nodejs-hello-world
         tag: v0.0.1
-        repoAccess:
-          otomiGit: false
-          privateGit: false
         mode:
           docker:
             repoUrl: https://github.com/redkubes/nodejs-helloworld
@@ -80,9 +77,6 @@ teamConfig:
           type: docker
       - name: demo-java-maven
         tag: v0.0.1
-        repoAccess:
-          otomiGit: false
-          privateGit: false
         mode:
           buildpacks:
             repoUrl: https://github.com/buildpacks/samples

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1322,21 +1322,6 @@ definitions:
       tag:
         description: Image tag
         $ref: '#/definitions/imageTag'
-      repoAccess:
-        properties:
-          privateGit:
-            type: boolean
-            default: false
-          otomiGit:
-            type: boolean
-            default: false
-          repoUserName:
-            description: The username used for basic authentication to access a private github repo.
-            $ref: '#/definitions/wordCharacterPattern'
-          repoPassword:
-            x-secret: ''
-            $ref: '#/definitions/wordCharacterPattern'
-            description: The password used for basic authentication to access a private github repo.
       mode:
         properties:
           docker:


### PR DESCRIPTION
Remove repo access for Builds. Access for local Gitea will be enabled by default. This PR has a dependency with https://github.com/redkubes/otomi-api/pull/443
