### PR TITLE
feat: disabled trivy infra assesment scanner (node-collector job)

### DIFF
--- a/values/trivy-operator/trivy-operator.gotmpl
+++ b/values/trivy-operator/trivy-operator.gotmpl
@@ -11,6 +11,7 @@ targetNamespaces: "{{- tpl $joinTpl (dict "list" $targets "sep" ",") }}"
 operator:
   replicas: {{ $t.operator.replicaCount }}
   metricsVulnIdEnabled: true
+  infraAssessmentScannerEnabled: false
 
 serviceMonitor:
   enabled: true
@@ -28,3 +29,4 @@ podSecurityContext:
   runAsUser: 1001
 
 resources: {{- $t.resources.operator | toYaml | nindent 2 }}
+


### PR DESCRIPTION
This PR will disable the trivy infra assessment scanner(node-collector job) by default. As experienced in Azure, the node collector job tried to schedule its pods in in the master node(which was not allowed). Since AKS,EKS,GCP are managed kubernetes services, it makes sense to keep this default.