### PR TITLE
feat: adjustments to Grafana team permissions

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -108,6 +108,8 @@ releases:
           nameOverride: {{ $teamId }}-po-grafana
           fullnameOverride: {{ $teamId }}-po-grafana
           grafana.ini:
+            "auth.generic_oauth":
+              role_attribute_path: contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'team-admin') && 'Admin' || contains(groups[*], 'team-{{ $teamId }}') && 'Editor'{{ if not ($team | get "managedMonitoring.private" false) }} || 'Viewer'{{- end }}
             server:
               root_url: https://grafana-{{ $teamId }}.{{ $domain }}
           sidecar:

--- a/helmfile.d/snippets/grafana.gotmpl
+++ b/helmfile.d/snippets/grafana.gotmpl
@@ -11,7 +11,8 @@
   auth_url: {{ printf "%s/protocol/openid-connect/auth" .keycloakBase }}
   token_url: {{ printf "%s/protocol/openid-connect/token" .keycloakBase }}
   api_url: {{ printf "%s/protocol/openid-connect/userinfo" .keycloakBase }}
-  role_attribute_path: contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'team-admin') && 'Admin' || 'Editor'
+  role_attribute_path: contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'team-admin') && 'Admin'
+  role_attribute_strict: true
 log:
   level: error
 users:

--- a/helmfile.d/snippets/grafana.gotmpl
+++ b/helmfile.d/snippets/grafana.gotmpl
@@ -16,7 +16,7 @@
 log:
   level: error
 users:
-  allow_sign_up: true
+  allow_sign_up: false
   auto_assign_org: true
   # fall back to admin for anonymous when no auth is available
   auto_assign_org_role: Viewer

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -124,3 +124,5 @@ changes:
       - 'apps.argocd.enabled'
   - version: 20
     networkPoliciesMigration: true
+    additions:
+      - 'teamConfig.{team}.managedMonitoring.private': true

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1246,6 +1246,9 @@ definitions:
           alertmanager:
             type: boolean
             default: false
+          private:
+            type: boolean
+            default: false
       networkPolicy:
         ingressPrivate:
           title: Enable filtering of ingress traffic inside the cluster


### PR DESCRIPTION
This PR implements the following changes:
- Non-admin users are no longer permitted to log into the platform Grafana instance (which would allow for them to see all logs)
- When team users log into another team's Grafana, they are by default assigned the "Viewer" role (before it was "Editor"). Users are still "Editor" in their own team.
- By setting `teams.[name].managedMonitoring.private` to `true`, only members of that team are allowed to log into this Grafana instance at all. Default is `false` for backwards compatibility.

Depends on redkubes/otomi-api#513