### PR TITLE
fix: trigger helmfile.d order

### DIFF
--- a/helmfile.d/helmfile-03.init.yaml
+++ b/helmfile.d/helmfile-03.init.yaml
@@ -89,9 +89,3 @@ releases:
     chart: ../charts/tekton-dashboard
     values:
       - ../values/tekton-dashboard/tekton-dashboard.gotmpl
-  - name: tekton-triggers
-    installed: {{ $a | get "tekton.enabled" }}
-    namespace: tekton-pipelines
-    labels:
-      pkg: tekton-triggers
-    <<: *default

--- a/helmfile.d/helmfile-09.init.yaml
+++ b/helmfile.d/helmfile-09.init.yaml
@@ -50,3 +50,9 @@ releases:
     labels:
       pkg: harbor
     <<: *raw
+  - name: tekton-triggers
+    installed: {{ $a | get "tekton.enabled" }}
+    namespace: tekton-pipelines
+    labels:
+      pkg: tekton-triggers
+    <<: *default


### PR DESCRIPTION
Tekton triggers is dependent on `config.webhook.pipeline.tekton.dev` and sometimes this is not ready and install will fail. This PR fixes this