### PR TITLE
chore: bump tools version in otomi core image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:multi-arch as ci
+FROM otomi/tools:v2.0.0 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:multi-arch as prod
+FROM otomi/tools:v2.0.0 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env


### PR DESCRIPTION
Bumped to new version v2.0.0