### PR TITLE
fix: trace2logs query

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -150,7 +150,7 @@ releases:
                   filterByTraceID: false
                   filterBySpanID: false
                   customQuery: true
-                  query: '{${__tags}} |= "${__span.traceId}"'
+                  query: '{namespace="team-{{ $teamId }}"} |= "${__span.traceId}"'
                 nodeGraph:
                   enabled: true
                 search:

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -150,7 +150,7 @@ releases:
                   filterByTraceID: false
                   filterBySpanID: false
                   customQuery: true
-                  query: '{namespace="team-{{ $teamId }}"} |= "${__span.traceId}"'
+                  query: '{namespace="team-{{ $teamId }}"} |= "$${__span.traceId}"'
                 nodeGraph:
                   enabled: true
                 search:
@@ -166,7 +166,7 @@ releases:
                     tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
                     queries:
                       - name: 'Span duration (example)'
-                        query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
+                        query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
                 httpMethod: GET
                 spanBar:
                   type: 'Tag'

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -301,7 +301,7 @@ grafana:
           filterByTraceID: false
           filterBySpanID: false
           customQuery: true
-          query: '{namespace=~".+"} |= "${__span.traceId}"'
+          query: '{namespace=~".+"} |= "$${__span.traceId}"'
         tracesToMetrics:
           datasourceUid: 'prometheus'
           spanStartTimeShift: '1h'
@@ -309,7 +309,7 @@ grafana:
           tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
           queries:
             - name: 'Span duration (example)'
-              query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
+              query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
         serviceMap:
           datasourceUid: 'prometheus'
         nodeGraph:


### PR DESCRIPTION
This PR fixes:
- the trace2log query for the tempo datasource config for teams
- missing double $ signs needed for YAML interpolation
