### PR TITLE
feat: whitelist all ingress traffic if team network policies are disa…

### DIFF
--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@
 {{- $alertmng := dig "managedMonitoring" "alertmanager" false $v }}
 {{- if (not (dig "networkPolicy" "ingressPrivate" true $v)) }}
 ---
-# If team network policies are disable then we whitelist all traffic to prvent undesired blocking while deploying team workloads
+# If team network policies are disabled then we whitelist all traffic to prevent undesired blocking while deploying team workloads
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:

--- a/charts/team-ns/templates/networkpolicy.yaml
+++ b/charts/team-ns/templates/networkpolicy.yaml
@@ -2,7 +2,21 @@
 {{- $v := .Values | merge (dict) }}
 {{- $prometheus := dig "managedMonitoring" "prometheus" false $v }}
 {{- $alertmng := dig "managedMonitoring" "alertmanager" false $v }}
-{{- if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
+{{- if (not (dig "networkPolicy" "ingressPrivate" true $v)) }}
+---
+# If team network policies are disable then we whitelist all traffic to prvent undesired blocking while deploying team workloads
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-ingress-allow-all
+  labels: {{- include "team-ns.chart-labels" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {}
+  ingress:
+  - from:
+    - namespaceSelector: {}
+{{- else if and (not (eq $v.teamId "admin")) (dig "networkPolicy" "ingressPrivate" true $v) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -30,7 +30,7 @@ teamConfig:
             prometheus: true
         networkPolicy:
             egressPublic: true
-            ingressPrivate: true
+            ingressPrivate: false
         oidc:
             groupMapping: somesecretvalue
         resourceQuota:


### PR DESCRIPTION
Teams may or may not enabled network polices (`teams.<name>.networkPolicy.ingressPrivate: true|false`)

Teams can also deploy workloads with arbitrary network policies.

If a team sets  `networkPolicy.ingressPrivate: false` AND deploys a workload, which defines custom network policy, then it will disrupt network connectivity of other workloads and services in that team.

This PR aims to mitigate that issue by allowing all traffic if netpols are disabled.