### PR TITLE
feat: enable team prometheus prometheus is monitoringStack enabled

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -41,7 +41,7 @@ releases:
     values:
       - ../values/tekton-dashboard/tekton-dashboard-teams.gotmpl
   - name: prometheus-{{ $teamId }}
-    installed: {{ and $a.prometheus.enabled $a.grafana.enabled }}
+    installed: {{ $team | get "monitoringStack.enabled" false }}
     namespace: team-{{ $teamId }}
     chart: ../charts/kube-prometheus-stack
     labels:


### PR DESCRIPTION
(cherry picked from commit 22472281a475feb7d862d7d924b84e1fbbd6d47d)
