### PR TITLE
fix: aws cluster schema

### DIFF
--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -298,18 +298,6 @@ definitions:
     required:
       - name
       - provider
-    allOf:
-      - oneOf:
-          - properties:
-              provider:
-                enum: [aws]
-            required:
-              - apiName
-              - region
-          - not:
-              properties:
-                provider:
-                  enum: [aws]
   clusterName:
     $ref: '#/definitions/wordCharacterPattern'
     type: string


### PR DESCRIPTION
The minimal required values for installing Otomi are `cluster.name` and `cluster.provider`. In the schema `cluster.apiName` and `cluster.region` where still required for the AWS provider. This PR removes this requirement.
