### PR TITLE
fix: Harbor htpasswd bootstrap

### DIFF
--- a/src/common/values.test.ts
+++ b/src/common/values.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, merge } from 'lodash'
+import { cloneDeep, merge, set } from 'lodash'
 import { generateSecrets } from 'src/common/values'
 import stubs from 'src/test-stubs'
 
@@ -6,6 +6,8 @@ const { terminal } = stubs
 
 describe('generateSecrets', () => {
   const values = { one: 'val', secret: 'prop', apps: { yo: { di: { lo: 'loves you' } } } }
+  set(values, 'apps.harbor.registry.credentials.username', 'u')
+  set(values, 'apps.harbor.registry.credentials.password', 'p')
   const simpleTemplate = 'dummy'
   const schema = {
     properties: {

--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -271,13 +271,11 @@ export const deriveSecrets = async (values: Record<string, any> = {}): Promise<R
   // Some secrets needs to be drived from the generated secrets
 
   const secrets = {}
-  if (values?.apps?.harbor?.enabled) {
-    const htpasswd = (
-      await $`htpasswd -nbB ${values.apps.harbor.registry.credentials.username} ${values.apps.harbor.registry.credentials.password}`
-    ).stdout.trim()
+  const htpasswd = (
+    await $`htpasswd -nbB ${values.apps.harbor.registry.credentials.username} ${values.apps.harbor.registry.credentials.password}`
+  ).stdout.trim()
 
-    set(secrets, 'apps.harbor.registry.credentials.htpasswd', htpasswd)
-  }
+  set(secrets, 'apps.harbor.registry.credentials.htpasswd', htpasswd)
 
   return secrets
 }

--- a/tests/bootstrap/input.yaml
+++ b/tests/bootstrap/input.yaml
@@ -5,13 +5,6 @@ cluster:
   k8sContext: CONTEXT_PLACEHOLDER
 otomi:
   version: 'main'
-  adminPassword: test
-apps:
-  harbor:
-    enabled: true
-license: testLicense
-
-databases:
-  keycloak:
-    size: '5Gi'
-    replicas: 1
+# apps:
+#   harbor:
+#     enabled: true

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -323,9 +323,9 @@ registry:
       {{- end }}
   relativeurls: false
   credentials:
-    username: {{ $h | get "registry.credentials.username" }}
-    password: {{ $h | get "registry.credentials.password" $v.otomi.adminPassword }}
-    htpasswdString: {{ $h | get "registry.credentials.htpasswd" nil }}
+    username: {{ $h.registry.credentials.username }}
+    password: {{ $h.registry.credentials.password }}
+    htpasswdString: {{ $h.registry.credentials.htpasswd }}
 
 trivy:
   priorityClassName: otomi-critical


### PR DESCRIPTION
fixes #1398

This PR ensures that the `httpaswd` secret is always generated during the initial installation.

Note: it does not solve the issue on existing clusters. Only for new installations.


Tested with:
```
npm run bootstrap-dev
```

