### PR TITLE
fix: escaped characters

### DIFF
--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Delete Clusters and Private Networks in DEV
         run: |
           SCALEWAY_CLUSTER_IDS=$(scw k8s cluster list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-          echo Deleting Cluster(s) with ID: $SCALEWAY_CLUSTER_IDS
+          echo Deleting Cluster\(s\) with ID\(s\): $SCALEWAY_CLUSTER_IDS
           scw k8s cluster delete $SCALEWAY_CLUSTER_IDS with-additional-resources=true region=nl-ams --wait
 
           PRIVATE_NETWORK_IDS=$(scw vpc private-network list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-          echo Deleting Private Network(s) with ID:
+          echo Deleting Private Network\(s\) with ID\(s\):
           scw vpc private-network delete region=nl-ams $PRIVATE_NETWORK_IDS


### PR DESCRIPTION
This MR fixes the schedule deletion of the private networks in scaleway. It was previously failing because of the unescaped '(' character in the echo command.