### PR TITLE
fix: rm otel debts

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -393,7 +393,6 @@ adminApps:
     path: /explore?orgId=1&left=%7B"datasource":"tempo","queries":%5B%7B"refId":"A","datasource":%7B"type":"tempo","uid":"tempo"%7D,"queryType":"clear","limit":20%7D%5D,"range":%7B"from":"now-1h","to":"now"%7D%7D
   - name: otel
     tags: [tracing]
-    deps: [prometheus, grafana, tempo, loki]
   - name: thanos
     tags: [metrics, observability]
     ownHost: true

--- a/core.yaml
+++ b/core.yaml
@@ -388,7 +388,7 @@ adminApps:
         auth: true
   - name: tempo
     tags: [tracing]
-    deps: [prometheus, grafana]
+    deps: [prometheus, grafana, minio]
     useHost: grafana
     path: /explore?orgId=1&left=%7B"datasource":"tempo","queries":%5B%7B"refId":"A","datasource":%7B"type":"tempo","uid":"tempo"%7D,"queryType":"clear","limit":20%7D%5D,"range":%7B"from":"now-1h","to":"now"%7D%7D
   - name: otel


### PR DESCRIPTION
This PR removes the debts for otel in core.yaml. Otel can be activated independent of enabled receivers of exporters
