### PR TITLE
fix: oauth2-proxy cert

### DIFF
--- a/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
@@ -42,7 +42,11 @@ resources:
             pathType: Prefix
       {{- if not $v.otomi.hasCloudLB }}
       tls: 
-        - secretName: {{ $domain | replace "." "-" }}
+        {{- if eq $cm.issuer "byo-wildcard-cert" }}
+        - secretName: "byo-wildcard-cert"
+        {{- else }}
+        - secretName: otomi-cert-manager-wildcard-cert
+        {{- end }}
           hosts:
             - '{{ $domain }}'
       {{- end }}


### PR DESCRIPTION
This PR fixes the oauth2-proxy ingress configuration when "Bring Your Own Certificate" is in use. 