### PR TITLE
fix: add trusted root certificates to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:v2.0.0 as ci
+FROM otomi/tools:v2.0.2 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v2.0.0 as prod
+FROM otomi/tools:v2.0.2 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -160,6 +160,8 @@ COPY --from=builder /usr/lib /usr/lib
 # Copy over tools
 COPY --from=builder $APP_HOME $APP_HOME
 COPY --from=builder $HOME/.local/share/helm/plugins $HOME/.local/share/helm/plugins
+# Copy over trust store
+COPY --from=builder /etc/ssl /etc/ssl
 
 RUN chown -R app:app /home/app
 USER app


### PR DESCRIPTION
The images `otomi-tools` and `otomi-core` are missing the CA trust store provided by the base image's distribution (Ubuntu). The package is installed but the files are not transferred to the final image. Therefore, contacting any HTTPS site fails unless the verification is deactivated.

This PR adds the `/etc/ssl` directory from the base image, fixing this issue.