### PR TITLE
fix: team monitoring stack schema change

### DIFF
--- a/charts/team-ns/templates/istio-sidecar.yaml
+++ b/charts/team-ns/templates/istio-sidecar.yaml
@@ -1,6 +1,6 @@
 {{- $v := .Values | merge (dict) }}
 {{- $ := . }}
-{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
+{{- $prometheus := dig "managedMonitoring" "prometheus" false $v }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $egressFilteringEnabled := $v | dig "networkPolicy" "egressPublic" true }}
 {{- if $egressFilteringEnabled }}
@@ -13,7 +13,7 @@ metadata:
 spec:
   outboundTrafficPolicy: 
     mode: REGISTRY_ONLY
-{{- if $hasProm }}
+{{- if $prometheus }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
@@ -29,7 +29,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $hasProm }}
+{{- if $prometheus }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/charts/team-ns/templates/istio-sidecar.yaml
+++ b/charts/team-ns/templates/istio-sidecar.yaml
@@ -1,5 +1,6 @@
 {{- $v := .Values | merge (dict) }}
 {{- $ := . }}
+{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $egressFilteringEnabled := $v | dig "networkPolicy" "egressPublic" true }}
 {{- if $egressFilteringEnabled }}
@@ -12,7 +13,7 @@ metadata:
 spec:
   outboundTrafficPolicy: 
     mode: REGISTRY_ONLY
-{{- if $v.managedMonitoring.prometheus }}
+{{- if $hasProm }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
@@ -28,7 +29,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $v.managedMonitoring.prometheus }}
+{{- if $hasProm }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/charts/team-ns/templates/istio-sidecar.yaml
+++ b/charts/team-ns/templates/istio-sidecar.yaml
@@ -1,6 +1,5 @@
 {{- $v := .Values | merge (dict) }}
 {{- $ := . }}
-{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $egressFilteringEnabled := $v | dig "networkPolicy" "egressPublic" true }}
 {{- if $egressFilteringEnabled }}
@@ -13,7 +12,7 @@ metadata:
 spec:
   outboundTrafficPolicy: 
     mode: REGISTRY_ONLY
