### PR TITLE
feat: always install prometheus and alertmanger operator

### DIFF
--- a/helmfile.d/helmfile-08.init.yaml
+++ b/helmfile.d/helmfile-08.init.yaml
@@ -19,12 +19,10 @@ releases:
       pkg: prometheus-operator
     <<: *raw
   - name: prometheus-operator
-    # we turn on the whole chart just by checking prometheus (not alertmanager or grafana, as all should be on)
-    installed: {{ $a | get "prometheus.enabled" }}
+    installed: true
     namespace: monitoring
     labels:
       pkg: prometheus-operator
-    # chart: ../charts/prometheus-operator
     chart: ../charts/kube-prometheus-stack
     values:
       - ../values/prometheus-operator/prometheus-operator.gotmpl

--- a/tests/fixtures/env/apps/grafana.yaml
+++ b/tests/fixtures/env/apps/grafana.yaml
@@ -1,3 +1,3 @@
 apps:
     grafana:
-        enabled: true
+        enabled: false

--- a/tests/fixtures/env/apps/opencost.yaml
+++ b/tests/fixtures/env/apps/opencost.yaml
@@ -2,7 +2,7 @@ apps:
     opencost:
         enabled: true
         alerts:
-            enabled: true
+            enabled: false
             costOfAllNodesQuotaPerMonthReached:
                 quota: 500
         keys:

--- a/tests/fixtures/env/apps/prometheus.yaml
+++ b/tests/fixtures/env/apps/prometheus.yaml
@@ -1,6 +1,6 @@
 apps:
     prometheus:
-        enabled: true
+        enabled: false
         disabledRules:
             - InfoInhibitor
             - PrometheusOperatorListErrors

--- a/tests/fixtures/env/apps/thanos.yaml
+++ b/tests/fixtures/env/apps/thanos.yaml
@@ -1,6 +1,6 @@
 apps:
     thanos:
-        enabled: true
+        enabled: false
         compactor:
             retentionResolutionRaw: 0s
             retentionResolution5m: 0s

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -28,6 +28,7 @@ global:
 {{- end }}
 
 defaultRules:
+  create: {{ $p.enabled }}
   disabled:
     {{- range $p.disabledRules }}
     {{ . }}: true
@@ -244,7 +245,7 @@ grafana:
           enabled: true
     {{- end }}
   serviceMonitor:
-    # namespace: grafana
+    enabled: {{ $p.enabled }}
     labels:
       prometheus: system
 
@@ -254,6 +255,7 @@ grafana:
   plugins:
     - grafana-piechart-panel
   additionalDataSources:
+    {{- if $c.loki.enabled }}
     - name: Loki
       editable: false
       uid: loki
@@ -264,6 +266,7 @@ grafana:
       basicAuthUser: otomi-admin
       secureJsonData:
         basicAuthPassword: {{ $v.apps.loki.adminPassword }}
+    {{- end }}
     {{- if $c.tempo.enabled }}
       jsonData:
         derivedFields:
@@ -335,6 +338,12 @@ grafana:
     security:
       allow_embedding: true
 
+kubernetesServiceMonitors:
+  enabled: {{ $p.enabled }}
+
+kubeStateMetrics:
+  enabled: {{ $p.enabled }}
+
 kube-state-metrics:
   prometheus:
     monitor:
@@ -356,6 +365,10 @@ kube-state-metrics:
       cpu: 100m
       memory: 128Mi
     {{- end }}
+
+
+nodeExporter:
+  enabled: {{ $p.enabled }}
 
 prometheus-node-exporter:
   prometheus:


### PR DESCRIPTION
Teams need to be able to activate prometheus and alertmanager independent of the platform prometheus and alertmanager. This feat makes sure the prometheus and alertmanager operators are always installed.

Note: this first needs to be tested. Fixtures have been adjusted for this use-case (and need to be restored)
