### PR TITLE
feat: migrate values

### DIFF
--- a/.values/env/settings.yaml
+++ b/.values/env/settings.yaml
@@ -1,1 +1,1 @@
-version: 16
+version: 17

--- a/.values/env/teams.yaml
+++ b/.values/env/teams.yaml
@@ -1,3 +1,7 @@
 teamConfig:
     admin:
         id: admin
+        managedMonitoring:
+            alertmanager: true
+            grafana: true
+            prometheus: true

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -777,7 +777,7 @@ environments:
           upgrade:
             version: main
         # TODO: update this when schema version changes: (and think more?)
-        version: 16
+        version: 17
         letsencryptRootCA: |
           -----BEGIN CERTIFICATE-----
           MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "jest-ts-auto-mock": "2.1.0",
         "json-schema-to-typescript": "10.1.5",
         "json2ts": "0.0.7",
-        "jsonpath": "1.1.1",
+        "jsonpath": "^1.1.1",
         "lint-staged": "10.5.4",
         "npm-run-all": "4.1.5",
         "prettier": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jest-ts-auto-mock": "2.1.0",
     "json-schema-to-typescript": "10.1.5",
     "json2ts": "0.0.7",
-    "jsonpath": "1.1.1",
+    "jsonpath": "^1.1.1",
     "lint-staged": "10.5.4",
     "npm-run-all": "4.1.5",
     "prettier": "2.7.1",

--- a/tests/fixtures/env/secrets.teams.yaml
+++ b/tests/fixtures/env/secrets.teams.yaml
@@ -4,6 +4,8 @@ teamConfig:
             email:
                 critical: admins@yourdoma.in
                 nonCritical: admins@yourdoma.in
+            slack:
+                url: https://slack.con
         password: somesecretvalue
     admin:
         password: YTrnkdUsKPcGATfg

--- a/tests/fixtures/env/secrets.teams.yaml
+++ b/tests/fixtures/env/secrets.teams.yaml
@@ -9,3 +9,5 @@ teamConfig:
         password: somesecretvalue
     admin:
         password: YTrnkdUsKPcGATfg
+    dev:
+        password: IkdUsKPcGAdanjas

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -121,4 +121,4 @@ status:
         deployingVersion: 0.21.0
         status: deployed
         version: 0.21.0
-version: 16
+version: 17

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -1,30 +1,29 @@
 teamConfig:
     admin:
         id: admin
-    dev:
-        id: dev
-        services: []
-        password: ''
-        test: test
+        managedMonitoring:
+            alertmanager: true
+            grafana: true
+            prometheus: true
     demo:
         alerts:
+            email: {}
             receivers:
                 - slack
             repeatInterval: 3h
             slack:
                 channel: aaaaa
                 channelCrit: aaaaa
-                url: https://slack.con
-        managedMonitoring:
-            grafana: true
-            prometheus: true
-            alertmanager: true
         billingAlertQuotas:
             teamCpuMonthQuotaReached:
                 quota: 150
             teamMemMonthQuotaReached:
                 quota: 200
         id: demo
+        managedMonitoring:
+            alertmanager: true
+            grafana: true
+            prometheus: true
         networkPolicy:
             egressPublic: true
             ingressPrivate: true
@@ -39,3 +38,9 @@ teamConfig:
                 - networkPolicy
             team:
                 - alerts
+    dev:
+        id: dev
+        managedMonitoring:
+            alertmanager: true
+            grafana: true
+            prometheus: true

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -1,6 +1,11 @@
 teamConfig:
     admin:
         id: admin
+    dev:
+        id: dev
+        services: []
+        password: ''
+        test: test
     demo:
         alerts:
             receivers:

--- a/tests/fixtures/env/teams/apps.dev.yaml
+++ b/tests/fixtures/env/teams/apps.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        apps: {}

--- a/tests/fixtures/env/teams/backups.dev.yaml
+++ b/tests/fixtures/env/teams/backups.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        backups: []

--- a/tests/fixtures/env/teams/builds.dev.yaml
+++ b/tests/fixtures/env/teams/builds.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        builds: []

--- a/tests/fixtures/env/teams/external-secrets.dev.yaml
+++ b/tests/fixtures/env/teams/external-secrets.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        secrets: []

--- a/tests/fixtures/env/teams/jobs.dev.yaml
+++ b/tests/fixtures/env/teams/jobs.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        jobs: []

--- a/tests/fixtures/env/teams/services.dev.yaml
+++ b/tests/fixtures/env/teams/services.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        services: []

--- a/tests/fixtures/env/teams/workloads.dev.yaml
+++ b/tests/fixtures/env/teams/workloads.dev.yaml
@@ -1,0 +1,3 @@
+teamConfig:
+    dev:
+        workloads: []

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -106,3 +106,10 @@ changes:
       - platformBackups.persistentVolumes.kubeapps
     additions:
       - apps.drone.enabled: true
+  - version: 16
+    deletions:
+      - 'teamConfig.{team}.monitoringStack'
+    additions:
+      - 'teamConfig.{team}.managedMonitoring.alertmanager': true
+      - 'teamConfig.{team}.managedMonitoring.grafana': true
+      - 'teamConfig.{team}.managedMonitoring.prometheus': true

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -106,7 +106,7 @@ changes:
       - platformBackups.persistentVolumes.kubeapps
     additions:
       - apps.drone.enabled: true
-  - version: 16
+  - version: 17
     deletions:
       - 'teamConfig.{team}.monitoringStack'
     additions:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
