### PR TITLE
fix: use kc theme jar

### DIFF
--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -44,7 +44,7 @@ spec:
         containers: #
         - volumeMounts:
             - name: theme-volume
-              mountPath: /opt/keycloak/themes/otomi
+              mountPath: /opt/keycloak/providers
           resources: {{ $k.resources.keycloak | toYaml  | nindent 12 }}
         volumes:
         - name: theme-volume
@@ -59,7 +59,7 @@ spec:
           - -c
           - |
             echo "Copying theme..."
-            cp -Rv /app/keycloak/themes/otomi/* /theme/
+            cp -Rv /app/otomi.jar /opt/keycloak/providers/
           volumeMounts: 
             - name: theme-volume
-              mountPath: /theme
+              mountPath: /opt/keycloak/providers


### PR DESCRIPTION
Changes to support the use of a jar for the Otomi Keycloak theme.
