### PR TITLE
fix: removed service account from values changes

### DIFF
--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -126,7 +126,6 @@ changes:
     networkPoliciesMigration: true
     additions:
       - 'teamConfig.{team}.managedMonitoring.private': true
-      - 'apps.loki.storage.gcs.serviceAccount'
     deletions:
       - 'apps.loki.storage.gcs.project'
       - 'apps.loki.storage.gcs.instance'


### PR DESCRIPTION
This PR removes the new field serviceAccount from the value-changes file, as no useful default can be provided, and due to lack of functionality no current installation will currently use Loki together with GCS.

This currently blocks a smooth upgrade from the latest release.

Note there is also redkubes/otomi-api#515, although it is not strictly dependent.