### PR TITLE
fix: team netpol for prom

### DIFF
--- a/charts/team-ns/templates/istio-sidecar.yaml
+++ b/charts/team-ns/templates/istio-sidecar.yaml
@@ -1,5 +1,6 @@
 {{- $v := .Values | merge (dict) }}
 {{- $ := . }}
+{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $egressFilteringEnabled := $v | dig "networkPolicy" "egressPublic" true }}
 {{- if $egressFilteringEnabled }}
@@ -12,6 +13,20 @@ metadata:
 spec:
   outboundTrafficPolicy: 
     mode: REGISTRY_ONLY
+{{ if $hasStack }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: team-prometheus
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
+spec:
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY
+  workloadSelector:
+    labels:
+      otomi.io/app: prometheus-team-{{ $v.teamId }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if (dig "monitoringStack" "enabled" false $v) }}

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,7 +1,6 @@
 {{/* Below merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
 {{- $v := .Values | merge (dict) }}
 {{- $hasStack := dig "monitoringStack" "enabled" false $v }}
-{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
 {{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,5 +1,7 @@
 {{/* Below merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
 {{- $v := .Values | merge (dict) }}
+{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
+{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
 {{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -137,6 +139,28 @@ spec:
     - Ingress
 
   {{- range $s := $v.services }}
+    {{ if and ($hasStack) (not $s.isCore) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $s.name }}-ingress-allow-prometheus
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      otomi.io/app: {{ $s.name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: team-{{ $v.teamId }}
+          podSelector:
+            matchLabels:
+              otomi.io/app: prometheus-team-{{ $v.teamId }}
+    {{- end }}
     {{- $isKnativeService := dig "ksvc" "predeployed" false $s }}
     {{- if not $s.isCore }}
       {{- $ingressPrivateMode := dig "networkPolicy" "ingressPrivate" "mode" "DenyAll" $s }}

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -71,11 +71,14 @@ releases:
         commonLabels:
           prometheus: team-{{ $teamId }}
         prometheus:
-          annotations:
-            traffic.sidecar.istio.io/excludeOutboundPorts: "9093"
           enabled: {{ and ($team | get "monitoringStack.enabled" false) ($a.prometheus.enabled)  }}
           namespaceOverride: null # team-{{ $teamId }}
           prometheusSpec:
+            podMetadata:
+              annotations:
+                traffic.sidecar.istio.io/excludeOutboundPorts: "9093"
+              labels:
+                otomi.io/app: prometheus-team-{{ $teamId }}
             externalLabels:
               cluster: "prometheus-{{ $teamId }}.{{ $domain }}"
             externalUrl: "https://prometheus-{{ $teamId }}.{{ $domain }}"

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -54,9 +54,6 @@ prometheus:
     selfMonitor: false
   additionalServiceMonitors: null
   prometheusSpec:
-    podMetadata:
-      annotations:
-        traffic.sidecar.istio.io/excludeOutboundPorts: "9093"
     enableAdminAPI: false
     replicas: 1
     remoteWrite: null


### PR DESCRIPTION
If a team deploy's servicemonitors for the team's prometheus to scrape, prometheus needs access to the workload service. This PR adds:
- a default ingress policy for each service to allow access for prometheus
- a Sidecar resource for prometheus using a workload selector to overrule the default outboundTrafficPolicy
- add `otomi.io/app` label to the team's prometheus pod

