### PR TITLE
feat: disable policy check for velero so restic can access hostpath

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -119,6 +119,7 @@ k8s:
       app: vault
     - name: velero
       app: velero
+      disablePolicyChecks: true
     - name: otomi-pipelines
       app: tekton
       disableIstioInjection: true


### PR DESCRIPTION
Disable policy check for velero so restic can access the needed hostpath as described [here](https://velero.io/docs/v1.13/file-system-backup/#configure-node-agent-daemonset-spec)