### PR TITLE
fix: update paketo builder image

### DIFF
--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -69,6 +69,10 @@ spec:
     - name: BUILDER_IMAGE
       value: paketobuildpacks/builder-jammy-full:latest
       {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
+    - name: USER_ID
+      value: "1001"
+    - name: GROUP_ID
+      value: "1001"
     - name: ENV_VARS
       value: 
         {{- range . }}

--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -70,8 +70,6 @@ spec:
       value: paketobuildpacks/builder-jammy-full:latest
     - name: USER_ID
       value: "1001"
-    - name: GROUP_ID
-      value: "1001"
       {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
     - name: ENV_VARS
       value: 

--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -67,7 +67,7 @@ spec:
       value: {{ . }}
     {{- end }}
     - name: BUILDER_IMAGE
-      value: paketobuildpacks/builder:full
+      value: paketobuildpacks/builder-jammy-full:latest
       {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
     - name: ENV_VARS
       value: 

--- a/charts/team-ns/templates/builds/buildpack.yaml
+++ b/charts/team-ns/templates/builds/buildpack.yaml
@@ -68,11 +68,11 @@ spec:
     {{- end }}
     - name: BUILDER_IMAGE
       value: paketobuildpacks/builder-jammy-full:latest
-      {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
     - name: USER_ID
       value: "1001"
     - name: GROUP_ID
       value: "1001"
+      {{- with (dig "mode" "buildpacks" "envVars" nil . ) }}
     - name: ENV_VARS
       value: 
         {{- range . }}

--- a/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
+++ b/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Buildpacks"
     tekton.dev/platforms: "linux/amd64"
+    policy.otomi.io/ignore: banned-image-tags
 spec:
   description: >-
     The Buildpacks task builds source into a container image and pushes it to a registry,

--- a/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
+++ b/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
@@ -176,7 +176,7 @@ spec:
           mountPath: /platform
       securityContext:
         runAsUser: 1001
-        runAsGroup: 1001
+        runAsGroup: 1000
 
     - name: results
       computeResources: {}

--- a/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
+++ b/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
@@ -175,8 +175,8 @@ spec:
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 1001
+        runAsGroup: 1001
 
     - name: results
       computeResources: {}


### PR DESCRIPTION
The image currently used for buildpacks is outdated and no longer maintained. The underlying GitHub repo has been archived. This causes errors on unsupported features by following common buildpack usage patterns, but also might build images with outdated components.

This PR updates the image to the successor image as found on https://paketo.io/docs/reference/builders-reference/ . It also provides the necessary updates considering the user id during image creation has changed.
