### PR TITLE
fix: team tekton tasks

### DIFF
--- a/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
+++ b/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
@@ -1,6 +1,3 @@
-{{- $v := .Values }}
-{{- $t := $v.apps.tekton }}
-{{- if $t.enabled }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -184,4 +181,3 @@ spec:
       emptyDir: {}
     - name: layers-dir
       emptyDir: {}
-{{- end }}

--- a/charts/team-ns/templates/tekton-tasks/git-clone.yaml
+++ b/charts/team-ns/templates/tekton-tasks/git-clone.yaml
@@ -1,6 +1,3 @@
-{{- $v := .Values }}
-{{- $t := $v.apps.tekton }}
-{{- if $t.enabled }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -251,4 +248,3 @@ spec:
         printf "%s" "${RESULT_COMMITTER_DATE}" > "$(results.committer-date.path)"
         printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
         printf "%s" "${PARAM_URL}" > "$(results.url.path)"
-{{- end }}

--- a/charts/team-ns/templates/tekton-tasks/kaniko.yaml
+++ b/charts/team-ns/templates/tekton-tasks/kaniko.yaml
@@ -1,6 +1,3 @@
-{{- $v := .Values }}
-{{- $t := $v.apps.tekton }}
-{{- if $t.enabled }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -75,4 +72,3 @@ spec:
         set -e
         image="$(params.IMAGE)"
         echo -n "${image}" | tee "$(results.IMAGE_URL.path)"
-{{- end }}


### PR DESCRIPTION
With tekton enabled by default, tekton tasks should always be added.