-{{ if $hasStack }}
+{{- if $v.managedMonitoring.prometheus }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
@@ -29,7 +28,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if (dig "monitoringStack" "enabled" false $v) }}
+{{- if $v.managedMonitoring.prometheus }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,5 +1,7 @@
 {{/* Below merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
 {{- $v := .Values | merge (dict) }}
+{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
+{{- $hasAlert := dig "managedMonitoring" "alertmanager" false $v }}
 {{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -45,7 +47,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               name: tekton-pipelines
-{{- if $v.managedMonitoring.alertmanager }}
+{{- if $hasAlert }}
 ---
 # Allow traffic from team's prometheus to team's alertmanager
 apiVersion: networking.k8s.io/v1
@@ -68,13 +70,13 @@ spec:
   policyTypes:
     - Ingress
 {{- end }}
-{{- if $v.managedMonitoring.prometheus }}
+{{- if $hasProm }}
 ---
 # Allow traffic from Alertmanager and Grafana to Prometheus
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-to-team-prometheus
+  name: default-to-prometheus
   labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   ingress:
@@ -139,13 +141,13 @@ spec:
       app.kubernetes.io/managed-by: EventListener
   policyTypes:
     - Ingress
-{{- if $v.managedMonitoring.prometheus }}
+{{- if $hasProm }}
 ---
 # Allow traffic from Prometheus to all pods for scraping metrics
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-from-team-prometheus
+  name: default-from-prometheus
   labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   podSelector: {}

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,7 +1,7 @@
 {{/* Below merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
 {{- $v := .Values | merge (dict) }}
-{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
-{{- $hasAlert := dig "managedMonitoring" "alertmanager" false $v }}
+{{- $prometheus := dig "managedMonitoring" "prometheus" false $v }}
+{{- $alertmng := dig "managedMonitoring" "alertmanager" false $v }}
 {{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -47,7 +47,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               name: tekton-pipelines
-{{- if $hasAlert }}
+{{- if $alertmng }}
 ---
 # Allow traffic from team's prometheus to team's alertmanager
 apiVersion: networking.k8s.io/v1
@@ -70,7 +70,7 @@ spec:
   policyTypes:
     - Ingress
 {{- end }}
-{{- if $hasProm }}
+{{- if $prometheus }}
 ---
 # Allow traffic from Alertmanager and Grafana to Prometheus
 apiVersion: networking.k8s.io/v1
@@ -141,7 +141,7 @@ spec:
       app.kubernetes.io/managed-by: EventListener
   policyTypes:
     - Ingress
-{{- if $hasProm }}
+{{- if $prometheus }}
 ---
 # Allow traffic from Prometheus to all pods for scraping metrics
 apiVersion: networking.k8s.io/v1

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -1,6 +1,5 @@
 {{/* Below merge is a workaround for: https://github.com/helm/helm/issues/9266 */}}
 {{- $v := .Values | merge (dict) }}
-{{- $hasStack := dig "monitoringStack" "enabled" false $v }}
 {{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -46,6 +45,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               name: tekton-pipelines
+{{- if $v.managedMonitoring.alertmanager }}
 ---
 # Allow traffic from team's prometheus to team's alertmanager
 apiVersion: networking.k8s.io/v1
@@ -67,12 +67,14 @@ spec:
       app.kubernetes.io/instance: {{ $v.teamId }}-po-alertmanager
   policyTypes:
     - Ingress
+{{- end }}
+{{- if $v.managedMonitoring.prometheus }}
 ---
-# Allow traffic from team's kube-state-metrics + team's alertmanager to team's prometheus
+# Allow traffic from Alertmanager and Grafana to Prometheus
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-to-prometheus
+  name: default-to-team-prometheus
   labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
 spec:
   ingress:
@@ -95,7 +97,7 @@ spec:
   policyTypes:
     - Ingress
 ---
-# Allow traffic from team's prometheus to team's kube-state-metrics
+# Allow traffic from Prometheus to kube-state-metrics
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -115,6 +117,7 @@ spec:
       app.kubernetes.io/name: kube-state-metrics
   policyTypes:
     - Ingress
+{{- end }}
 ---
 # Allow webhook traffic from gitea to event listeners
 apiVersion: networking.k8s.io/v1
@@ -136,8 +139,9 @@ spec:
       app.kubernetes.io/managed-by: EventListener
   policyTypes:
     - Ingress
-{{- if $hasStack }}
+{{- if $v.managedMonitoring.prometheus }}
 ---
+# Allow traffic from Prometheus to all pods for scraping metrics
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -154,7 +158,7 @@ spec:
               name: team-{{ $v.teamId }}
           podSelector:
             matchLabels:
-              otomi.io/app: prometheus-team-{{ $v.teamId }}
+              app.kubernetes.io/instance: {{ $v.teamId }}-po-prometheus
 {{- end }}
   {{- range $s := $v.services }}
     {{- $isKnativeService := dig "ksvc" "predeployed" false $s }}

--- a/charts/team-ns/templates/servicemonitors/service-monitors.yaml
+++ b/charts/team-ns/templates/servicemonitors/service-monitors.yaml
@@ -1,8 +1,10 @@
 {{- $v := .Values | merge (dict) }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $ns := .Release.Namespace }}
-{{- if (dig "managedMonitoring.prometheus" "enabled" false $v) }}
-{{- if $v.apps.alertmanager.enabled }}
+{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
+{{- $hasAlert := dig "managedMonitoring" "alertmanager" false $v }}
+{{- $hasGraf := dig "managedMonitoring" "grafana" false $v }}
+{{- if $hasAlert }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -25,7 +27,7 @@ spec:
       release: prometheus-{{ $v.teamId }}
 {{- end }}
 ---
-{{- if $v.apps.prometheus.enabled }}
+{{- if $hasProm }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -46,7 +48,7 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if $v.apps.grafana.enabled }}
+{{- if $hasGraf }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/team-ns/templates/servicemonitors/service-monitors.yaml
+++ b/charts/team-ns/templates/servicemonitors/service-monitors.yaml
@@ -1,10 +1,10 @@
 {{- $v := .Values | merge (dict) }}
+{{- $prometheus := dig "managedMonitoring" "prometheus" false $v }}
+{{- $alertmng := dig "managedMonitoring" "alertmanager" false $v }}
+{{- $grafana := dig "managedMonitoring" "grafana" false $v }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $ns := .Release.Namespace }}
-{{- $hasProm := dig "managedMonitoring" "prometheus" false $v }}
-{{- $hasAlert := dig "managedMonitoring" "alertmanager" false $v }}
-{{- $hasGraf := dig "managedMonitoring" "grafana" false $v }}
-{{- if $hasAlert }}
+{{- if $alertmng }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -27,7 +27,7 @@ spec:
       release: prometheus-{{ $v.teamId }}
 {{- end }}
 ---
-{{- if $hasProm }}
+{{- if $prometheus }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -46,9 +46,8 @@ spec:
       app: {{ $v.teamId }}-po-prometheus
       release: prometheus-{{ $v.teamId }}
 {{- end }}
-{{- end }}
 ---
-{{- if $hasGraf }}
+{{- if $grafana }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/team-ns/templates/servicemonitors/service-monitors.yaml
+++ b/charts/team-ns/templates/servicemonitors/service-monitors.yaml
@@ -1,7 +1,7 @@
 {{- $v := .Values | merge (dict) }}
 {{- if not (eq $v.teamId "admin") }}
 {{- $ns := .Release.Namespace }}
-{{- if (dig "monitoringStack" "enabled" false $v) }}
+{{- if (dig "managedMonitoring.prometheus" "enabled" false $v) }}
 {{- if $v.apps.alertmanager.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -12,8 +12,8 @@ teamConfig:
                 url: https://slack.con
         managedMonitoring:
             grafana: true
-            prometheus: false
-            alertmanager: false
+            prometheus: true
+            alertmanager: true
         billingAlertQuotas:
             teamCpuMonthQuotaReached:
                 quota: 150

--- a/tests/integration/minimal-with-team.yaml
+++ b/tests/integration/minimal-with-team.yaml
@@ -20,8 +20,10 @@ teamConfig:
       service:
         - ingress
         - networkPolicy
-    monitoringStack:
-      enabled: false
+    managedMonitoring:
+      grafana: false
+      prometheus: false
+      alertmanager: false
     networkPolicy:
       egressPublic: true
       ingressPrivate: true

--- a/tests/integration/monitoring-with-team.yaml
+++ b/tests/integration/monitoring-with-team.yaml
@@ -50,8 +50,8 @@ teamConfig:
         - networkPolicy
     managedMonitoring:
       grafana: true
-      prometheus: false
-      alertmanager: false
+      prometheus: true
+      alertmanager: true
     networkPolicy:
       egressPublic: false
       ingressPrivate: false

--- a/tests/integration/monitoring-with-team.yaml
+++ b/tests/integration/monitoring-with-team.yaml
@@ -48,8 +48,10 @@ teamConfig:
       service:
         - ingress
         - networkPolicy
-    monitoringStack:
-      enabled: true
+    managedMonitoring:
+      grafana: true
+      prometheus: false
+      alertmanager: false
     networkPolicy:
       egressPublic: false
       ingressPrivate: false


### PR DESCRIPTION
This PR fixes some last issues in the team sidecar, netpol and servicemonitor configuration after changing the team monitoring stack schema
