### PR TITLE
feat: optimise generating gitea job configuration

### DIFF
--- a/charts/gitea/templates/gitea/statefulset.yaml
+++ b/charts/gitea/templates/gitea/statefulset.yaml
@@ -48,6 +48,8 @@ spec:
       initContainers:
         - name: init-directories
           image: "{{ include "gitea.image" . }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command: ["/usr/sbin/init_directory_structure.sh"]
           env:
             - name: GITEA_APP_INI
@@ -78,6 +80,8 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
         - name: init-app-ini
           image: "{{ include "gitea.image" . }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command: ["/usr/sbin/config_environment.sh"]
           env:
             - name: GITEA_APP_INI
@@ -114,6 +118,8 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
         - name: configure-gitea
           image: "{{ include "gitea.image" . }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command: ["/usr/sbin/configure_gitea.sh"]
           securityContext:
             {{- /* By default this container runs as user 1000 unless otherwise stated */ -}}

--- a/helmfile.d/snippets/values-gitea-prepare.gotmpl
+++ b/helmfile.d/snippets/values-gitea-prepare.gotmpl
@@ -1,0 +1,14 @@
+{{- $v := . }}
+{{- $teams := keys $v.teamConfig }}
+apps:
+  argocd:
+    enabled: {{ $v.apps.argocd.enabled }}
+cluster:
+  domainSuffix: {{ $v.cluster.domainSuffix }}
+teamConfig:
+  teams:
+    {{- range $teamId, $team := $v.teamConfig }}
+      {{ $teamId }}: 
+        selfService:
+          apps: {{ $team | get "selfService.apps" list}}
+    {{- end }}

--- a/tests/fixtures/env/apps/drone.yaml
+++ b/tests/fixtures/env/apps/drone.yaml
@@ -2,14 +2,9 @@ apps:
     drone:
         adminUser: somesecretvalue
         debug: false
-        githubAdmins:
-            org: redkubes
-            team: admins
-            token: somesecretvalue
         orgsFilter: redkubes
         repoFilter: redkubes
         sourceControl:
-            github:
-                clientID: somesecretvalue
-                server: https://github.com
-            provider: github
+            gitea:
+                server: 'https://gitea.demo.eks.otomi.cloud'
+            provider: gitea

--- a/tests/fixtures/env/apps/gitea.yaml
+++ b/tests/fixtures/env/apps/gitea.yaml
@@ -1,2 +1,3 @@
 apps:
-    gitea: {}
+    gitea:
+        enabled: true

--- a/values/jobs/gitea-prepare.gotmpl
+++ b/values/jobs/gitea-prepare.gotmpl
@@ -1,8 +1,7 @@
 {{- $v := .Values }}
 {{- $c := $v.apps }}
 {{- $g := $c.gitea }}
-{{- $otomiValues := pick $v "cluster" "otomi" "teamConfig" "apps" }}
-
+{{- $otomiValues := tpl (readFile "../../helmfile.d/snippets/values-gitea-prepare.gotmpl") $v | fromYaml | toJson }}
 type: Job
 name: gitea-prepare
 runPolicy: OnSpecChange
@@ -13,7 +12,7 @@ env:
   DRONE_NAMESPACE: drone
 nativeSecrets:
   GITEA_PASSWORD: {{ $g.adminPassword }}
-  OTOMI_VALUES: '{{ $otomiValues | toJson }}'
+  OTOMI_VALUES: '{{ $otomiValues }}'
 annotations:
   {{- if $v | get "policies.banned-image-tags.tags" | has $v.otomi.version }}
   policy.otomi.io/ignore: "banned-image-tags"


### PR DESCRIPTION
We noticed that in case of huge amount of teams in Otomi, the `job-gitea-prepare` fails with ambiguous message 
```
exec /bin/sh: argument list too long
```

After debugging this issue we realised that it is caused by an environment variable that exceeds the allowed size.
