### PR TITLE
feat: select secret for external private repo

### DIFF
--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -64,7 +64,6 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       spec:
-
         pipelineRef:
           name: buildpacks-build-{{ .name }}
         taskRunTemplate:
@@ -83,7 +82,11 @@ spec:
                   storage: 1Gi
         - name: git-credentials
           secret:
+            {{- if .mode.buildpacks.externalRepo }}
+            secretName: {{ .mode.buildpacks.secretName }}
+            {{- else }}
             secretName: gitea-credentials
+            {{- end }}
         - name: docker-credentials
           secret:
             secretName: harbor-pushsecret-builds
@@ -115,7 +118,11 @@ spec:
             storage: 1Gi
   - name: git-credentials
     secret:
+      {{- if .mode.buildpacks.externalRepo }}
+      secretName: {{ .mode.buildpacks.secretName }}
+      {{- else }}
       secretName: gitea-credentials
+      {{- end }}
   - name: docker-credentials
     secret:
       secretName: harbor-pushsecret-builds

--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -82,8 +82,8 @@ spec:
                   storage: 1Gi
         - name: git-credentials
           secret:
-            {{- if .mode.buildpacks.externalRepo }}
-            secretName: {{ .mode.buildpacks.secretName }}
+            {{- if .externalRepo }}
+            secretName: {{ .secretName }}
             {{- else }}
             secretName: gitea-credentials
             {{- end }}
@@ -118,8 +118,8 @@ spec:
             storage: 1Gi
   - name: git-credentials
     secret:
-      {{- if .mode.buildpacks.externalRepo }}
-      secretName: {{ .mode.buildpacks.secretName }}
+      {{- if .externalRepo }}
+      secretName: {{ .secretName }}
       {{- else }}
       secretName: gitea-credentials
       {{- end }}

--- a/charts/team-ns/templates/builds/docker.yaml
+++ b/charts/team-ns/templates/builds/docker.yaml
@@ -80,8 +80,8 @@ spec:
                   storage: 1Gi
         - name: git-credentials
           secret:
-            {{- if .mode.docker.externalRepo }}
-            secretName: {{ .mode.docker.secretName }}
+            {{- if .externalRepo }}
+            secretName: {{ .secretName }}
             {{- else }}
             secretName: gitea-credentials
             {{- end }}
@@ -116,8 +116,8 @@ spec:
             storage: 1Gi
   - name: git-credentials
     secret:
-      {{- if .mode.docker.externalRepo }}
-      secretName: {{ .mode.docker.secretName }}
+      {{- if .externalRepo }}
+      secretName: {{ .secretName }}
       {{- else }}
       secretName: gitea-credentials
       {{- end }}

--- a/charts/team-ns/templates/builds/docker.yaml
+++ b/charts/team-ns/templates/builds/docker.yaml
@@ -80,7 +80,11 @@ spec:
                   storage: 1Gi
         - name: git-credentials
           secret:
+            {{- if .mode.docker.externalRepo }}
+            secretName: {{ .mode.docker.secretName }}
+            {{- else }}
             secretName: gitea-credentials
+            {{- end }}
         - name: docker-credentials
           secret:
             secretName: harbor-pushsecret-builds
@@ -112,7 +116,11 @@ spec:
             storage: 1Gi
   - name: git-credentials
     secret:
+      {{- if .mode.docker.externalRepo }}
+      secretName: {{ .mode.docker.secretName }}
+      {{- else }}
       secretName: gitea-credentials
+      {{- end }}
   - name: docker-credentials
     secret:
       secretName: harbor-pushsecret-builds

--- a/tests/fixtures/env/teams/builds.demo.yaml
+++ b/tests/fixtures/env/teams/builds.demo.yaml
@@ -10,6 +10,7 @@ teamConfig:
                       revision: HEAD
                       path: ./Docker
                   type: docker
+              externalRepo: false
             - name: demo-java2
               tag: v.0.0.1
               trigger: false
@@ -19,6 +20,7 @@ teamConfig:
                       revision: HEAD
                       path: apps/java-maven
                   type: buildpacks
+              externalRepo: false
             - name: demo-java3
               tag: v_0_0_1
               trigger: true
@@ -27,6 +29,6 @@ teamConfig:
                       repoUrl: https://github.com/buildpacks/samples
                       revision: HEAD
                       path: ./Docker
-                      externalRepo: true
-                      secretName: my-secret
                   type: docker
+              externalRepo: true
+              secretName: my-secret

--- a/tests/fixtures/env/teams/builds.demo.yaml
+++ b/tests/fixtures/env/teams/builds.demo.yaml
@@ -27,4 +27,6 @@ teamConfig:
                       repoUrl: https://github.com/buildpacks/samples
                       revision: HEAD
                       path: ./Docker
+                      externalRepo: true
+                      secretName: my-secret
                   type: docker

--- a/tests/fixtures/env/teams/workloads.demo.yaml
+++ b/tests/fixtures/env/teams/workloads.demo.yaml
@@ -25,9 +25,11 @@ teamConfig:
               url: https://myrepo.local/mychart.git
               path: ./
               revision: main
+              imageUpdateStrategy:
+                  type: disabled
             - name: wd
               url: https://myrepo.local/mychart.git
               path: ./
               revision: main
-              autoUpdate:
-                  enabled: false
+              imageUpdateStrategy:
+                  type: disabled

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1365,6 +1365,14 @@ definitions:
                 description: A relative directory path within the Git repository.
                 type: string
                 default: ./Dockerfile
+              externalRepo:
+                type: boolean
+                description: Select when using an external private Git repository.
+                default: false
+              secretName:
+                description: The name of the secret with the credentials of the external private Git repository
+                example: my-git-credentials
+                type: string
           buildpacks:
             properties:
               repoUrl:
@@ -1376,6 +1384,14 @@ definitions:
                 default: HEAD
               path:
                 description: A relative directory path within the Git repository.
+                type: string
+              externalRepo:
+                type: boolean
+                description: Select when using an external private Git repository.
+                default: false
+              secretName:
+                description: The name of the secret with the credentials of the external private Git repository
+                example: my-git-credentials
                 type: string
     required:
       - name

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1350,6 +1350,13 @@ definitions:
       trigger:
         type: boolean
         default: false
+      externalRepo:
+        type: boolean
+        description: Select when using an external private Git repository.
+        default: false
+      secretName:
+        description: The name of the secret with the credentials of the external private Git repository
+        type: string
       mode:
         properties:
           docker:
@@ -1365,14 +1372,6 @@ definitions:
                 description: A relative directory path within the Git repository.
                 type: string
                 default: ./Dockerfile
-              externalRepo:
-                type: boolean
-                description: Select when using an external private Git repository.
-                default: false
-              secretName:
-                description: The name of the secret with the credentials of the external private Git repository
-                example: my-git-credentials
-                type: string
           buildpacks:
             properties:
               repoUrl:
@@ -1384,14 +1383,6 @@ definitions:
                 default: HEAD
               path:
                 description: A relative directory path within the Git repository.
-                type: string
-              externalRepo:
-                type: boolean
-                description: Select when using an external private Git repository.
-                default: false
-              secretName:
-                description: The name of the secret with the credentials of the external private Git repository
-                example: my-git-credentials
                 type: string
     required:
       - name


### PR DESCRIPTION
Now builds can only be created when using a repo in Gitea. To support the use of external private Git repo's, a user can now select to use a secret that contains the credentials of a external (like Github or Gitlab) private repo.
External public repo's and private repo's in Gitea are supported by default.
