### PR TITLE
fix: team monitoring logic

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -118,6 +118,7 @@ releases:
               label: release
               labelValue: grafana-dashboards-{{ $teamId }}
           additionalDataSources:
+          {{- if $v.apps.prometheus.enabled }}
             - name: Prometheus-platform
               editable: false
               uid: prometheus-platform
@@ -126,6 +127,7 @@ releases:
               url: http://po-prometheus.monitoring:9090
               jsonData:
                 httpMethod: GET
+            {{- end }}
             {{- if $v.apps.loki.enabled }}
             - name: Loki
               editable: false

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -41,7 +41,7 @@ releases:
     values:
       - ../values/tekton-dashboard/tekton-dashboard-teams.gotmpl
   - name: prometheus-{{ $teamId }}
-    installed: {{ $team | get "monitoringStack.enabled" false }}
+    installed: {{ or ($team | get "monitoringStack.enabled" false) ($a.prometheus.enabled) }}
     namespace: team-{{ $teamId }}
     chart: ../charts/kube-prometheus-stack
     labels:
@@ -53,7 +53,7 @@ releases:
       - nameOverride: {{ $teamId }}-po
         fullnameOverride: {{ $teamId }}-po
         alertmanager:
-          enabled: {{ and ($team | get "monitoringStack.enabled" false) ($a.alertmanager.enabled) }}
+          enabled: {{ $team | get "monitoringStack.enabled" false }}
           namespaceOverride: null
           alertmanagerSpec:
             externalUrl: "https://alertmanager-{{ $teamId }}.{{ $domain }}"
@@ -71,7 +71,7 @@ releases:
         commonLabels:
           prometheus: team-{{ $teamId }}
         prometheus:
-          enabled: {{ and ($team | get "monitoringStack.enabled" false) ($a.prometheus.enabled)  }}
+          enabled: {{ $team | get "monitoringStack.enabled" false }}
           namespaceOverride: null # team-{{ $teamId }}
           prometheusSpec:
             podMetadata:


### PR DESCRIPTION
This PR improves the logic for team monitoring to make sure that:
- Alertmanager, Prometheus and Grafana are  installed for the team when monitoringStack.enabled=true, also when Prometheus and Grafana on the platform are not enabled
- Grafana is installed when platform prometheus.enabled=true so the team gets Grafana for dashboards using the platform Prometheus datasource
- Grafana additional datasources are configured based on platform availability of Loki, Prometheus and Tempo. If Grafana for the team is enabled, but Prometheus, Loki and Tempo on platform level are not enabled, then the team Grafana will only have the default datasource (for the team's Prometheus)
