### PR TITLE
fix: buildpacks source subpath

### DIFF
--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -43,8 +43,10 @@ spec:
     params:
     - name: APP_IMAGE
       value: harbor.{{ $v.cluster.domainSuffix }}/team-{{ $v.teamId }}/{{ .name }}:{{ .tag }}
+    {{- with .mode.buildpacks.path }}
     - name: SOURCE_SUBPATH
-      value: {{ .mode.buildpacks.path }}
+      value: {{ . }}
+    {{- end }}
     - name: BUILDER_IMAGE
       value: paketobuildpacks/builder:full
       {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}


### PR DESCRIPTION
The `SOURCE_SUBPATH` empty value (default) results in an out-of-sync. This fix makes sure the subpath is only added if a value is provided.

Before:

<img width="1084" alt="Screenshot 2024-01-05 at 10 13 46" src="https://github.com/redkubes/otomi-core/assets/53382213/9c4324e2-1279-4f3f-acac-2857f6217223">

After:

<img width="1089" alt="Screenshot 2024-01-05 at 10 27 28" src="https://github.com/redkubes/otomi-core/assets/53382213/5ddccd78-26ba-4724-9302-7f40d301a7f5">

