### PR TITLE
ci: reworked cluster and private network deletion

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -160,6 +160,8 @@ jobs:
     steps:
       - name: Install scw-cli
         uses: scaleway/action-scw@v0
+        with:
+          version: v2.26.0
       - id: k8s-versions
         name: Process k8s version input
         run: |
@@ -212,7 +214,7 @@ jobs:
         with:
           save-config: true
           export-config: true
-          version: v2.23.0
+          version: v2.26.0
           access-key: ${{ secrets.SCW_ACCESS_KEY }}
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
           default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           save-config: true
           export-config: true
-          version: v2.23.0
+          version: v2.26.0
           access-key: ${{ secrets.SCW_ACCESS_KEY }}
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
           default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}

--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           save-config: true
           export-config: true
-          version: v2.13.0
+          version: v2.26.0
           access-key: ${{ secrets.SCW_ACCESS_KEY }}
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
           default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}

--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -21,12 +21,55 @@ jobs:
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
           default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
           default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
-      - name: Delete Clusters and Private Networks in DEV
+      - name: Delete Clusters in DEV
         run: |
-          SCALEWAY_CLUSTER_IDS=$(scw k8s cluster list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-          echo Deleting Cluster\(s\) with ID\(s\): $SCALEWAY_CLUSTER_IDS
-          scw k8s cluster delete $SCALEWAY_CLUSTER_IDS with-additional-resources=true region=nl-ams --wait
+          # Set the maximum number of attempts
+          max_attempts=5
+          # Set a counter for the number of attempts
+          attempt_num=1
+          # Set a flag to indicate whether the command was successful
+          success=false
 
-          PRIVATE_NETWORK_IDS=$(scw vpc private-network list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-          echo Deleting Private Network\(s\) with ID\(s\):
-          scw vpc private-network delete region=nl-ams $PRIVATE_NETWORK_IDS
+          while [ $attempt_num -le $max_attempts ] && [ $success = false ]; do
+            echo "Attempt $attempt_num"
+            # Get the cluster IDs
+            SCALEWAY_CLUSTER_IDS=$(scw k8s cluster list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
+            # Try deleting the clusters
+            echo Trying to delete Cluster\(s\) with ID\(s\): $SCALEWAY_CLUSTER_IDS
+            scw k8s cluster delete $SCALEWAY_CLUSTER_IDS with-additional-resources=true region=nl-ams --wait
+            # Check if the command was successful
+            if [ $? -eq 0 ]; then
+              success=true
+            else
+              # Increment the counter
+              attempt_num=$[$attempt_num+1]
+              # Wait for 1 min before trying again
+              sleep 1m
+            fi
+          done
+      - name: Delete Private Networks in DEV
+        run: |
+          # Set the maximum number of attempts
+          max_attempts=5
+          # Set a counter for the number of attempts
+          attempt_num=1
+          # Set a flag to indicate whether the command was successful
+          success=false
+
+          while [ $attempt_num -le $max_attempts ] && [ $success = false ]; do
+            echo "Attempt $attempt_num"
+            # Get the private network IDs
+            PRIVATE_NETWORK_IDS=$(scw vpc private-network list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
+            # Try deleting the private networks
+            echo Trying to delete Private Network\(s\) with ID\(s\): $PRIVATE_NETWORK_IDS
+            scw vpc private-network delete region=nl-ams $PRIVATE_NETWORK_IDS
+            # Check if the command was successful
+            if [ $? -eq 0 ]; then
+              success=true
+            else
+              # Increment the counter
+              attempt_num=$[$attempt_num+1]
+              # Wait for 1 min before trying again
+              sleep 1m
+            fi
+          done


### PR DESCRIPTION
This PR tries to fix the daily cleanup task in scaleway by adding a retry mechanism. It will try up to 5 times with a distance of 1 minute if the deletion command fails either for clusters or private networks. This PR also updates the scw cli to version 2.26.0