### PR TITLE
fix: keycloak theme

### DIFF
--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -1,4 +1,4 @@
-{{- $pinnedConsoleVersion := "0.5.4" }}
+{{- $pinnedConsoleVersion := "main" }}
 {{- $v := .Values }}
 {{- $k := $v | get "apps.keycloak" }}
 

--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -51,7 +51,7 @@ spec:
           emptyDir: {}
         initContainers:
         - name: init-container-theme-copy # Otomi branding init container
-          image: docker.io/otomi/console:v{{ $pinnedConsoleVersion }}
+          image: docker.io/otomi/console:{{ $pinnedConsoleVersion }}
           resources: {{ $k.resources.keycloak | toYaml  | nindent 12 }}
           command: 
           - sh 


### PR DESCRIPTION
This change fixes compatibility issue with keycloak theme, which prevent deploying Otomi from main.