### PR TITLE
fix: kc limits

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -257,14 +257,14 @@ environments:
                       cpu: 200m
                       memory: 512Mi
                   limits:
-                      cpu: 400m
+                      cpu: 2000m
                       memory: 1Gi
               operator:
                   requests:
                       cpu: 100m
                       memory: 128Mi
                   limits:
-                      cpu: 400m
+                      cpu: 1000m
                       memory: 512Mi
             idp:
               alias: otomi-idp


### PR DESCRIPTION
When using Keycloak operator, keycloak is build at each start. This is time consuming. To speed up the building process, more CPU is needed. This PR increases CPU limits for both Keycloak and Keycloak operator.
