### PR TITLE
feat: download otomi values

### DIFF
--- a/src/cmd/values.ts
+++ b/src/cmd/values.ts
@@ -2,7 +2,7 @@ import { prepareEnvironment } from 'src/common/cli'
 import { terminal } from 'src/common/debug'
 import { hfValues } from 'src/common/hf'
 import { getFilename } from 'src/common/utils'
-import { BasicArguments, getParsedArgs, setParsedArgs } from 'src/common/yargs'
+import { BasicArguments, setParsedArgs } from 'src/common/yargs'
 import { stringify } from 'yaml'
 import { Argv } from 'yargs'
 
@@ -13,10 +13,9 @@ interface Arguments extends BasicArguments {
   excludeSecrets?: boolean
 }
 
-const values = async (): Promise<void> => {
+const values = async (argv: Arguments): Promise<void> => {
   const d = terminal(`cmd:${cmdName}:values`)
   d.info('Get values')
-  const argv: Arguments = getParsedArgs()
   const hfVal = await hfValues({ filesOnly: argv.filesOnly, excludeSecrets: argv.excludeSecrets })
   d.info('Print values')
   console.log(stringify(hfVal))
@@ -41,6 +40,6 @@ export const module = {
   handler: async (argv: Arguments): Promise<void> => {
     setParsedArgs(argv)
     await prepareEnvironment({ skipKubeContextCheck: true })
-    await values()
+    await values(argv)
   },
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@ import { bootstrapSops } from 'src/cmd/bootstrap'
 import { validateValues } from 'src/cmd/validate-values'
 import { decrypt, encrypt } from 'src/common/crypt'
 import { terminal } from 'src/common/debug'
+import { hfValues } from './common/hf'
+import { objectToYaml } from './common/values'
 
 const d = terminal('server')
 const app = express()
@@ -53,6 +55,28 @@ app.get('/prepare', async (req: Request, res: Response) => {
       status = 422
     }
     res.status(status).send(err)
+  }
+})
+
+function parseBoolean(string) {
+  return string === 'true' ? true : string === 'false' ? false : false
+}
+app.get('/otomi/values', async (req: Request, res: Response) => {
+  const { envDir } = req.query as QueryParams
+
+  const filesOnly = parseBoolean(req.query.filesOnly)
+  const excludeSecrets = parseBoolean(req.query.excludeSecrets)
+  console.log(req.query)
+  try {
+    d.log('Get otomi values')
+    const data = await hfValues({ filesOnly, excludeSecrets }, envDir)
+    res.setHeader('Content-type', 'text/plain')
+    const yamlData = objectToYaml(data!)
+    res.status(200).send(yamlData)
+  } catch (error) {
+    const status = 500
+    d.error(error)
+    res.status(status).send(error)
   }
 })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,17 +58,16 @@ app.get('/prepare', async (req: Request, res: Response) => {
   }
 })
 
-function parseBoolean(string) {
-  return string === 'true' ? true : string === 'false' ? false : false
+function parseBoolean(string, defaultValue = false) {
+  return string === 'true' ? true : string === 'false' ? false : defaultValue
 }
 app.get('/otomi/values', async (req: Request, res: Response) => {
   const { envDir } = req.query as QueryParams
 
-  const filesOnly = parseBoolean(req.query.filesOnly)
-  const excludeSecrets = parseBoolean(req.query.excludeSecrets)
-  console.log(req.query)
+  const filesOnly = parseBoolean(req.query.filesOnly, true)
+  const excludeSecrets = parseBoolean(req.query.excludeSecrets, true)
+  d.log('Get otomi values', req.query)
   try {
-    d.log('Get otomi values')
     const data = await hfValues({ filesOnly, excludeSecrets }, envDir)
     res.setHeader('Content-type', 'text/plain')
     const yamlData = objectToYaml(data!)

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 2.4.0
-console: 2.3.0
+api: get-values
+console: get-values
 tasks: 2.3.0
 tools: 1.6.0


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
