### PR TITLE
fix: added runAsUser parameter for velero's node-agent

### DIFF
--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -200,7 +200,7 @@ kubectl:
 # Equivalent to running the velero install with --use-node-agent flag.
 deployNodeAgent: {{ $vl.restic.enabled }}
 
-nodeAgeent:
+nodeAgent:
   podSecurityContext:
     runAsUser: 1338
     fsGroup: 1338

--- a/values/velero/velero.gotmpl
+++ b/values/velero/velero.gotmpl
@@ -200,6 +200,11 @@ kubectl:
 # Equivalent to running the velero install with --use-node-agent flag.
 deployNodeAgent: {{ $vl.restic.enabled }}
 
+nodeAgeent:
+  podSecurityContext:
+    runAsUser: 1338
+    fsGroup: 1338
+
 schedules:
 {{- if $b.gitea.enabled }}
   gitea:


### PR DESCRIPTION
This MR updates the user UID and fsGroup under which the velero node-agent daemonset is running for hardening purposes and avoiding conflict with the gatekeeper runAs policy when enabled.