### PR TITLE
feat: updating otomi tasks and otomi installer job resource limits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
           fi
 
           # Update Chart.yaml and values.yaml with the new app version
-          sed -i "s/CHART_VERSION_PLACEHOLDER/v$app_version/g" chart/otomi/Chart.yaml
+          sed -i "s/CHART_VERSION_PLACEHOLDER/$app_version/g" chart/otomi/Chart.yaml
           sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/otomi/Chart.yaml
 
           echo "Chart and values files updated successfully with version $app_version"

--- a/chart/otomi/templates/job.yaml
+++ b/chart/otomi/templates/job.yaml
@@ -34,13 +34,7 @@ spec:
               drop:
               - ALL
             runAsNonRoot: true
-          resources:
-            limits:
-              memory: 2Gi
-              cpu: '2'
-            requests:
-              memory: 1Gi
-              cpu: '1'
+          resources: {}
           command: [bash, -c]
           args:
             - |

--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -19,7 +19,6 @@ spec:
     - name: gitea-credentials
       mountPath: /etc/gitea-credentials
   stepTemplate:
-    computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     workingDir: $(workspaces.source.path)
     image: otomi/core:v1.0.0
   steps:

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -17,7 +17,6 @@ spec:
     - name: gitea-credentials
       mountPath: /etc/gitea-credentials
   stepTemplate:
-    computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     imagePullPolicy: Always
     image: otomi/core:$(params["OTOMI_VERSION"])
     workingDir: /home/app/stack

--- a/core.yaml
+++ b/core.yaml
@@ -115,6 +115,7 @@ k8s:
     - name: otomi-pipelines
       app: tekton
       disableIstioInjection: true
+      disablePolicyChecks: true
 
 adminApps:
   - name: alertmanager


### PR DESCRIPTION
This MR removes the resource limits for the otomi installer job and disables gatekeeper policy checks for the otomi-pipelines namespace.
