### PR TITLE
feat: prometheus with its own host

### DIFF
--- a/charts/team-ns/templates/_helpers.tpl
+++ b/charts/team-ns/templates/_helpers.tpl
@@ -41,20 +41,11 @@ otomi.io/team: {{ .Values.teamId }}
 
 {{- define "service.domain" -}}
 {{- $v := .dot.Values }}
-{{- $isApps := and .s.isCore (not (or .s.ownHost .s.isShared)) }}
-{{- if and $isApps (not .vs) -}}
-  {{- if eq $v.teamId "admin" -}}
-    {{- printf "apps.%s" $v.domain -}}
-  {{- else -}}
-    {{- printf "apps-%s.%s" $v.teamId $v.domain -}}
-  {{- end -}}
-{{- else -}}
 {{- $svc := (hasKey .s "hasPrefix" | ternary (printf "%s-%s" $v.teamId (.s.svc | default .s.name)) (.s.svc | default .s.name)) -}}
 {{- $shared := (and .s.isCore (eq $v.teamId "admin") (hasKey .s "isShared")) | default false -}}
 {{- $host := ($shared | ternary .s.name (printf "%s-%s" .s.name $v.teamId )) -}}
 {{- $domain := (index .s "domain" | default (printf "%s.%s" $host $v.domain)) -}}
 {{- print $domain -}}
-{{- end -}}
 {{- end -}}
 
 {{/* aggregate all the files and create a dict by dirname > list (filename content) */}}

--- a/charts/team-ns/templates/_ingress.tpl
+++ b/charts/team-ns/templates/_ingress.tpl
@@ -30,7 +30,6 @@ extensions/v1
 {{- define "ingress" -}}
 {{- $ := . }}
 {{- $v := .dot.Values }}
-{{- $appsDomain := printf "apps-%s.%s" $v.teamId $v.domain }}
 {{- $istioSvc := print "istio-ingressgateway-" .type }}
 {{- $cm := index $v.apps "cert-manager" }}
 {{- range $ingress := $v.ingress.classes }}

--- a/charts/team-ns/templates/_ingress.tpl
+++ b/charts/team-ns/templates/_ingress.tpl
@@ -104,14 +104,6 @@ metadata:
           {{- end }}
         {{- end }}
       {{- end }}
-      {{- if $.isApps }}
-    nginx.ingress.kubernetes.io/upstream-vhost: $1.{{ $v.domain }}
-        {{- if $.hasForward }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$1/$3
-        {{- else }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$3
-        {{- end }}
-      {{- end }}
         {{- with $ingress.sourceIpAddressFiltering }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ . }}"
         {{- end}}
@@ -135,14 +127,6 @@ metadata:
           proxy_set_header Connection "upgrade";
           proxy_cache_bypass $http_upgrade;
         }
