### PR TITLE
fix: deploying teams

### DIFF
--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -68,5 +68,4 @@ spec:
         set -e
         # Prevent the detected dubious ownership in repository error
         git config --global --add safe.directory '*'
-        binzx/otomi apply-as-apps -f helmfile.d/helmfile-15.ingress-core.yaml -l pipeline=otomi-task-teams
-        binzx/otomi apply-as-apps -f helmfile.d/helmfile-60.teams.yaml
+        binzx/otomi apply-as-apps -l pipeline=otomi-task-teams

--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -68,5 +68,5 @@ spec:
         set -e
         # Prevent the detected dubious ownership in repository error
         git config --global --add safe.directory '*'
-        binzx/otomi apply-as-apps -f helmfile.d/helmfile-15.ingress-core.yaml -l team=admin
+        binzx/otomi apply-as-apps -f helmfile.d/helmfile-15.ingress-core.yaml -l pipeline=otomi-task-teams
         binzx/otomi apply-as-apps -f helmfile.d/helmfile-60.teams.yaml

--- a/helmfile.d/helmfile-15.ingress-core.yaml
+++ b/helmfile.d/helmfile-15.ingress-core.yaml
@@ -37,6 +37,7 @@ releases:
     labels:
       ingress: 'true'
       team: admin
+      pipeline: otomi-task-teams
     values:
       - name: admin
         teamId: admin

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -38,6 +38,7 @@ releases:
     labels:
       tag: teams
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     values:
       - ../values/tekton-dashboard/tekton-dashboard-teams.gotmpl
   - name: prometheus-{{ $teamId }}
@@ -47,6 +48,7 @@ releases:
     labels:
       tag: teams
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     values:
       - ../values/prometheus-operator/prometheus-operator.gotmpl
       - ../values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -198,6 +200,7 @@ releases:
     labels:
       tag: teams
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     values:
       - ../values/prometheus-msteams/prometheus-msteams.gotmpl
       - commonLabels:
@@ -217,6 +220,7 @@ releases:
     labels:
       tag: teams
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     values:
       - cluster: {{- $v.cluster | toYaml | nindent 10 }}
         team: {{ $teamId }}
@@ -243,6 +247,7 @@ releases:
       tag: teams
       ingress: 'true'
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     values:
       - cluster: {{- $v.cluster | toYaml | nindent 10 }}
         apps: {{- $a | toYaml | nindent 10 }}
@@ -268,6 +273,7 @@ releases:
       group: jobs
       tag: teams
       team: {{ $teamId }}
+      pipeline: otomi-task-teams
     hooks:
       - events: [presync]
         showlogs: true

--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -103,7 +103,7 @@ const writeApplicationManifest = async (release: HelmRelese, otomiVersion: strin
   await writeFile(applicationPath, objectToYaml(manifest))
 }
 export const applyAsApps = async (argv: HelmArguments): Promise<void> => {
-  const helmfileSource = argv.file?.length === 0 ? 'helmfile.d/' : argv.file?.toString()
+  const helmfileSource = argv.file?.toString() || 'helmfile.d/'
   d.info(`Parsing helm releases defined in ${helmfileSource}`)
   setup()
   const otomiVersion = await getImageTag()

--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -105,7 +105,7 @@ const writeApplicationManifest = async (release: HelmRelese, otomiVersion: strin
 export const applyAsApps = async (argv: HelmArguments): Promise<void> => {
   const helmfileSource = argv.file?.length === 0 ? 'helmfile.d/' : argv.file?.toString()
   d.info(`Parsing helm releases defined in ${helmfileSource}`)
-
+  setup()
   const otomiVersion = await getImageTag()
 
   const res = await hf({
@@ -161,7 +161,6 @@ export const module: CommandModule = {
 
   handler: async (argv: HelmArguments): Promise<void> => {
     setParsedArgs(argv)
-    setup()
     await prepareEnvironment()
     await applyAsApps(argv)
   },

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -85,12 +85,11 @@ const applyAll = async () => {
   let labelOpts = ['tag!=teams']
 
   if (!intitalInstall) {
-    // If Otomi has already been deployed, then team-ns-admin can be deployed as ArgoCD Application
     const params = cloneDeep(argv)
-    params.label = ['name=team-ns-admin']
+    params.label = ['team=admin']
+    // We still ned to deploy team admin as it contain ingress for platform apps
     await applyAsApps(params)
-    // Since team-ns-admin is deployed as app then we can exlude it for hf apply
-    labelOpts = ['tag!=teams', 'name!=team-ns-admin']
+    labelOpts = ['pipeline!=otomi-task-teams']
   }
 
   await hf(

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, rmdirSync, writeFileSync } from 'fs'
-import { isEmpty } from 'lodash'
+import { cloneDeep, isEmpty } from 'lodash'
 import { prepareDomainSuffix } from 'src/common/bootstrap'
 import { cleanupHandler, prepareEnvironment } from 'src/common/cli'
 import { logLevelString, terminal } from 'src/common/debug'
@@ -12,6 +12,7 @@ import { HelmArguments, getParsedArgs, helmOptions, setParsedArgs } from 'src/co
 import { ProcessOutputTrimmed } from 'src/common/zx-enhance'
 import { Argv, CommandModule } from 'yargs'
 import { $ } from 'zx'
+import { applyAsApps } from './apply-as-apps'
 import { cloneOtomiChartsInGitea, commit, printWelcomeMessage } from './commit'
 import { upgrade } from './upgrade'
 
@@ -79,16 +80,27 @@ const applyAll = async () => {
   await prepareDomainSuffix()
   // const applyLabel: string = process.env.OTOMI_DEV_APPLY_LABEL || 'stage!=prep'
   // d.info(`Deploying charts containing label ${applyLabel}`)
+
+  // The 'tag!=teams' does not include team-ns-admin release name
+  let labelOpts = ['tag!=teams']
+
+  if (!intitalInstall) {
+    // If Otomi has already been deployed, then team-ns-admin can be deployed as ArgoCD Application
+    const params = cloneDeep(argv)
+    params.label = ['name=team-ns-admin']
+    await applyAsApps(params)
+    // Since team-ns-admin is deployed as app then we can exlude it for hf apply
+    labelOpts = ['tag!=teams', 'name!=team-ns-admin']
+  }
+
   await hf(
     {
-      labelOpts: ['tag!=teams'],
+      labelOpts,
       logLevel: logLevelString(),
       args: ['apply'],
     },
     { streams: { stdout: d.stream.log, stderr: d.stream.error } },
   )
-  // argv.label = ['name=team-ns-admin']
-  // await applyAsApps(argv)
 
   await upgrade({ when: 'post' })
   if (!(env.isDev && env.DISABLE_SYNC)) {


### PR DESCRIPTION
This PR aims to fix the following issues:
- team-ns-admin release should not be deployed by helmfile in otomi-tekton-task 
- otomi-tekton-task-teams should not break if there is no team defined