### PR TITLE
fix: dockerfile otomi tools script

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update -qq \
   curl \
   gettext \
   git \
+  gnupg \
   gnupg2 \
   groff \
   locales \
@@ -128,8 +129,6 @@ RUN mv /tmp/konstraint-linux-amd64 konstraint && chmod +x konstraint
 # node
 # https://github.com/nodesource/distributions
 RUN set -uex && \
-  apt-get update && \
-  apt-get install -y ca-certificates curl gnupg && \
   mkdir -p /etc/apt/keyrings && \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
   NODE_MAJOR=${NODE_VERSION} && \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -126,8 +126,16 @@ ADD https://github.com/plexsystems/konstraint/releases/download/v${KONSTRAINT_VE
 RUN mv /tmp/konstraint-linux-amd64 konstraint && chmod +x konstraint
 
 # node
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
-RUN apt-get install -y nodejs && \
+# https://github.com/nodesource/distributions
+RUN set -uex && \
+  apt-get update && \
+  apt-get install -y ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  NODE_MAJOR=${NODE_VERSION} && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install nodejs -y && \
   npm install -g ajv-cli@v3.3.0 json-dereference-cli@0.1.2 zx
 
 RUN chown -R app:app /home/app


### PR DESCRIPTION
### Implements:
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/otomi-core/1299

### Description:
This PR updates the dockerfile node.js installation script for otomi tools. In the dockerfile deprecated installation script changed with the new one via the [instructions](https://github.com/nodesource/distributions).

### Testing:
- Run Docker Desktop
- Open integrated terminal in VS Code (otomi-core) 
- Run on your local `docker buildx build --load -t otomi/tools -f tools/Dockerfile .`
- Verify that `otomi-tools` image is builded successfully (without getting `SCRIPT DEPRECATION WARNING`)

### Changes Made:
Updated tools dockerfile.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
