### PR TITLE
feat: block public metrics endpoint for Gitea and Keycloak

### DIFF
--- a/charts/team-ns/templates/ingress/excpetions.yaml
+++ b/charts/team-ns/templates/ingress/excpetions.yaml
@@ -1,0 +1,21 @@
+{{- $v := .Values }}
+{{- if eq $v.teamId "admin" }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: otomi-forbidden-urls
+spec:
+  gateways:
+  - {{ $.Release.Namespace }}/team-admin-public-tlsterm
+  hosts:
+  - {{ $v._derived.giteaDomain }}
+  http:
+  - match:
+    - uri:
+        exact: /metrics
+    directResponse:
+      status: 403
+      body:
+        string: "Forbidden"
+{{- end }}

--- a/charts/team-ns/templates/ingress/excpetions.yaml
+++ b/charts/team-ns/templates/ingress/excpetions.yaml
@@ -10,6 +10,7 @@ spec:
   - {{ $.Release.Namespace }}/team-admin-public-tlsterm
   hosts:
   - {{ $v._derived.giteaDomain }}
+  - {{ $v._derived.keycloakDomain }}
   http:
   - match:
     - uri:

--- a/helmfile.d/helmfile-15.ingress-core.yaml
+++ b/helmfile.d/helmfile-15.ingress-core.yaml
@@ -41,6 +41,7 @@ releases:
     values:
       - name: admin
         teamId: admin
+        _derived: {{- toYaml $v._derived | nindent 10 }}
         teamIds: {{- toYaml (keys $v.teamConfig) | nindent 10 }}
         apps: {{- $a | toYaml | nindent 10 }}
         oidc: {{- $v.oidc | toYaml | nindent 10 }}

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -59,6 +59,7 @@ environments:
           oidcWellKnownUrl: {{ $oidcWellKnownUrl }}
           oidcWellKnownUrlBackchannel: {{ $oidcWellKnownBackchannel}}
           giteaDomain: {{ printf "gitea.%s" $domainSuffix }}
+          keycloakDomain: {{ printf "keycloak.%s" $domainSuffix }}
         apps:
           aws-alb-ingress-controller:
             enabled: {{ and (eq $provider "aws") $v.otomi.hasCloudLB }}

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -58,6 +58,7 @@ environments:
           oidcBaseUrlBackchannel: {{ $oidcBaseUrlBackchannel}}
           oidcWellKnownUrl: {{ $oidcWellKnownUrl }}
           oidcWellKnownUrlBackchannel: {{ $oidcWellKnownBackchannel}}
+          giteaDomain: {{ printf "gitea.%s" $domainSuffix }}
         apps:
           aws-alb-ingress-controller:
             enabled: {{ and (eq $provider "aws") $v.otomi.hasCloudLB }}


### PR DESCRIPTION
fixes redkubes/unassigned-issues#756


<img width="1604" alt="image" src="https://github.com/redkubes/otomi-core/assets/17126497/0fc42d1a-00ef-4065-8cfe-9833320b3227">
