### PR TITLE
feat: default two replicas of keycloak db

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -706,7 +706,7 @@ environments:
             useOtomiDB: true
             imported: false
             size: "1Gi"
-            replicas: 1
+            replicas: 2
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
Two replicas ensure smooth db Pod traversal between nodes.
E.g.: draining a node.