### PR TITLE
test: make project ID visible

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -214,7 +214,7 @@ jobs:
           version: v2.23.0
           access-key: ${{ secrets.SCW_ACCESS_KEY }}
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
-          default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+          default-project-id: e41d0c87-e67c-45be-9b28-9ca10d8d035f
           default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
       - name: Set k8s cluster name
         run: |


### PR DESCRIPTION
The project-id was treated as a secret but it is not a secret.
After this change it will be possible to copy and paste scw k8s cluster creation command.