### PR TITLE
fix: loki query frontend rolling update on teamConfig change

### DIFF
--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -239,6 +239,8 @@ distributor:
 
 queryFrontend:
   resources: {{- $l.resources.queryFrontend | toYaml | nindent 4 }}
+  podAnnotations:
+    rollme: {{ randAlphaNum 5 | quote }}
   autoscaling:
     enabled: {{ $l.autoscaling.queryFrontend.enabled }}
     minReplicas: {{ $l.autoscaling.queryFrontend.minReplicas }}

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -240,7 +240,7 @@ distributor:
 queryFrontend:
   resources: {{- $l.resources.queryFrontend | toYaml | nindent 4 }}
   podAnnotations:
-    checksum/team-config: {{ sha256sum ( toJson $v.teamConfig ) }}
+    checksum/team-config: {{ ( toString (keys $v.teamConfig | sortAlpha ) ) | sha256sum }}
   autoscaling:
     enabled: {{ $l.autoscaling.queryFrontend.enabled }}
     minReplicas: {{ $l.autoscaling.queryFrontend.minReplicas }}

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -240,7 +240,7 @@ distributor:
 queryFrontend:
   resources: {{- $l.resources.queryFrontend | toYaml | nindent 4 }}
   podAnnotations:
-    rollme: {{ randAlphaNum 5 | quote }}
+    checksum/team-config: {{ sha256sum ( toJson $v.teamConfig ) }}
   autoscaling:
     enabled: {{ $l.autoscaling.queryFrontend.enabled }}
     minReplicas: {{ $l.autoscaling.queryFrontend.minReplicas }}


### PR DESCRIPTION
A fix for Loki queryfrontend to do a rolling update to reload the authentication secret whenever there is a change in the teamConfig.
