### PR TITLE
feat: set holdApplicationUntilProxyStarts flag for istio

### DIFF
--- a/values/istio-operator/istio-operator-raw.gotmpl
+++ b/values/istio-operator/istio-operator-raw.gotmpl
@@ -152,6 +152,7 @@ resources:
           useMCP: false
         meshConfig:
           defaultConfig:
+            holdApplicationUntilProxyStarts: true
             gatewayTopology:
               numTrustedProxies: 1
           accessLogFile: /dev/stdout


### PR DESCRIPTION
This change ensures that containers will not start until istio-proxy sidecar is ready.
By doing so, we mitigate the network issues "connection refused" that some applications does not handle well (e.g.: cloud native PG)
The side effect is that application start time will be a bit slower.