### PR TITLE
fix: svc name to max 14

### DIFF
--- a/charts/tekton-dashboard/templates/_helpers.tpl
+++ b/charts/tekton-dashboard/templates/_helpers.tpl
@@ -26,7 +26,7 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 
 {{- define "tekton-dashboard.svcname" -}}
 {{- if .Values.teamId -}}
-{{- printf "%s-%s" .Values.teamId "tekton-dashboard" | trunc 26 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Values.teamId "tekton-dashboard" | trunc 32 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "tekton-dashboard" -}}
 {{- end -}}

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -418,7 +418,6 @@ definitions:
   idName:
     description: A lowercase name that starts with a letter and may contain dashes.
     pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])$'
-    maxLength: 12
     type: string
   image:
     additionalProperties: false

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -418,6 +418,7 @@ definitions:
   idName:
     description: A lowercase name that starts with a letter and may contain dashes.
     pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])$'
+    maxLength: 12
     type: string
   image:
     additionalProperties: false


### PR DESCRIPTION
The svc name of the tekton dasboard was limited to 26 characters and this limits team-names to be max 9 characters. By setting the svc name to 32 characters, team names now can be max 12 characters. I added the max team name to the docs.
