### PR TITLE
ci: fix tty console latest tag push [TTY][MINOR]

### DIFF
--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -63,7 +63,6 @@ jobs:
         if: ${{ env.NEW_VERSION != null }}
         run: |
           docker buildx build --load -t ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }} -t ${{ env.NAMESPACE }}/${{ env.REPO }}:latest -f tools/Dockerfile-tty .
-          docker tag ${{ env.NAMESPACE }}/${{ env.REPO }} ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }}
 
       - name: Squash image
         if: ${{ env.NEW_VERSION != null }}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build and tag Docker image
         if: ${{ env.NEW_VERSION != null }}
         run: |
-          docker buildx build --load -t ${{ env.NAMESPACE }}/${{ env.REPO }} -f tools/Dockerfile-tty .
+          docker buildx build --load -t ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }} -t ${{ env.NAMESPACE }}/${{ env.REPO }}:latest -f tools/Dockerfile-tty .
           docker tag ${{ env.NAMESPACE }}/${{ env.REPO }} ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }}
 
       - name: Squash image
@@ -82,3 +82,4 @@ jobs:
         if: ${{ env.NEW_VERSION != null }}
         run: |
           docker push ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }}
+          docker push ${{ env.NAMESPACE }}/${{ env.REPO }}:latest


### PR DESCRIPTION
This MR fixes the push of the latest tag for the TTY Console image. At the moment the new image(and tag) is created correctly but the latest tag/version is not updated.