### PR TITLE
feat: remove old charts while cloning into gitea

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -75,6 +75,8 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await $`git clone --depth 1 ${otomiChartsUrl} ${workDir}`
     cd(workDir)
     await $`rm -rf .git`
+    await $`rm -rf deployment`
+    await $`rm -rf ksvc`
     await $`git init`
     await setIdentity(username, password, email)
     await $`git checkout -b main`


### PR DESCRIPTION
### Description:
This PR adds a feature to remove `deployment` and `ksvc` folders while cloning into the gitea charts repository.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
