### PR TITLE
fix: renamed the secret to be used by the ingress

### DIFF
--- a/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
@@ -43,7 +43,7 @@ resources:
       {{- if not $v.otomi.hasCloudLB }}
       tls: 
         {{- if eq $cm.issuer "byo-wildcard-cert" }}
-        - secretName: "byo-wildcard-cert"
+        - secretName: "otomi-byo-wildcard-cert"
         {{- else }}
         - secretName: otomi-cert-manager-wildcard-cert
         {{- end }}


### PR DESCRIPTION
This PR fixes the name of the tls secret to be used by the oauth2-proxy ingress in case the "byo-wildcard-cert" is used.