### PR TITLE
fix: add netpol podselector

### DIFF
--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -178,9 +178,17 @@ spec:
     matchLabels:
         {{- if $isKnativeService }}
       # The app label cannot be used because Knative appends revision number to the service
-      serving.knative.dev/service: {{ $s.name }}
+            {{- if hasKey $s.networkPolicy "podSelector" }}
+      serving.knative.dev/service: {{ $s.networkPolicy.podSelector }}
+            {{- else }}
+      serving.knative.dev/service: {{ $s.name }} 
+            {{- end }}  
         {{- else }}
+            {{- if hasKey $s.networkPolicy "podSelector" }}
+      otomi.io/app: {{ $s.networkPolicy.podSelector }}
+            {{- else }}
       otomi.io/app: {{ $s.name }}
+            {{- end }}
         {{- end }}
   policyTypes:
     - Ingress
@@ -201,9 +209,17 @@ spec:
     matchLabels:
         {{- if $isKnativeService }}
       # The app label cannot be used because Knative appends revision number to its value
-      serving.knative.dev/service: {{ $s.name }}
+            {{- if hasKey $s.networkPolicy "podSelector" }}
+      serving.knative.dev/service: {{ $s.networkPolicy.podSelector }}
+            {{- else }}
+      serving.knative.dev/service: {{ $s.name }} 
+            {{- end }}  
         {{- else }}
+            {{- if hasKey $s.networkPolicy "podSelector" }}
+      otomi.io/app: {{ $s.networkPolicy.podSelector }}
+            {{- else }}
       otomi.io/app: {{ $s.name }}
+            {{- end }}
         {{- end }}
   policyTypes:
     - Ingress
@@ -224,7 +240,7 @@ spec:
               name: team-{{ .team }}
           podSelector:
             matchLabels:
-              serving.knative.dev/service: {{ .service}}
+              serving.knative.dev/service: {{ .service }}
             {{- end }}
           {{- end }}
         {{- end }}

--- a/tests/fixtures/env/teams/services.demo.yaml
+++ b/tests/fixtures/env/teams/services.demo.yaml
@@ -59,6 +59,7 @@ teamConfig:
               type: public
             - name: service-a
               networkPolicy:
+                  podSelector: test-label-value
                   egressPublic:
                       - domain: domain1.com
                         ports:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -646,9 +646,11 @@ definitions:
   networkPolicy:
     additionalProperties: false
     properties:
-      ingressPrivate:
+      podSelector:
+        type: string
         title: Internal ingress filtering
         description: 'Pods belonging to this service must contain "otomi.io/app: <service name>" label'
+      ingressPrivate:
         oneOf:
           - title: Deny all
             description: Deny traffic from all teams (including this one)
@@ -670,12 +672,12 @@ definitions:
                   type: object
                   properties:
                     team:
-                      title: Team name
-                      description: 'Allow traffic from a given team'
+                      title: FROM team name
+                      description: Allow traffic from a given team
                       type: string
                     service:
-                      title: Service name
-                      description: 'Allow traffic from pods with "otomi.io/app: <some service name>" label'
+                      title: FROM label value
+                      description: 'Allow traffic from pods with label "otomi.io/app: <value>"'
                       type: string
                   required:
                     - team


### PR DESCRIPTION
optionally set a custom value for the `otomi.io/app` label. Default is set to the name of the service. This allows to configure netpols when multiple services are used within a workload and all pods have the same `otomi.io/app` label value.
