### PR TITLE
fix: change created to published

### DIFF
--- a/.github/workflows/slackbot-release.yml
+++ b/.github/workflows/slackbot-release.yml
@@ -3,7 +3,7 @@ name: Slackbot on release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   notify_slack:


### PR DESCRIPTION
This PR changes release type from created to published.
Now workflow gets triggered if the release was a draft first
