### PR TITLE
fix: updated argocd-server hpa

### DIFF
--- a/values/argocd-operator/argocd-operator-cr.gotmpl
+++ b/values/argocd-operator/argocd-operator-cr.gotmpl
@@ -63,9 +63,9 @@ spec:
         maxReplicas: {{ .maxReplicas }}
         minReplicas: {{ .minReplicas }}
         scaleTargetRef:
-          apiVersion: extensions/v1
+          apiVersion: apps/v1
           kind: Deployment
-          name: otomi-argocd
+          name: argocd-server
         targetCPUUtilizationPercentage: 70
     {{- end }}
     resources:


### PR DESCRIPTION
This PR corrects the HPA definition for argocd-server. The previous definition is failing with this error message:
<img width="989" alt="image" src="https://github.com/redkubes/otomi-core/assets/61050265/67a3a5c9-016a-4029-8e04-c2e545c02ed7">

This change is needed to create a patch for v2.8