### PR TITLE
fix: metrics server extra args

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -419,8 +419,6 @@ environments:
           metrics-server:
             apiServer:
               create: true
-            extraArgs:
-              - --kubelet-preferred-address-types=InternalIP
           minio:
             enabled: false
             provisioning:

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -108,11 +108,6 @@ environments:
             adminPassword: {{ $a | get "keycloak.adminPassword" $v.otomi.adminPassword }}
           metrics-server:
             enabled: {{ $a | get "metrics-server.enabled" (has $provider (list "custom" "aws" "digitalocean" "linode")) }}
-            {{- if eq $provider "linode" }}
-            _rawValues:
-              extraArgs:
-                - --kubelet-insecure-tls=true
-            {{- end}}
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
           snapshot-controller:

--- a/tests/fixtures/env/apps/metrics-server.yaml
+++ b/tests/fixtures/env/apps/metrics-server.yaml
@@ -1,5 +1,11 @@
 apps:
     metrics-server:
-        enabled: true
+        resources:
+            limits:
+                cpu: 300m
+                memory: 512Mi
+            requests:
+                cpu: 100m
+                memory: 64Mi
         extraArgs:
-            - --kubelet-insecure-tls=true
+            - --test-extra-arg=true

--- a/tests/fixtures/env/cluster.yaml
+++ b/tests/fixtures/env/cluster.yaml
@@ -5,5 +5,5 @@ cluster:
     k8sContext: otomi-eks-demo
     name: demo
     owner: redkubes
-    provider: google
+    provider: linode
     region: eu-central-1

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2620,12 +2620,7 @@ properties:
           extraArgs:
             type: array
           resources:
-            additionalProperties: false
-            properties:
-              api:
-                $ref: '#/definitions/resources'
-              tools:
-                $ref: '#/definitions/resources'
+            $ref: '#/definitions/resources'
       minio:
         additionalProperties: false
         properties:

--- a/values/metrics-server/metrics-server.gotmpl
+++ b/values/metrics-server/metrics-server.gotmpl
@@ -1,10 +1,14 @@
 {{- $v := .Values }}
+{{- $provider := $v.cluster.provider }}
 {{- $m := $v.apps | get "metrics-server" }}
 
 extraArgs:
   - --kubelet-preferred-address-types=InternalIP
-{{- with $m.extraArgs }}
-{{- toYaml . | nindent 2 }}
+{{- if eq $provider "linode" }}
+  - --kubelet-insecure-tls=true
+{{- end }}
+{{- if (hasKey $m "extraArgs") }}
+  {{- $m.extraArgs | toYaml | nindent 2 }}
 {{- end }}
 
 apiService:


### PR DESCRIPTION
The extra args for metrics server are set on multiple levels (defaults, custom app, derived) which resulted in incorrect configuration. This PR fixes this.
