### PR TITLE
feat: add cpu limits for otomi pipelines

### DIFF
--- a/chart/otomi/templates/job.yaml
+++ b/chart/otomi/templates/job.yaml
@@ -34,7 +34,13 @@ spec:
               drop:
               - ALL
             runAsNonRoot: true
-          resources: {}
+          resources:
+            limits:
+              memory: 2Gi
+              cpu: '2'
+            requests:
+              memory: 1Gi
+              cpu: '1'
           command: [bash, -c]
           args:
             - |

--- a/chart/otomi/templates/job.yaml
+++ b/chart/otomi/templates/job.yaml
@@ -36,10 +36,8 @@ spec:
             runAsNonRoot: true
           resources:
             limits:
-              memory: 2Gi
               cpu: '2'
             requests:
-              memory: 1Gi
               cpu: '1'
           command: [bash, -c]
           args:

--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -19,6 +19,7 @@ spec:
     - name: gitea-credentials
       mountPath: /etc/gitea-credentials
   stepTemplate:
+    computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     workingDir: $(workspaces.source.path)
     image: otomi/core:v1.0.0
   steps:

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -17,6 +17,7 @@ spec:
     - name: gitea-credentials
       mountPath: /etc/gitea-credentials
   stepTemplate:
+    computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     imagePullPolicy: Always
     image: otomi/core:$(params["OTOMI_VERSION"])
     workingDir: /home/app/stack

--- a/charts/otomi-pipelines/values.yaml
+++ b/charts/otomi-pipelines/values.yaml
@@ -22,10 +22,8 @@ tektonTask:
   resources:
     # Tekton Task pod resouce limits and requests
     requests:
-      memory: '512Mi'
       cpu: '500m'
     limits:
-      memory: '2Gi'
       cpu: '2'
 
 kms: {}

--- a/core.yaml
+++ b/core.yaml
@@ -115,6 +115,7 @@ k8s:
     - name: otomi-pipelines
       app: tekton
       disableIstioInjection: true
+      disablePolicyChecks: true
 
 adminApps:
   - name: alertmanager

--- a/core.yaml
+++ b/core.yaml
@@ -115,7 +115,6 @@ k8s:
     - name: otomi-pipelines
       app: tekton
       disableIstioInjection: true
-      disablePolicyChecks: true
 
 adminApps:
   - name: alertmanager


### PR DESCRIPTION
The CPU needs to be contained. Otherwise pipeline may perform too many kube-api requests