### PR TITLE
feat: uninstall admission controllers

### DIFF
--- a/src/cmd/destroy.ts
+++ b/src/cmd/destroy.ts
@@ -52,7 +52,44 @@ const destroyAll = async () => {
   await stream(nothrow($`kubectl delete mutatingwebhookconfiguration istio-sidecar-injector`), debugStream)
 
   d.info('Uninstalling webhook validatingwebhookconfiguration ...')
-  await stream(nothrow($`kubectl delete validatingwebhookconfiguration istio-validator-istio-system`), debugStream)
+
+  const validationAdmissionControllers = [
+    'cert-manager-webhook',
+    'cnpg-validating-webhook-configuration',
+    'config.webhook.istio.networking.internal.knative.dev',
+    'config.webhook.pipeline.tekton.dev',
+    'config.webhook.serving.knative.dev',
+    'istio-validator-istio-system',
+    'validation-webhook.snapshot.storage.k8s.io',
+    'validation.webhook.domainmapping.serving.knative.dev',
+    'validation.webhook.pipeline.tekton.dev',
+    'validation.webhook.serving.knative.dev',
+  ]
+
+  await Promise.allSettled(
+    validationAdmissionControllers.map(async (val) =>
+      stream(
+        nothrow($`kubectl delete validatingwebhookconfiguration.admissionregistration.k8s.io ${val}`),
+        debugStream,
+      ),
+    ),
+  )
+
+  const mutatingAdminionControllers = [
+    'cert-manager-webhook',
+    'cnpg-mutating-webhook-configuration',
+    'istio-sidecar-injector',
+    'webhook.domainmapping.serving.knative.dev',
+    'webhook.istio.networking.internal.knative.dev',
+    'webhook.pipeline.tekton.dev',
+    'webhook.serving.knative.dev',
+  ]
+
+  await Promise.allSettled(
+    mutatingAdminionControllers.map(async (val) =>
+      stream(nothrow($`kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io ${val}`), debugStream),
+    ),
+  )
 
   const templateOutput: string = output.stdout
   writeFileSync(templateFile, templateOutput)

--- a/src/cmd/destroy.ts
+++ b/src/cmd/destroy.ts
@@ -3,7 +3,7 @@ import { cleanupHandler, prepareEnvironment } from 'src/common/cli'
 import { logLevelString, terminal } from 'src/common/debug'
 import { hf } from 'src/common/hf'
 import { getFilename } from 'src/common/utils'
-import { BasicArguments, getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from 'src/common/yargs'
+import { BasicArguments, HelmArguments, getParsedArgs, helmOptions, setParsedArgs } from 'src/common/yargs'
 import { ProcessOutputTrimmed, stream } from 'src/common/zx-enhance'
 import { Argv } from 'yargs'
 import { $, nothrow } from 'zx'
@@ -47,6 +47,13 @@ const destroyAll = async () => {
   if (output.exitCode > 0 || output.stderr.length > 0) {
     d.error(output.stderr)
   }
+
+  d.info('Uninstalling webhook mutatingwebhookconfiguration ...')
+  await stream(nothrow($`kubectl delete mutatingwebhookconfiguration istio-sidecar-injector`), debugStream)
+
+  d.info('Uninstalling webhook validatingwebhookconfiguration ...')
+  await stream(nothrow($`kubectl delete validatingwebhookconfiguration istio-validator-istio-system`), debugStream)
+
   const templateOutput: string = output.stdout
   writeFileSync(templateFile, templateOutput)
   await stream(nothrow($`kubectl delete -f ${templateFile}`), debugStream)
@@ -86,6 +93,7 @@ const destroyAll = async () => {
     nothrow($`kubectl delete apiservices.apiregistration.k8s.io v1.packages.operators.coreos.com`),
     debugStream,
   )
+
   d.log('Uninstalled otomi!')
 }
 


### PR DESCRIPTION
This PR aims to improve otomi destroy functionality by removing admission controllers that were installed by various operators.


It is important to do it because they may bock any further deployments to the cluster.