### PR TITLE
fix: tekton platform path

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -288,6 +288,7 @@ adminApps:
   - name: tekton
     tags: [buildpacks, ci, pipelines]
     ownHost: true
+    path: /#/namespaces/otomi-pipelines/pipelineruns
     ingress:
       - svc: tekton-dashboard
         namespace: tekton-pipelines


### PR DESCRIPTION
Add path to tekton in core.yaml for adminApps (platform), so link directly shows all the pipelineruns
