### PR TITLE
feat: oidc gitea teams group mapping

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -6,7 +6,7 @@
 {{- $cm := $v.apps | get "cert-manager" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teams := keys $t.teamConfig}}
-{{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}{{ end }}
+{{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}
 {{- $teams := .Values.teams }}
 {{- $teamData := dict }}
 
@@ -15,7 +15,7 @@
 
 {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
 {{- end }}
-
+{{ end }}
 nameOverride: gitea
 fullnameOverride: gitea
 

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -7,10 +7,9 @@
 {{- $ENV_DIR := env "ENV_DIR" | default "../env" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teams := keys $t.teamConfig}}
+{{- $teamData := dict }}
 {{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}
 {{- $teams := .Values.teams }}
-{{- $teamData := dict }}
-
 {{- range $team := $teams }}
 {{- $teamPath := printf "/%s" $team }}
 

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -4,6 +4,17 @@
 {{- $k := $v.apps.keycloak }}
 {{- $giteaDomain := printf "gitea.%s" $v.cluster.domainSuffix }}
 {{- $cm := $v.apps | get "cert-manager" }}
+{{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
+{{- $teams := keys $t.teamConfig}}
+{{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}{{ end }}
+{{- $teams := .Values.teams }}
+{{- $teamData := dict }}
+
+{{- range $team := $teams }}
+{{- $teamPath := printf "/%s" $team }}
+
+{{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+{{- end }}
 
 nameOverride: gitea
 fullnameOverride: gitea
@@ -111,11 +122,7 @@ gitea:
       autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
       adminGroup: team-admin
       groupClaimName: groups
-      groupTeamMap: { 
-        "/team-demo": {
-          "otomi": ["otomi-viewer"]
-        }
-      }
+      groupTeamMap: {{- toYaml $teamData | nindent 2 }}
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -4,6 +4,7 @@
 {{- $k := $v.apps.keycloak }}
 {{- $giteaDomain := printf "gitea.%s" $v.cluster.domainSuffix }}
 {{- $cm := $v.apps | get "cert-manager" }}
+{{- $ENV_DIR := env "ENV_DIR" | default "../env" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teams := keys $t.teamConfig}}
 {{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -12,9 +12,10 @@
 {{- if gt (len $teamConfigKeys) 0 }}
   {{- range $team := $teamConfigKeys }}
   {{- if ne $team "admin" }}
-    {{- $teamPath := printf "/%s" $team }}
+    {{- $teamPath := printf "/%steam-" $team }}
+    {{- $teamName := printf "team-" $team }}
 
-    {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+    {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $teamName))) }}
   {{- end }}
   {{- end }}
   {{- $jsonTeamData = toJson $teamData }}

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -14,6 +14,7 @@
 {{- $teamPath := printf "/%s" $team }}
 
 {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+{{- $teamData = toJson $teamData }}
 {{- end }}
 {{ end }}
 nameOverride: gitea
@@ -122,7 +123,7 @@ gitea:
       autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
       adminGroup: team-admin
       groupClaimName: groups
-      groupTeamMap: {{- toYaml $teamData | nindent 2 }}
+      groupTeamMap: {{ $teamData | quote }}
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -111,6 +111,11 @@ gitea:
       autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
       adminGroup: team-admin
       groupClaimName: groups
+      groupTeamMap: { 
+        "/team-demo": {
+          "otomi": ["otomi-viewer"]
+        }
+      }
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -8,13 +8,14 @@
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teamData := dict }}
 {{- $teamConfigKeys := keys $t.teamConfig }}
+{{- $jsonTeamData := "" }}
 {{- if gt (len $teamConfigKeys) 0 }}
   {{- range $team := $t.teamConfig }}
   {{- $teamPath := printf "/%s" $team }}
 
   {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
-  {{- $teamData = toJson $teamData }}
   {{- end }}
+  {{- $jsonTeamData = toJson $teamData }}
 {{ end }}
 nameOverride: gitea
 fullnameOverride: gitea
@@ -122,7 +123,7 @@ gitea:
       autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
       adminGroup: team-admin
       groupClaimName: groups
-      groupTeamMap: {{ $teamData | quote }}
+      groupTeamMap: {{ $jsonTeamData | quote }}
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -8,7 +8,6 @@
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teamData := dict }}
 {{- $teamConfigKeys := keys $t.teamConfig }}
-{{- $jsonTeamData := "" }}
 {{- if gt (len $teamConfigKeys) 0 }}
   {{- range $team := $teamConfigKeys }}
   {{- if ne $team "admin" }}
@@ -18,7 +17,7 @@
     {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $teamName))) }}
   {{- end }}
   {{- end }}
-  {{- $jsonTeamData = toJson $teamData }}
+  {{- $teamData = toJson $teamData }}
 {{ end }}
 nameOverride: gitea
 fullnameOverride: gitea
@@ -126,7 +125,7 @@ gitea:
       autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
       adminGroup: team-admin
       groupClaimName: groups
-      groupTeamMap: {{ $jsonTeamData | quote }}
+      groupTeamMap: {{ $teamData | quote }}
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -7,8 +7,9 @@
 {{- $ENV_DIR := env "ENV_DIR" | default "../env" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teamData := dict }}
-{{- if hasKey $t.teamConfig }}{{ $teams := keys $t.teamConfig }}
-  {{- range $team := $teams }}
+{{- $teamConfigKeys := keys $t.teamConfig }}
+{{- if gt (1en $teamConfigKeys) 0 }}
+  {{- range $team := $t.teamConfig }}
   {{- $teamPath := printf "/%s" $team }}
 
   {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -6,16 +6,14 @@
 {{- $cm := $v.apps | get "cert-manager" }}
 {{- $ENV_DIR := env "ENV_DIR" | default "../env" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
-{{- $teams := keys $t.teamConfig}}
 {{- $teamData := dict }}
-{{- if hasKey $t.teamConfig "teams" }}{{ $teams = keys $t.teamConfig.teams }}
-{{- $teams := .Values.teams }}
-{{- range $team := $teams }}
-{{- $teamPath := printf "/%s" $team }}
+{{- if hasKey $t.teamConfig "teams" }}{{ $teams := keys $t.teamConfig }}
+  {{- range $team := $teams }}
+  {{- $teamPath := printf "/%s" $team }}
 
-{{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
-{{- $teamData = toJson $teamData }}
-{{- end }}
+  {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+  {{- $teamData = toJson $teamData }}
+  {{- end }}
 {{ end }}
 nameOverride: gitea
 fullnameOverride: gitea

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -8,7 +8,7 @@
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teamData := dict }}
 {{- $teamConfigKeys := keys $t.teamConfig }}
-{{- if gt (1en $teamConfigKeys) 0 }}
+{{- if gt (len $teamConfigKeys) 0 }}
   {{- range $team := $t.teamConfig }}
   {{- $teamPath := printf "/%s" $team }}
 

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -7,7 +7,7 @@
 {{- $ENV_DIR := env "ENV_DIR" | default "../env" }}
 {{- $t := readFile (print $ENV_DIR "/env/teams.yaml") | fromYaml }}
 {{- $teamData := dict }}
-{{- if hasKey $t.teamConfig "teams" }}{{ $teams := keys $t.teamConfig }}
+{{- if hasKey $t.teamConfig }}{{ $teams := keys $t.teamConfig }}
   {{- range $team := $teams }}
   {{- $teamPath := printf "/%s" $team }}
 

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -10,10 +10,12 @@
 {{- $teamConfigKeys := keys $t.teamConfig }}
 {{- $jsonTeamData := "" }}
 {{- if gt (len $teamConfigKeys) 0 }}
-  {{- range $team := $t.teamConfig }}
-  {{- $teamPath := printf "/%s" $team }}
+  {{- range $team := $teamConfigKeys }}
+  {{- if ne $team "admin" }}
+    {{- $teamPath := printf "/%s" $team }}
 
-  {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+    {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $team))) }}
+  {{- end }}
   {{- end }}
   {{- $jsonTeamData = toJson $teamData }}
 {{ end }}

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -12,8 +12,8 @@
 {{- if gt (len $teamConfigKeys) 0 }}
   {{- range $team := $teamConfigKeys }}
   {{- if ne $team "admin" }}
-    {{- $teamPath := printf "/%steam-" $team }}
-    {{- $teamName := printf "team-" $team }}
+    {{- $teamPath := printf "/team-%s" $team }}
+    {{- $teamName := printf "team-%s" $team }}
 
     {{- $teamData = merge $teamData (dict $teamPath (dict "otomi" (list "otomi-viewer" $teamName))) }}
   {{- end }}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
 console: main
-tasks: 1.0.0
+tasks: oidc-gitea-teams
 tools: 1.4.25


### PR DESCRIPTION
This PR adds automatic group mapping from keycloak to gitea.
Users who login via OIDC are now automatically added to the correct team.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
