### PR TITLE
fix: node selector with argocd

### DIFF
--- a/charts/gatekeeper-artifacts/templates/_helpers.tpl
+++ b/charts/gatekeeper-artifacts/templates/_helpers.tpl
@@ -68,6 +68,7 @@ namespaces:
   {{- range $teamId := (.teamIds | sortAlpha) }}
   - team-{{ $teamId }}
   {{- end }}
+  - argocd
 {{- end -}}
 {{- end -}}
 

--- a/values/argocd-operator/argocd-operator-cr.gotmpl
+++ b/values/argocd-operator/argocd-operator-cr.gotmpl
@@ -46,6 +46,13 @@ spec:
       requests:
         cpu: 100m
         memory: 256M
+  {{- with $v.otomi | get "nodeSelector" nil }}
+  nodePlacement:
+    nodeSelector:
+      {{- range $key, $val := . }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
+  {{- end }}
   server:
     host: argocd.{{ $v.cluster.domainSuffix }}
     insecure: true # nginx terminates tls


### PR DESCRIPTION
Gatekeeper mutations do not work with Argo CD operator. This PR excludes the `argocd` namespace from the mutations and configured the Argo CD operator with the `nodePlacement.nodeSelector` when nodeSelector labels are set in Otomi.

```
apiVersion: mutations.gatekeeper.sh/v1alpha1
kind: Assign
metadata:
  name: set-platform-node-affinity-others
spec:
  applyTo:
    - groups: [apps]
      kinds: [Deployment, ReplicaSet, StatefulSet]
      versions: [v1]
    - groups: [batch]
      kinds: [Job]
      versions: [v1]
    - groups: [serving.knative.dev]
      kinds: [Service]
      versions: [v1]
  match:
    scope: Namespaced
    kinds:
      # We don't want DaemonSets to be given affinity (in Otomi all DSs are node exporters), so we explicitly 
      # whitelist everything creating pods since GK doesn't have an exclude approach for kinds.
      # This means that this list has to be kept up to date with whatever resource creating pods.
      # TODO: visit here when ading CRDs.
      - apiGroups: [apps]
        kinds: [Deployment, ReplicaSet, StatefulSet]
      - apiGroups: [batch]
        kinds: [Job]
      - apiGroups: [serving.knative.dev]
        kinds: [Service]
    excludedNamespaces:
      - team-admin
      - team-demo
      - team-dev
      - argocd
```
