### PR TITLE
feat: update backup schedule definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
           fi
 
           # Update Chart.yaml and values.yaml with the new app version
-          sed -i "s/CHART_VERSION_PLACEHOLDER/v$app_version/g" chart/otomi/Chart.yaml
+          sed -i "s/CHART_VERSION_PLACEHOLDER/$app_version/g" chart/otomi/Chart.yaml
           sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/otomi/Chart.yaml
 
           echo "Chart and values files updated successfully with version $app_version"

--- a/charts/team-ns/templates/backup/schedule.yaml
+++ b/charts/team-ns/templates/backup/schedule.yaml
@@ -13,11 +13,7 @@ spec:
   template:
     includedNamespaces:
     - team-{{ $v.teamId }}
-    includedResources:
-    - pv
-    - pvc
     ttl: {{ .ttl }}
-    includeClusterResources: true
     {{- if hasKey . "labelSelector" }}
     labelSelector:
       matchLabels:


### PR DESCRIPTION
This MR removes hardcoding of specific resources to be backed up by velero. Doing so insures that velero automatically backes up the PV/PVC. For more info check  this link (note the `includeClusterResources` comments): https://velero.io/docs/main/api-types/backup/#api-groupversion