### PR TITLE
ci: fix scheduled deletion of scaleway cluster and private networks

### DIFF
--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Delete Clusters in DEV
         run: |
           scw k8s cluster list project_id="${{ secrets.SCW_DEFAULT_PROJECT_ID }}" region=nl-ams -o template={{.ID}} | while read -r cluster_id; do
-            scw k8s cluster delete $cluster_id with-additional-resources=true region=nl-ams --wait || true
+            scw k8s cluster delete $cluster_id with-additional-resources=true region=nl-ams --wait || echo "Could not delete cluster: $cluster_id"
           done
 
       - name: Delete Private Networks in DEV
         run: |
           scw vpc private-network list project-id="e41d0c87-e67c-45be-9b28-9ca10d8d035f" -o template={{.ID}} | while read -r network_id; do
-            scw vpc private-network delete $network_id --wait || true
+            scw vpc private-network delete $network_id --wait || echo "Could not delete network: $network_id"
           done

--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Delete Private Networks in DEV
         run: |
-          scw vpc private-network list project-id="e41d0c87-e67c-45be-9b28-9ca10d8d035f" -o template={{.ID}} | while read -r network_id; do
+          scw vpc private-network list project-id="${{ secrets.SCW_DEFAULT_PROJECT_ID }}" -o template={{.ID}} | while read -r network_id; do
             scw vpc private-network delete $network_id --wait || echo "Could not delete network: $network_id"
           done

--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -23,53 +23,12 @@ jobs:
           default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
       - name: Delete Clusters in DEV
         run: |
-          # Set the maximum number of attempts
-          max_attempts=5
-          # Set a counter for the number of attempts
-          attempt_num=1
-          # Set a flag to indicate whether the command was successful
-          success=false
-
-          while [ $attempt_num -le $max_attempts ] && [ $success = false ]; do
-            echo "Attempt $attempt_num"
-            # Get the cluster IDs
-            SCALEWAY_CLUSTER_IDS=$(scw k8s cluster list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-            # Try deleting the clusters
-            echo Trying to delete Cluster\(s\) with ID\(s\): $SCALEWAY_CLUSTER_IDS
-            scw k8s cluster delete $SCALEWAY_CLUSTER_IDS with-additional-resources=true region=nl-ams --wait
-            # Check if the command was successful
-            if [ $? -eq 0 ]; then
-              success=true
-            else
-              # Increment the counter
-              attempt_num=$[$attempt_num+1]
-              # Wait for 1 min before trying again
-              sleep 1m
-            fi
+          scw k8s cluster list project_id="${{ secrets.SCW_DEFAULT_PROJECT_ID }}" region=nl-ams -o template={{.ID}} | while read -r cluster_id; do
+            scw k8s cluster delete $cluster_id with-additional-resources=true region=nl-ams --wait || true
           done
+
       - name: Delete Private Networks in DEV
         run: |
-          # Set the maximum number of attempts
-          max_attempts=5
-          # Set a counter for the number of attempts
-          attempt_num=1
-          # Set a flag to indicate whether the command was successful
-          success=false
-
-          while [ $attempt_num -le $max_attempts ] && [ $success = false ]; do
-            echo "Attempt $attempt_num"
-            # Get the private network IDs
-            PRIVATE_NETWORK_IDS=$(scw vpc private-network list region=nl-ams -o json | jq -r '.[] | select(.project_id == "${{ secrets.SCW_DEFAULT_PROJECT_ID }}") | .id')
-            # Try deleting the private networks
-            echo Trying to delete Private Network\(s\) with ID\(s\): $PRIVATE_NETWORK_IDS
-            scw vpc private-network delete region=nl-ams $PRIVATE_NETWORK_IDS
-            # Check if the command was successful
-            if [ $? -eq 0 ]; then
-              success=true
-            else
-              # Increment the counter
-              attempt_num=$[$attempt_num+1]
-              # Wait for 1 min before trying again
-              sleep 1m
-            fi
+          scw vpc private-network list project-id="e41d0c87-e67c-45be-9b28-9ca10d8d035f" -o template={{.ID}} | while read -r network_id; do
+            scw vpc private-network delete $network_id --wait || true
           done

--- a/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
+++ b/.github/workflows/scw-remove-clusters-dev-on-schedule.yml
@@ -23,7 +23,7 @@ jobs:
           default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
       - name: Delete Clusters in DEV
         run: |
-          scw k8s cluster list project_id="${{ secrets.SCW_DEFAULT_PROJECT_ID }}" region=nl-ams -o template={{.ID}} | while read -r cluster_id; do
+          scw k8s cluster list project-id="${{ secrets.SCW_DEFAULT_PROJECT_ID }}" region=nl-ams -o template={{.ID}} | while read -r cluster_id; do
             scw k8s cluster delete $cluster_id with-additional-resources=true region=nl-ams --wait || echo "Could not delete cluster: $cluster_id"
           done
 


### PR DESCRIPTION
This MR updated the code of the scheduled github workflow to execute the delete command for each cluster and private network. This way if a single instance can not be deleted it will be skipped and will not block the deletion of other instances.