### PR TITLE
fix: updated resource names in upgrade script

### DIFF
--- a/upgrades/pre/upgrade-2-7-0.sh
+++ b/upgrades/pre/upgrade-2-7-0.sh
@@ -5,7 +5,7 @@ set -eu
 if [[ $(helm status -n velero velero 2>/dev/null) ]]; then
   echo "Found old velero release. Upgrading Velero CRDs"
   kubectl annotate -n velero backupstoragelocations.velero.io otomi meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
-  kubectl annotate -n velero volumesnapshotlocations.velero.io default meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
+  kubectl annotate -n velero volumesnapshotlocations.velero.io otomi meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
   kubectl apply -f charts/velero/crds --server-side --force-conflicts
 else
   echo "Velero helm release not found. Skipping."


### PR DESCRIPTION
This PR fixes the volumesnapshotlocation names in the 2.7 upgrade script to match the one created by otomi installation.