### PR TITLE
feat: use ec2 role for loki s3 access

### DIFF
--- a/tests/fixtures/env/apps/loki.yaml
+++ b/tests/fixtures/env/apps/loki.yaml
@@ -84,7 +84,14 @@ apps:
             duration: 24h
             period: 24h
         storage:
-            azure:
-                account_key: account_key
-            type: minioLocal
+            # azure:
+            #     account_key: account_key
+            #     account_name: blabla
+            #     container_name: test
+            # type: azure
+            s3:
+                useInstanceRole: true
+                region: west-eu
+                bucket: my-bucket
+            type: s3
         v11StartDate: 2021-05-13

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2537,6 +2537,9 @@ properties:
                     x-secret: ''
               s3:
                 properties:
+                  useInstanceRole:
+                    type: boolean
+                    default: false
                   bucket:
                     $ref: '#/definitions/wordCharacterPattern'
                   s3Url:
@@ -2546,6 +2549,8 @@ properties:
                   secretAccessKey:
                     $ref: '#/definitions/wordCharacterPattern'
                     x-secret: ''
+                  region:
+                    $ref: '#/definitions/wordCharacterPattern'
               gcs:
                 properties:
                   bucket:

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -163,10 +163,17 @@ loki:
         s3: http://otomi-admin:{{ $v.otomi.adminPassword }}@minio.minio.svc.cluster.local.:9000/loki
         s3forcepathstyle: true
       {{- end }}
-      {{- if eq $st.type "S3" }}
+      {{- if eq $st.type "s3" }}
+      {{- if $st.s3.useInstanceRole }}
+      aws:
+        s3: s3://{{ $st.s3.region }}/{{ $st.s3.bucket }}
+        dynamodb:
+          dynamodb_url: dynamodb://{{ $st.s3.region }}    
+      {{- else }}
       aws:
         s3: s3://{{ $st.s3.accessKeyId }}:{{ $st.s3.secretAccessKey }}@{{ $st.s3.s3Url }}/{{ $st.s3.bucket }}
         s3forcepathstyle: true
+      {{- end }}
       {{- end }}
       {{- if eq $st.type "azure" }}
       azure:


### PR DESCRIPTION
This PR adds the option to use an EC2 role to provide access to s3 for Loki storage (instead of providing credentials).
