### PR TITLE
fix: ksvc url

### DIFF
--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,7 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
-      domain-template: {{`{{.Name}}-{{.Namespace}}.{{.Domain}}`}}
+      domain-template: {{`{{`}}.Name{{`}}`}}-{{`{{`}}.Namespace{{`}}`}}.{{`{{`}}.Domain{{`}}`}}
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s

--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,6 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
+      domain-template: '{{.Name}}-{{.Namespace}}.{{.Domain}}'
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s

--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,7 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
-      domain-template: {{ printf "{{.Name}}-{{.Namespace}}.{{.Domain}}" }}
+      domain-template: {{`{{.Name}}`}}-{{`{{.Namespace}}`}}.{{`{{.Domain}}`}}
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s

--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,7 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
-      domain-template: {{`{{`}}.Name{{`}}`}}-{{`{{`}}.Namespace{{`}}`}}.{{`{{`}}.Domain{{`}}`}}
+      domain-template: {{ printf "{{.Name}}-{{.Namespace}}.{{.Domain}}" }}
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s

--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,7 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
-      domain-template: {{`{{.Name}}`}}-{{`{{.Namespace}}`}}.{{`{{.Domain}}`}}
+      domain-template: "{{`{{.Name}}`}}-{{`{{.Namespace}}`}}.{{`{{.Domain}}`}}"
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s

--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,7 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
-      domain-template: '{{.Name}}-{{.Namespace}}.{{.Domain}}'
+      domain-template: {{`{{.Name}}-{{.Namespace}}.{{.Domain}}`}}
     autoscaler:
       stable-window: 600s
       scale-to-zero-grace-period: 60s


### PR DESCRIPTION
Change ksvc URL template for usingmwildcard certificates that only support a single level of domain name added to the certificate's domain
