### PR TITLE
fix: scaleway private network id

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,6 +126,7 @@ env:
   GIT_USER: redkubesbot
   SCALEWAY_NODE_TYPE: PRO2-M
   SCALEWAY_NODE_POOL_MIN_SIZE: 3
+  SCALEWAY_PRIVATE_NETWORK_ID: ccbab0a5-a2a2-4407-b0fd-4764f227b4fd
   DIGITALOCEAN_NODE_SIZE: s-8vcpu-16gb
   DIGITALOCEAN_NODE_POOL_MIN_SIZE: 3
   CHECK_CONTEXT: continuous-integration/integration-test
@@ -222,16 +223,11 @@ jobs:
       - name: Determine exact k8s version
         run: |
           echo SCALEWAY_K8s_VERSION=$(scw k8s version list -o json | jq -re 'map(select(.name | startswith("${{ matrix.kubernetes_versions }}"))) | .[].name') >> $GITHUB_ENV
-      - name: Create Private Network
-        run: |
-          out=$(scw vpc private-network create name=VPC-${{env.SCALEWAY_CLUSTER_NAME}} region=nl-ams)
-      - name: Retrieve VPC id
-        run: echo SCALEWAY_VPC_ID=$(scw vpc private-network list region=nl-ams -o json | jq -r '.[] | select(.name == "VPC-${{ env.SCALEWAY_CLUSTER_NAME }}") | .id') >> $GITHUB_ENV
       - name: Create k8s cluster at Scaleway ${{env.SCALEWAY_CLUSTER_NAME}}
         run: |
           out=$(scw k8s cluster create name=${{env.SCALEWAY_CLUSTER_NAME}} \
               project-id=${{ env.SCW_DEFAULT_PROJECT_ID }} \
-              private-network-id=${{ env.SCALEWAY_VPC_ID }} \
+              private-network-id=${{ env.SCALEWAY_PRIVATE_NETWORK_ID }} \
               auto-upgrade.enable=false \
               cni=calico \
               pools.0.node-type=${{ env.SCALEWAY_NODE_TYPE }} \


### PR DESCRIPTION
This PR uses a private network id so that there are no longer private networks created with every deployment.
