### PR TITLE
fix: digitalocean release

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -355,7 +355,8 @@ jobs:
           # Cluster name must be no longer than 63 characters
       - name: Determine exact k8s version
         run: |
-          echo DIGITALOCEAN_K8S_VERSION=`doctl kubernetes options versions -o json | jq -re 'map(select(.kubernetes_versions | startswith("${{ matrix.kubernetes_versions }}"))) | .[0] | .slug'` >> $GITHUB_ENV
+          echo "DIGITALOCEAN_K8S_VERSION=$(doctl kubernetes options versions -o json | jq -r '.[] | select(.kubernetes_version | startswith("${{ matrix.kubernetes_versions }}")) | .slug')" >> $GITHUB_ENV
+
       - name: Get default VPC for region
         run: |
           echo DIGITALOCEAN_VPC_UUID=`doctl vpcs list -o json | jq -re 'map(select((.region == "ams3") and .default)) | .[0] | .id'` >> $GITHUB_ENV

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -351,7 +351,7 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Set k8s cluster name
         run: |
-          echo DIGITALOCEAN_CLUSTER_NAME=${{ github.actor }}-$(TZ="GMT-2" date +"%m-%d-%H-%M") >> $GITHUB_ENV
+          echo "DIGITALOCEAN_CLUSTER_NAME=$(echo ${{ github.actor }} | tr '[:upper:]' '[:lower:]')-$(TZ='GMT-2' date +'%m-%d-%H-%M')" >> $GITHUB_ENV
           # Cluster name must be no longer than 63 characters
       - name: Determine exact k8s version
         run: |


### PR DESCRIPTION
This PR fixes te issues with digitalocean workflow not working. It changes the clustername to lowercase and getting the slug version is working again.

[Ticket](https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/otomi-core/1471)