### PR TITLE
fix: add env vars for paketo

### DIFF
--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -47,6 +47,13 @@ spec:
       value: {{ .mode.buildpacks.path }}
     - name: BUILDER_IMAGE
       value: paketobuildpacks/builder:full
+      {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
+    - name: ENV_VARS
+      value: 
+        {{- range . }}
+        - {{ .name }}={{ .value }}
+        {{- end }}
+      {{- end }}
 ---
 {{- if .trigger }}
 apiVersion: triggers.tekton.dev/v1alpha1

--- a/tests/fixtures/env/teams/builds.demo.yaml
+++ b/tests/fixtures/env/teams/builds.demo.yaml
@@ -19,6 +19,11 @@ teamConfig:
                       repoUrl: https://github.com/buildpacks/samples
                       revision: HEAD
                       path: apps/java-maven
+                      envVars:
+                          - name: TEST1
+                            value: test1
+                          - name: TEST2
+                            value: test2
                   type: buildpacks
               externalRepo: false
             - name: demo-java3

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1394,6 +1394,18 @@ definitions:
               path:
                 description: A relative directory path within the Git repository.
                 type: string
+              envVars:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                    - name
+                    - value
     required:
       - name
 


### PR DESCRIPTION
To use Gradle in Paketo buildpacks we need to add some additional variables to the pipeline. Note that the values of these variables are now stored as plain text. This will be solved with the introduction of sealed secrets in Otomi.