### PR TITLE
fix: mem util dashboard

### DIFF
--- a/charts/grafana-dashboards/k8s-admin/compute-cluster.json
+++ b/charts/grafana-dashboards/k8s-admin/compute-cluster.json
@@ -185,7 +185,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
+          "expr": "sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,


### PR DESCRIPTION
The platform dashboard in Console uses the Compute Resources / cluster dashboard for showing cluster memory utilization, but the query did not show correct results. This fixes it.