-
-      {{- if $.isApps }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/$ https://otomi.{{ $v.cluster.domainSuffix }}/ permanent;
-        {{- if $.hasForward }}
-      rewrite ^/({{ $namesCollection }})([^/]*)$ $1/$2 permanent;
-        {{- end }}
-      {{- end }}
   labels: {{- include "team-ns.chart-labels" $.dot | nindent 4 }}
   name: {{ $.provider }}-team-{{ $v.teamId }}-{{ $ingress.className }}-{{ $.type }}-{{ $.name }}
   namespace: {{ if ne $.provider "nginx" }}ingress{{ else }}istio-system{{ end }}
@@ -158,12 +142,6 @@ spec:
         paths:
               {{- include "ingress.path" (dict "dot" $.dot "svc" $istioSvc "port" 443) | nindent 8 }}
           {{- end }}
-        {{- else if $.isApps }}
-    - host: {{ $appsDomain }}
-      http:
-        paths:
-        {{- include "ingress.path" (dict "dot" $.dot "svc" $istioSvc) | nindent 8 }}
-        {{- include "ingress.path" (dict "dot" $.dot "svc" $istioSvc "path" (printf "/(%s)(/|$)(.*)" (include "helm-toolkit.utils.joinListWithSep" (dict "list" $names "sep" "|")))) | nindent 8 }}
       {{- else }}
         {{- range $domain, $paths := $routes }}
     - host: {{ $domain }}

--- a/charts/team-ns/templates/ingress.yaml
+++ b/charts/team-ns/templates/ingress.yaml
@@ -7,8 +7,6 @@
 # - auth/open?
 # - tlsPass?
 {{- range $type := list "public" "private" }}{{/* type "cluster" does not need ingress*/}}
-  {{- $apps := list }}
-  {{- $appsForward := list }}
   {{- $auth := list }}
   {{- $authForward := list }}
   {{- $open := list }}
@@ -18,16 +16,9 @@
     {{- if not $s.hasOwnIngress }}
     {{- $ingType := $s.type | default "public" }}
     {{- if and (eq $ingType $type) }}
-      {{- $isApps := and $s.isCore (not (or $s.ownHost $s.isShared)) }}
       {{- $hasAuth := $s.auth | default false }}
       {{- $isTlsPass := $s.tlsPass | default false }}
-      {{- if $isApps }}
-        {{- if $s.forwardPath }}
-          {{- $appsForward = append $appsForward $s }}
-        {{- else }}
-          {{- $apps = append $apps $s }}
-        {{- end }}
-      {{- else if $isTlsPass }}
+      {{- if $isTlsPass }}
         {{- $tlsPass = append $tlsPass $s }}
       {{- else if $hasAuth }}
         {{- if $s.forwardPath }}
@@ -49,14 +40,6 @@
 
   {{- if gt (len $tlsPass) 0 }}
 {{ include "ingress" (dict "type" $type "dot" $ "provider" "nginx" "name" "tlspass" "hasForward" false "hasAuth" false "services" $tlsPass "tlsPass" true) }}
-  {{- end }}
-
-  {{- if gt (len $apps) 0 }}
-{{ include "ingress" (dict "type" $type "dot" $ "provider" "nginx" "name" "apps" "hasAuth" true "services" $apps "isApps" true) }}
-  {{- end }}
-
-  {{- if gt (len $appsForward) 0 }}
-{{ include "ingress" (dict "type" $type "dot" $ "provider" "nginx" "name" "apps-forward" "hasForward" true "hasAuth" true "services" $appsForward "isApps" true) }}
   {{- end }}
 
   {{- if gt (len $auth) 0 }}

--- a/core.yaml
+++ b/core.yaml
@@ -404,6 +404,7 @@ adminApps:
 
 teamApps:
   - name: alertmanager
+    ownHost: true
     ingress:
       - svc: po-alertmanager
         hasPrefix: true

--- a/core.yaml
+++ b/core.yaml
@@ -115,6 +115,7 @@ adminApps:
   - name: alertmanager
     tags: [alerting, observability]
     deps: [prometheus]
+    ownHost: true
     ingress:
       - svc: po-alertmanager
         namespace: monitoring
@@ -358,6 +359,7 @@ adminApps:
         auth: true
   - name: prometheus
     tags: [metrics, observability]
+    ownHost: true
     ingress:
       - svc: po-prometheus
         port: 9090
@@ -423,6 +425,7 @@ teamApps:
     useHost: grafana
     path: /explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22#NS#%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
   - name: prometheus
+    ownHost: true
     ingress:
       - svc: po-prometheus
         hasPrefix: true

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -27,7 +27,8 @@ releases:
 {{- range $teamId, $team := omit $tc "admin" }} 
   {{- $teamServices := ($team | get "services" list) }}
   {{- $domain := ($v.cluster | get "domainSuffix" nil) }}
-  {{- $appsDomain := printf "apps.%s" $domain }}
+  {{- $alertmanagerDomain := printf "alertmanager.%s" $domain }}
+  {{- $prometheusDomain := printf "prometheus-%s.%s" $teamId $domain }}
   {{- $grafanaDomain := printf "grafana-%s.%s" $teamId $domain }}
   {{- $azure := $team | get "azure" dict }}
   {{- if and $a.prometheus.enabled $v.otomi.isMultitenant }}
@@ -47,7 +48,7 @@ releases:
         alertmanager:
           namespaceOverride: team-{{ $teamId }}
           alertmanagerSpec:
-            externalUrl: https://{{ $appsDomain }}/alertmanager
+            externalUrl: "https://{{ $alertmanagerDomain }}"
           # to do: load slackTpl and opsgenieTpl only if alerts.receicers = true
           config: {{- tpl (readFile "../helmfile.d/snippets/alertmanager.gotmpl") (dict "instance" $team "root" $v "slackTpl" $slackTpl "opsgenieTpl" $opsgenieTpl) | nindent 12 }}
         defaultRules:
@@ -63,7 +64,7 @@ releases:
           enabled: {{ $team | get "monitoringStack.enabled" true }}
           namespaceOverride: null # team-{{ $teamId }}
           prometheusSpec:
-            externalUrl: https://{{ $appsDomain }}/prometheus
+            externalUrl: "https://{{ $prometheusDomain }}"
     {{- range $selType := list "podMonitor" "probe" "rule" "serviceMonitor" }}
             {{ $selType }}NamespaceSelector:
               matchLabels:

--- a/helmfile.d/snippets/domains.gotmpl
+++ b/helmfile.d/snippets/domains.gotmpl
@@ -23,8 +23,7 @@
   {{- $services := (eq $teamId "admin" | ternary (concat $coreAdminServices ($team | get "services" list)) (concat $coreTeamServices ($team | get "services" list))) }}
   {{- range $s := $services }}
     {{- $host := eq $teamId "admin" | ternary $s.name (printf "%s-%s" $s.name $teamId ) -}}
-    {{- $domain = printf "%s.%s" $host $baseDomain }}
-    {{- $domain := printf "apps.%s" $baseDomain }}
+    {{- $domain := printf "%s.%s" $host $baseDomain }}
     {{- if not (hasKey $domains $domain) }}
       {{- $_ := set $domains $domain (dict "hasCert" (hasKey $s "hasCert")) }}
     {{- end }}

--- a/helmfile.d/snippets/domains.gotmpl
+++ b/helmfile.d/snippets/domains.gotmpl
@@ -23,14 +23,8 @@
   {{- $services := (eq $teamId "admin" | ternary (concat $coreAdminServices ($team | get "services" list)) (concat $coreTeamServices ($team | get "services" list))) }}
   {{- range $s := $services }}
     {{- $host := eq $teamId "admin" | ternary $s.name (printf "%s-%s" $s.name $teamId ) -}}
+    {{- $domain = printf "%s.%s" $host $baseDomain }}
     {{- $domain := printf "apps.%s" $baseDomain }}
-    {{- if hasKey $s "domain" }}
-      {{- $domain = $s.domain }}
-    {{- else if $s | get "isShared" false }}
-      {{- $domain = printf "%s.%s" $host $v.cluster.domainSuffix }}
-    {{- else if $s | get "ownHost" false }}
-      {{- $domain = printf "%s.%s" $host $baseDomain }}
-    {{- end }}
     {{- if not (hasKey $domains $domain) }}
       {{- $_ := set $domains $domain (dict "hasCert" (hasKey $s "hasCert")) }}
     {{- end }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "otomi-core",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "otomi-core",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.9",

--- a/src/cmd/template.ts
+++ b/src/cmd/template.ts
@@ -2,7 +2,7 @@ import { prepareEnvironment } from 'src/common/cli'
 import { DebugStream, terminal } from 'src/common/debug'
 import { hfTemplate } from 'src/common/hf'
 import { getFilename } from 'src/common/utils'
-import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from 'src/common/yargs'
+import { HelmArguments, getParsedArgs, helmOptions, setParsedArgs } from 'src/common/yargs'
 import { Argv } from 'yargs'
 
 interface Arguments extends HelmArguments {
@@ -14,12 +14,12 @@ const cmdName = getFilename(__filename)
 const template = async (): Promise<void> => {
   const d = terminal(`cmd:${cmdName}:template`)
   const argv = getParsedArgs() as Arguments
-  d.info('Templating STARTED')
+  d.info('# Templating STARTED')
   await hfTemplate(argv, argv.outDir, {
     stdout: new DebugStream(console.log),
     stderr: new DebugStream(console.error),
   })
-  d.info('Templating DONE')
+  d.info('# Templating DONE')
 }
 
 export const module = {

--- a/src/common/hf.ts
+++ b/src/common/hf.ts
@@ -129,15 +129,15 @@ export const hfTemplate = async (
   const params: HFParams = { args, fileOpts: argv.file, labelOpts: argv.label, logLevel: argv.logLevel }
   if (!argv.f && !argv.l) {
     const file = 'helmfile.tpl/helmfile-init.yaml'
-    d.debug(`Templating ${file} started`)
+    d.debug(`# Templating ${file} started`)
     const outInit = await hf({ ...params, fileOpts: file }, { streams }, envDir)
-    d.debug(`Templating ${file} done`)
+    d.debug(`# Templating ${file} done`)
     template += outInit.stdout
     template += '\n'
   }
-  d.debug('Templating charts started')
+  d.debug('# Templating charts started')
   const outAll = await hf(params, { streams }, envDir)
-  d.debug('Templating charts done')
+  d.debug('# Templating charts done')
   template += outAll.stdout
   return template
 }

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -7,8 +7,10 @@
 {{- $g := $v.apps | get "grafana" }}
 {{- $p := $v.apps | get "prometheus" }}
 {{- $hasKeycloak := $k.enabled }}
-{{- $appsDomain := printf "apps.%s" $v.cluster.domainSuffix }}
-{{- $grafanaDomain := printf "grafana.%s" $v.cluster.domainSuffix }}
+{{- $domain := ($v.cluster | get "domainSuffix" nil) }}
+{{- $alertmanagerDomain := printf "alertmanager.%s" $domain }}
+{{- $prometheusDomain := printf "prometheus.%s" $domain }}
+{{- $grafanaDomain := printf "grafana.%s" $domain }}
 {{- $slackTpl := tpl (readFile "../../helmfile.d/snippets/alertmanager/slack.gotmpl") $v | toString }}
 {{- $opsgenieTpl := tpl (readFile "../../helmfile.d/snippets/alertmanager/opsgenie.gotmpl") $v | toString }}
 # {{- $grafanaIni := tpl (readFile "../../helmfile.d/snippets/grafana.gotmpl") (dict "keycloakBase" $v._derived.oidcBaseUrlBackchannel "untrustedCA" $v._derived.untrustedCA "keycloak" ($k | get "idp")) | toString }}
@@ -106,7 +108,7 @@ prometheus:
             requests:
               storage: {{ $p | get "storageSize" }}
     enableAdminAPI: true
-    externalUrl: https://{{ $appsDomain }}/prometheus
+    externalUrl: https://{{ $prometheusDomain }}
 {{- if and (not $v.otomi.isMultitenant) $hasServices }}
     additionalScrapeConfigs:
   {{- range $teamId, $team := $v.teamConfig }}
@@ -203,7 +205,7 @@ alertmanager:
         cpu: 100m
         memory: 128Mi
       {{- end }}
-    externalUrl: https://{{ $appsDomain }}/alertmanager
+    externalUrl: https://{{ $alertmanagerDomain }}
   config: {{- tpl (readFile "../../helmfile.d/snippets/alertmanager.gotmpl") (dict "instance" $v "root" $v "slackTpl" $slackTpl "opsgenieTpl" $opsgenieTpl) | nindent 4 }}
 grafana:
   enabled: {{ $g.enabled }}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: 1.0.0
-console: prometheus-host
+console: main
 tasks: 1.0.0
 tools: 1.4.25

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: 1.0.0
-console: 1.0.0
+console: prometheus-host
 tasks: 1.0.0
 tools: 1.4.25


### PR DESCRIPTION
Before prometheus was exposed via `apps.<domainSuffix>` FQDN
Now prometheus is exposed via `prometheus.<domainSuffix>` FQDN
The `apps` host is no longer needed.
implements: #1260