### PR TITLE
feat: enhance otomi pipeline

### DIFF
--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -15,6 +15,8 @@ spec:
       description: Otomi version as in values/env/settings.yaml
     - name: TRIGGER_TEAMS_PIPELINE
       description: Determine if the otomi-task-teams is about to run
+    - name: TRIGGER_PLATFORM_PIPELINE
+      description: Determine if the otomi-task is about to run
   workspaces:
     - name: source
       mountPath: /home/app/stack/env/
@@ -66,6 +68,11 @@ spec:
         # Check if team files has been changed
         if git diff --name-only  HEAD~1 | grep  -e "env/.*.teams" -e "env/teams"; then
           echo -n "1" > $(results.TRIGGER_TEAMS_PIPELINE.path) 
+        fi
+
+        # Check if there is any other change than in teams/ dir
+        if git diff --name-only HEAD~1 | grep -v "env/teams/"; then
+          echo -n "1" > $(results.TRIGGER_PLATFORM_PIPELINE.path)
         fi
       args:
         - '$(params["commitMessage"])'

--- a/charts/otomi-pipelines/templates/tekton-pipeline.yaml
+++ b/charts/otomi-pipelines/templates/tekton-pipeline.yaml
@@ -50,6 +50,9 @@ spec:
         - input: $(tasks.otomi-git-clone.results.CI)
           operator: in
           values: ['1']
+        - input: $(tasks.otomi-git-clone.results.TRIGGER_PLATFORM_PIPELINE)
+          operator: in
+          values: ['1']
     - name: otomi-task-teams
       params:
         - name: repoUrl

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -87,8 +87,15 @@ const applyAll = async () => {
   if (!intitalInstall) {
     const params = cloneDeep(argv)
     params.label = ['team=admin']
-    // We still ned to deploy team admin as it contain ingress for platform apps
+    // We still need to deploy team admin as it contain ingress for platform apps
     await applyAsApps(params)
+
+    // We still need to deploy teams because some settings depend on platform apps
+    // We deploy it separately to ensure error isolation
+    params.label = ['tag=teams']
+    await applyAsApps(params)
+
+    // We ensure that helmfile does not deploy any team related Helm release
     labelOpts = ['pipeline!=otomi-task-teams']
   }
 

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -86,13 +86,9 @@ const applyAll = async () => {
 
   if (!intitalInstall) {
     const params = cloneDeep(argv)
-    params.label = ['team=admin']
-    // We still need to deploy team admin as it contain ingress for platform apps
-    await applyAsApps(params)
-
-    // We still need to deploy teams because some settings depend on platform apps
-    // We deploy it separately to ensure error isolation
-    params.label = ['tag=teams']
+    // We still need to deploy all teams because some settings depend on platform apps
+    // We still need to deploy team admin because it contains ingress for platform apps
+    params.label = ['pipeline=otomi-task-teams']
     await applyAsApps(params)
 
     // We ensure that helmfile does not deploy any team related Helm release


### PR DESCRIPTION
This PR aims to solve the following issues:
- team `ArgoCD app` reconfiguration on `otomi.version` upgrade 
- team `ArgoCD  app(s)` reconfiguration on platform app enable
- do not run platform pipeline there are no other changes than in env/teams/

Note: 
- this code change ensures that team `ArgoCD app` is always deployed in platform pipeline. 
## Checklist
- [x] add new team service => run only team pipeline
- [x] add a new team => run both pipelines
- [x] change team settings => run both pipelines
- [x] enable platform app => run only platform pipeline
- [x] install Otomi from scratch without any team
- [ ] install Otomi from scratch with a team