### PR TITLE
fix: incorrect defaults in backup schedule

### DIFF
--- a/charts/team-ns/templates/backup/schedule.yaml
+++ b/charts/team-ns/templates/backup/schedule.yaml
@@ -15,8 +15,9 @@ spec:
     - team-{{ $v.teamId }}
     includedResources:
     - pv
+    - pvc
     ttl: {{ .ttl }}
-    includeClusterResources: false
+    includeClusterResources: true
     {{- if hasKey . "labelSelector" }}
     labelSelector:
       matchLabels:


### PR DESCRIPTION
To create backup schedules to backup PVs, it is required to set `includeClusterResources: true` and also include `pvc` to the list of resources. This PR fixes this.
