### PR TITLE
fix: loki platform url

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -300,7 +300,7 @@ adminApps:
     tags: [logging, telemetry, observability]
     deps: [grafana, prometheus, minio]
     useHost: grafana
-    path: /explore?orgId=1&left=%5B"now-1h","now","Loki",%7B%7D,%7B"mode":"Logs"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D
+    path: /explore?orgId=1&left=%7B"datasource":"loki","queries":%5B%7B"refId":"A"%7D%5D,"range":%7B"from":"now-1h","to":"now"%7D%7D
     shortcuts:
       - title: Ingress logs
         description: All logs generated in the "ingress" namespace


### PR DESCRIPTION
A fix for this issue in the Loki platform URL:


<img width="1193" alt="Screenshot 2024-01-02 at 11 01 25" src="https://github.com/redkubes/otomi-core/assets/53382213/364e5900-0ee7-47c5-ae6b-c06039f31697">
