### PR TITLE
feat: updated velero-plugin-for-microsoft-azure memory limit

### DIFF
--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -29,7 +29,7 @@ initContainers:
         memory: 32Mi
       limits:
         cpu: 100m
-        memory: 32Mi
+        memory: 512Mi
     volumeMounts:
       - mountPath: /target
         name: plugins


### PR DESCRIPTION
This PR will increase the memory limit for the velero-plugin-for-microsoft-azure init container from 32 to 512Mi. While backing up large clusters, the velero server pod gets restarted and we can see the OOMKilled event in k8s events. 
Increasing the memory seems to solve the issue. 
Please check this issue: https://github.com/vmware-tanzu/velero/issues/3234  
