### PR TITLE
fix: argocd resource values

### DIFF
--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -29,7 +29,7 @@ controller:
     {{- else }}
     limits:
       cpu: 1
-      memory: 3Gi
+      memory: 2Gi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -1,4 +1,5 @@
 {{- $v := .Values }}
+{{- $a := $v.apps.argocd }}
 {{- $k := $v.apps.keycloak }}
 global:
   domain: argocd.{{ $v.cluster.domainSuffix }}
@@ -23,12 +24,16 @@ controller:
   autoscaling:
     enabled: true
   resources:
+    {{- with $a | get "resources.controller" nil }}
+      {{- toYaml .| nindent 4 }}
+    {{- else }}
     limits:
       cpu: 1
-      memory: 1Gi
+      memory: 3Gi
     requests:
       cpu: 100m
-      memory: 256M
+      memory: 1Gi
+    {{- end }}  
 dex:
   enabled: false
 notifications:
@@ -43,32 +48,50 @@ notifications:
       memory: 256M
 redis:
   resources:
+    {{- with $a | get "resources.redis" nil }}
+      {{- toYaml .| nindent 4 }}
+    {{- else }}
     limits:
       cpu: 1
       memory: 1Gi
     requests:
       cpu: 100m
       memory: 256M
+    {{- end }}
 repoServer:
   autoscaling:
     enabled: true
   resources:
+    {{- with $a | get "resources.repo" nil }}
+      {{- toYaml .| nindent 4 }}
+    {{- else }}
     limits:
       cpu: 1
       memory: 1Gi
     requests:
       cpu: 100m
       memory: 256M
+    {{- end }}  
 server:
   autoscaling:
     enabled: true
+    {{- with $a.autoscaling }}
+    maxReplicas: {{ .maxReplicas }}
+    minReplicas: {{ .minReplicas }}
+    targetCPUUtilizationPercentage: 70
+    {{- end }}
+
   resources:
+    {{- with $a | get "resources.server" nil }}
+      {{- toYaml .| nindent 4 }}
+    {{- else }}
     limits:
       cpu: 1
       memory: 1Gi
     requests:
       cpu: 100m
       memory: 256M
+    {{- end }}  
 configs:
   # General Argo CD configuration
   ## Ref: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-cm.yaml


### PR DESCRIPTION
During the implementation of #1338, the resource values `argocd.resources.[redis,controller,repo,server]` were not added to the new templates. Therefore, overrides in the values files have no effect. This PR adds the values to the template.
