### PR TITLE
feat: update velero to v1.13

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.12.2
+appVersion: 1.13.0
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -16,4 +16,4 @@ maintainers:
 name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-version: 5.2.0
+version: 5.4.1

--- a/charts/velero/README.md
+++ b/charts/velero/README.md
@@ -6,7 +6,7 @@ Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
-See the different options for installing the [Velero CLI](https://velero.io/docs/v1.12/basic-install/#install-the-cli).
+See the different options for installing the [Velero CLI](https://velero.io/docs/v1.13/basic-install/#install-the-cli).
 
 ## Installing the Velero server
 
@@ -16,7 +16,7 @@ Kubernetes v1.16+, because this helm chart uses CustomResourceDefinition `apiext
 
 ### Velero version
 
-This helm chart installs Velero version v1.12 https://velero.io/docs/v1.12/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.13 https://velero.io/docs/v1.13/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -26,7 +26,7 @@ When installing using the Helm chart, the provider's credential information will
 
 The default configuration values for this chart are listed in values.yaml.
 
-See Velero's full [official documentation](https://velero.io/docs/v1.12/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.12/supported-providers/) for specific configuration information and examples.
+See Velero's full [official documentation](https://velero.io/docs/v1.13/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.13/supported-providers/) for specific configuration information and examples.
 
 #### Set up Helm
 
@@ -89,6 +89,10 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 ```
 
 ## Upgrading
+
+### Upgrading to v1.13
+
+The [instructions found here](https://velero.io/docs/v1.13/upgrade-to-1.13/) will assist you in upgrading from version v1.12.x to v1.13.
 
 ### Upgrading to v1.12
 

--- a/charts/velero/ci/test-values.yaml
+++ b/charts/velero/ci/test-values.yaml
@@ -1,7 +1,7 @@
 # Set provider name and backup storage location bucket name
 configuration:
   backupStorageLocation:
-  - name: backups-primary
+  - name: default
     bucket: velero-backups
     default: true
     provider: aws

--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -479,6 +479,15 @@ spec:
                 description: TTL is a time.Duration-parseable string describing how
                   long the Backup should be retained for.
                 type: string
+              uploaderConfig:
+                description: UploaderConfig specifies the configuration for the uploader.
+                nullable: true
+                properties:
+                  parallelFilesUpload:
+                    description: ParallelFilesUpload is the number of files parallel
+                      uploads to perform when using the uploader.
+                    type: integer
+                type: object
               volumeSnapshotLocations:
                 description: VolumeSnapshotLocations is a list containing names of
                   VolumeSnapshotLocations associated with this backup.
@@ -537,6 +546,22 @@ spec:
                 description: FormatVersion is the backup format version, including
                   major, minor, and patch version.
                 type: string
+              hookStatus:
+                description: HookStatus contains information about the status of the
+                  hooks.
+                nullable: true
+                properties:
+                  hooksAttempted:
+                    description: HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks
+                      that failed to execute and the number of hooks that executed
+                      successfully.
+                    type: integer
+                  hooksFailed:
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
+                    type: integer
+                type: object
               phase:
                 description: Phase is the current state of the Backup.
                 enum:

--- a/charts/velero/crds/datadownloads.yaml
+++ b/charts/velero/crds/datadownloads.yaml
@@ -50,6 +50,8 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
+        description: DataDownload acts as the protocol between data mover plugins
+          and data mover controller for the datamover restore operation
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/charts/velero/crds/datauploads.yaml
+++ b/charts/velero/crds/datauploads.yaml
@@ -51,6 +51,8 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
+        description: DataUpload acts as the protocol between data mover plugins and
+          data mover controller for the datamover backup operation
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -55,6 +55,7 @@ spec:
                     - RestoreItemOperations
                     - CSIBackupVolumeSnapshots
                     - CSIBackupVolumeSnapshotContents
+                    - BackupVolumeInfos
                     type: string
                   name:
                     description: Name is the name of the Kubernetes resource with

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -37,10 +37,6 @@ spec:
       jsonPath: .spec.volume
       name: Volume
       type: string
-    - description: Backup repository identifier for this backup
-      jsonPath: .spec.repoIdentifier
-      name: Repository ID
-      type: string
     - description: The type of the uploader to handle data transfer
       jsonPath: .spec.uploaderType
       name: Uploader Type
@@ -126,6 +122,13 @@ spec:
                   type: string
                 description: Tags are a map of key-value pairs that should be applied
                   to the volume backup as tags.
+                type: object
+              uploaderSettings:
+                additionalProperties:
+                  type: string
+                description: UploaderSettings are a map of key-value pairs that should
+                  be applied to the uploader configuration.
+                nullable: true
                 type: object
               uploaderType:
                 description: UploaderType is the type of the uploader to handle the

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -121,6 +121,13 @@ spec:
                 description: SourceNamespace is the original namespace for namaspace
                   mapping.
                 type: string
+              uploaderSettings:
+                additionalProperties:
+                  type: string
+                description: UploaderSettings are a map of key-value pairs that should
+                  be applied to the uploader configuration.
+                nullable: true
+                type: object
               uploaderType:
                 description: UploaderType is the type of the uploader to handle the
                   data transfer.

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -188,6 +188,12 @@ spec:
                                     - Continue
                                     - Fail
                                     type: string
+                                  waitForReady:
+                                    description: WaitForReady ensures command will
+                                      be launched when container is Ready instead
+                                      of Running.
+                                    nullable: true
+                                    type: boolean
                                   waitTimeout:
                                     description: WaitTimeout defines the maximum amount
                                       of time Velero should wait for the container
@@ -414,6 +420,16 @@ spec:
                   restore from the most recent successful backup created from this
                   schedule.
                 type: string
+              uploaderConfig:
+                description: UploaderConfig specifies the configuration for the restore.
+                nullable: true
+                properties:
+                  writeSparseFiles:
+                    description: WriteSparseFiles is a flag to indicate whether write
+                      files sparsely or not.
+                    nullable: true
+                    type: boolean
+                type: object
             required:
             - backupName
             type: object
@@ -436,6 +452,22 @@ spec:
                 description: FailureReason is an error that caused the entire restore
                   to fail.
                 type: string
+              hookStatus:
+                description: HookStatus contains information about the status of the
+                  hooks.
+                nullable: true
+                properties:
+                  hooksAttempted:
+                    description: HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks
+                      that failed to execute and the number of hooks that executed
+                      successfully.
+                    type: integer
+                  hooksFailed:
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
+                    type: integer
+                type: object
               phase:
                 description: Phase is the current state of the Restore
                 enum:

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -63,6 +63,16 @@ spec:
                 description: Schedule is a Cron expression defining when to run the
                   Backup.
                 type: string
+              skipImmediately:
+                description: 'SkipImmediately specifies whether to skip backup if
+                  schedule is due immediately from `schedule.status.lastBackup` timestamp
+                  when schedule is unpaused or if schedule is new. If true, backup
+                  will be skipped immediately when schedule is unpaused if it is due
+                  based on .Status.LastBackupTimestamp or schedule is new, and will
+                  run at next schedule time. If false, backup will not be skipped
+                  immediately when schedule is unpaused, but will run at next schedule
+                  time. If empty, will follow server configuration (default: false).'
+                type: boolean
               template:
                 description: Template is the definition of the Backup to be run on
                   the provided schedule
@@ -516,6 +526,16 @@ spec:
                     description: TTL is a time.Duration-parseable string describing
                       how long the Backup should be retained for.
                     type: string
+                  uploaderConfig:
+                    description: UploaderConfig specifies the configuration for the
+                      uploader.
+                    nullable: true
+                    properties:
+                      parallelFilesUpload:
+                        description: ParallelFilesUpload is the number of files parallel
+                          uploads to perform when using the uploader.
+                        type: integer
+                    type: object
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names
                       of VolumeSnapshotLocations associated with this backup.
@@ -538,6 +558,11 @@ spec:
               lastBackup:
                 description: LastBackup is the last time a Backup was run for this
                   Schedule schedule
+                format: date-time
+                nullable: true
+                type: string
+              lastSkipped:
+                description: LastSkipped is the last time a Schedule was skipped
                 format: date-time
                 nullable: true
                 type: string

--- a/charts/velero/templates/deployment.yaml
+++ b/charts/velero/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - server
             ### Flags
           {{- with .Values.configuration }}
-            - --uploader-type={{ default "restic" .uploaderType }}
+            - --uploader-type={{ default "kopia" .uploaderType }}
             {{- with .backupSyncPeriod }}
             - --backup-sync-period={{ . }}
             {{- end }}
@@ -107,6 +107,9 @@ spec:
             {{- end }}
             {{- with .defaultBackupTTL }}
             - --default-backup-ttl={{ . }}
+            {{- end }}
+            {{- with .defaultItemOperationTimeout }}
+            - --default-item-operation-timeout={{ . }}
             {{- end }}
             {{- with .defaultVolumeSnapshotLocations }}
             - --default-volume-snapshot-locations={{ . }}

--- a/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+  {{- with .Values.kubectl.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   backoffLimit: 3
   template:

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -33,7 +33,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.12.2
+  tag: v1.13.0
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -106,13 +106,13 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-csi
-  #   image: velero/velero-plugin-for-csi:v0.6.0
+  #   image: velero/velero-plugin-for-csi:v0.7.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.8.0
+  #   image: velero/velero-plugin-for-aws:v1.9.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -391,7 +391,7 @@ configuration:
   # here if using a non-default value. The `velero server` default values are shown in the
   # comments below.
   # --------------------
-  # `velero server` default: restic
+  # `velero server` default: kopia
   uploaderType:
   # `velero server` default: 1m
   backupSyncPeriod:
@@ -405,6 +405,8 @@ configuration:
   clientQPS:
   # Name of the default backup storage location. Default: default
   defaultBackupStorageLocation:
+  # The default duration any single item operation can take before timing out, especially important for large volume schedules. Default 4h
+  defaultItemOperationTimeout:
   # How long to wait by default before backups can be garbage collected. Default: 72h
   defaultBackupTTL:
   # Name of the default volume snapshot location.

--- a/upgrades.yaml
+++ b/upgrades.yaml
@@ -75,3 +75,6 @@ operations:
   - version: 2.7.0
     pre:
       - upgrades/pre/upgrade-2-7-0.sh || true
+  - version: 2.8.0
+    pre:
+      - upgrades/pre/upgrade-2-8-0.sh || true

--- a/upgrades/pre/upgrade-2-7-0.sh
+++ b/upgrades/pre/upgrade-2-7-0.sh
@@ -5,7 +5,7 @@ set -eu
 if [[ $(helm status -n velero velero 2>/dev/null) ]]; then
   echo "Found old velero release. Upgrading Velero CRDs"
   kubectl annotate -n velero backupstoragelocations.velero.io otomi meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
-  kubectl annotate -n velero volumesnapshotlocations.velero.io default meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
+  kubectl annotate -n velero volumesnapshotlocations.velero.io otomi meta.helm.sh/release-name=velero meta.helm.sh/release-namespace=velero
   kubectl apply -f charts/velero/crds --server-side --force-conflicts
 else
   echo "Velero helm release not found. Skipping."

--- a/upgrades/pre/upgrade-2-8-0.sh
+++ b/upgrades/pre/upgrade-2-8-0.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+if [[ $(helm status -n velero velero 2>/dev/null) ]]; then
+  echo "Found old velero release. Upgrading Velero CRDs"
+  kubectl apply -f charts/velero/crds --server-side --force-conflicts
+else
+  echo "Velero helm release not found. Skipping."
+fi

--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -19,7 +19,7 @@ metrics:
 snapshotsEnabled: false
 {{- end }}
 
-upgradeCRDs: true
+upgradeCRDs: false
 cleanUpCRDs: false
 
 
@@ -69,6 +69,7 @@ podSecurityContext:
   runAsUser: 1000
 
 configuration:
+# Use restic for File System Backups instead of kopia
   uploaderType: restic
   defaultBackupStorageLocation: otomi
 
@@ -195,6 +196,8 @@ kubectl:
     sidecar.istio.io/inject: "false"
 
 # Whether to deploy the node-agent daemonset.
+# This parampeter is responsible for enabling restic(or kopia) to backup and restore volumes using File System Backup.
+# Equivalent to running the velero install with --use-node-agent flag.
 deployNodeAgent: {{ $vl.restic.enabled }}
 
 schedules:

--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -22,7 +22,7 @@ snapshotsEnabled: false
 upgradeCRDs: true
 cleanUpCRDs: false
 
-uploaderType: restic
+
 
 initContainers:
   - name: velero-plugin-for-azure
@@ -69,8 +69,10 @@ podSecurityContext:
   runAsUser: 1000
 
 configuration:
+  uploaderType: restic
+  defaultBackupStorageLocation: otomi
+  defaultVolumeSnapshotLocations: otomi
   {{- if eq $sp.type "azureBlob" }}
-
   backupStorageLocation:
   - name: otomi
     provider: azure

--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -19,8 +19,10 @@ metrics:
 snapshotsEnabled: false
 {{- end }}
 
-upgradeCRDs: false
+upgradeCRDs: true
 cleanUpCRDs: false
+
+uploaderType: restic
 
 initContainers:
   - name: velero-plugin-for-azure

--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -71,7 +71,7 @@ podSecurityContext:
 configuration:
   uploaderType: restic
   defaultBackupStorageLocation: otomi
-  defaultVolumeSnapshotLocations: otomi
+
   {{- if eq $sp.type "azureBlob" }}
   backupStorageLocation:
   - name: otomi


### PR DESCRIPTION
This MR updated velero to version 1.13(current latest).
Tested on Azure AKS cluster:
- Restored backups taken from velero 1.12 ✅
- Created backups for team containing multiple workloads ✅
- Backup/Restored workloads using different storage class backed up PVCs ✅