### PR TITLE
fix: removed networkpolicy

### DIFF
--- a/tests/integration/full.yaml
+++ b/tests/integration/full.yaml
@@ -93,9 +93,6 @@ teamConfig:
           securityContext:
             runAsUser: 1002
         name: hello
-        networkPolicy:
-          ingressPrivate:
-            mode: AllowAll
         ownHost: true
         paths: []
         port: 80


### PR DESCRIPTION
This PR removes the NetworkPolicy from the full integration so now it won't fail anymore.

https://github.com/redkubes/otomi-core/actions/runs/8478776555