### PR TITLE
fix: exclude argocd namespace

### DIFF
--- a/charts/gatekeeper-artifacts/templates/_helpers.tpl
+++ b/charts/gatekeeper-artifacts/templates/_helpers.tpl
@@ -60,16 +60,12 @@ Create the name of the service account to use
 
 {{- define "gatekeeper-artifacts.namespaces" -}}
 {{- if gt (len .teamIds) 0 }}
-  {{- if .excludedNamespaces }}
 excludedNamespaces:
-  {{- else }}
-namespaces:
-  {{- end }}
   {{- range $teamId := (.teamIds | sortAlpha) }}
   - team-{{ $teamId }}
   {{- end }}
-  - argocd
 {{- end -}}
+  - argocd
 {{- end -}}
 
 {{- define "gatekeeper-artifacts.nodeselector-terms" -}}

--- a/charts/gatekeeper-artifacts/templates/mutations.yaml
+++ b/charts/gatekeeper-artifacts/templates/mutations.yaml
@@ -28,7 +28,11 @@ spec:
     kinds:
       - apiGroups: [batch]
         kinds: [CronJob]
-    {{- include "gatekeeper-artifacts.namespaces" (dict "teamIds" $v.teamIds "excludedNamespaces" true) | nindent 4 }}
+    excludedNamespaces:
+      {{- range $teamId := ($v.teamIds | sortAlpha) }}
+      - team-{{ $teamId }}
+      {{- end }}
+      - argocd
   location: spec.jobTemplate.spec.affinity.nodeAffinity
   parameters:
     assign:
@@ -64,7 +68,11 @@ spec:
         kinds: [Job]
       - apiGroups: [serving.knative.dev]
         kinds: [Service]
-    {{- include "gatekeeper-artifacts.namespaces" (dict "teamIds" $v.teamIds "excludedNamespaces" true) | nindent 4 }}
+    excludedNamespaces:
+      {{- range $teamId := ($v.teamIds | sortAlpha) }}
+      - team-{{ $teamId }}
+      {{- end }}
+      - argocd
   location: spec.template.spec.affinity.nodeAffinity
   parameters:
     assign:
@@ -86,7 +94,12 @@ spec:
     kinds:
     - apiGroups: ["*"]
       kinds: [Pod]
-    {{- include "gatekeeper-artifacts.namespaces" (dict "teamIds" $v.teamIds) | nindent 4 }}
+    {{- if gt (len $v.teamIds) 0 }}
+    namespaces:
+      {{- range $teamId := ($v.teamIds | sortAlpha) }}
+      - team-{{ $teamId }}
+      {{- end }}
+    {{- end }}
   location: spec.affinity.nodeAffinity
   parameters:
     assign:


### PR DESCRIPTION
This change ensures that argocd namespace is not included in the `set-team-node-affinity` of `the Assign` resource.