### PR TITLE
feat: improve robustness of initial install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:v2.0.3 as ci
+FROM otomi/tools:v2.2.0 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v2.0.3 as prod
+FROM otomi/tools:v2.2.0 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:v2.0.0 as ci
+FROM otomi/tools:v2.0.1 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v2.0.0 as prod
+FROM otomi/tools:v2.0.1 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:v2.0.1 as ci
+FROM otomi/tools:v2.0.3 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v2.0.1 as prod
+FROM otomi/tools:v2.0.3 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -38,8 +38,8 @@ const applyAll = async () => {
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
   const hfArgs = intitalInstall
-    ? ['sync', '--sync-args', '"--wait-retries 10 --qps 20 --disable-openapi-validation"']
-    : ['apply', '--sync-args', '"--wait-retries 10 --qps 20"']
+    ? ['sync', '--args', '"--wait-retries 10 --qps 20 --disable-openapi-validation"']
+    : ['apply', '--args', '"--wait-retries 10 --qps 20"']
 
   await upgrade({ when: 'pre' })
   d.info('Start apply all')

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -37,9 +37,8 @@ const applyAll = async () => {
   const prevState = await getDeploymentState()
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
-  const hfArgs = intitalInstall
-    ? ['sync', '--args', '--wait-retries=10 --qps=20']
-    : ['apply', '--args', '--wait-retries=10 --qps=20']
+  const hfCommand = intitalInstall ? 'sync' : 'apply'
+  const hfArgs = [hfCommand, '--args', '--qps=20']
 
   await upgrade({ when: 'pre' })
   d.info('Start apply all')

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -37,6 +37,9 @@ const applyAll = async () => {
   const prevState = await getDeploymentState()
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
+  const hfArgs = intitalInstall
+    ? ['sync', '--sync-args', '"--wait-retries 10 --qps 20 --disable-openapi-validation"']
+    : ['apply', '--sync-args', '"--wait-retries 10 --qps 20"']
 
   await upgrade({ when: 'pre' })
   d.info('Start apply all')
@@ -73,13 +76,11 @@ const applyAll = async () => {
       fileOpts: 'helmfile.d/helmfile-02.init.yaml',
       labelOpts: ['stage=prep'],
       logLevel: logLevelString(),
-      args: ['apply'],
+      args: hfArgs,
     },
     { streams: { stdout: d.stream.log, stderr: d.stream.error } },
   )
   await prepareDomainSuffix()
-  // const applyLabel: string = process.env.OTOMI_DEV_APPLY_LABEL || 'stage!=prep'
-  // d.info(`Deploying charts containing label ${applyLabel}`)
 
   let labelOpts = ['']
   if (intitalInstall) {
@@ -102,7 +103,7 @@ const applyAll = async () => {
     {
       labelOpts,
       logLevel: logLevelString(),
-      args: ['apply'],
+      args: hfArgs,
     },
     { streams: { stdout: d.stream.log, stderr: d.stream.error } },
   )
@@ -116,7 +117,7 @@ const applyAll = async () => {
           // 'fileOpts' limits the hf scope and avoids parse errors (we only have basic values in this statege):
           fileOpts: `${rootDir}/helmfile.tpl/helmfile-e2e.yaml`,
           logLevel: logLevelString(),
-          args: ['apply'],
+          args: hfArgs,
         },
         { streams: { stdout: d.stream.log, stderr: d.stream.error } },
       )

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -38,8 +38,8 @@ const applyAll = async () => {
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
   const hfArgs = intitalInstall
-    ? ['sync', '--args', '"--wait-retries 10 --qps 20"']
-    : ['apply', '--args', '"--wait-retries 10 --qps 20"']
+    ? ['sync', '--args', '--wait-retries=10 --qps=20']
+    : ['apply', '--args', '--wait-retries=10 --qps=20']
 
   await upgrade({ when: 'pre' })
   d.info('Start apply all')

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -38,7 +38,7 @@ const applyAll = async () => {
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
   const hfArgs = intitalInstall
-    ? ['sync', '--args', '"--wait-retries 10 --qps 20 --disable-openapi-validation"']
+    ? ['sync', '--args', '"--wait-retries 10 --qps 20"']
     : ['apply', '--args', '"--wait-retries 10 --qps 20"']
 
   await upgrade({ when: 'pre' })

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -37,8 +37,9 @@ const applyAll = async () => {
   const prevState = await getDeploymentState()
   const intitalInstall = isEmpty(prevState.version)
   const argv: HelmArguments = getParsedArgs()
-  const hfCommand = intitalInstall ? 'sync' : 'apply'
-  const hfArgs = [hfCommand, '--args', '--qps=20']
+  const hfArgs = intitalInstall
+    ? ['sync', '--concurrency=1', '--sync-args', '--disable-openapi-validation --qps=20']
+    : ['apply', '--sync-args', '--qps=20']
 
   await upgrade({ when: 'pre' })
   d.info('Start apply all')

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -4,11 +4,11 @@ FROM ubuntu:20.04 as builder
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 # https://github.com/kubernetes/kubernetes/releases
-ARG KUBECTL_VERSION=1.26.9
+ARG KUBECTL_VERSION=1.28.10
 # https://github.com/helm/helm/tags
-ARG HELM_VERSION=3.12.3
+ARG HELM_VERSION=3.15.1
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.8.0
+ARG HELM_DIFF_VERSION=3.9.7
 # https://github.com/jkroepke/helm-secrets/releases
 ARG HELM_SECRETS_VERSION=3.15.0
 # https://github.com/mozilla/sops/releases
@@ -16,7 +16,7 @@ ARG SOPS_VERSION=3.7.3
 # https://github.com/noqcks/gucci/releases
 ARG GUCCI_VERSION=1.6.6
 # https://github.com/helmfile/helmfile/releases
-ARG HELMFILE_VERSION=0.156.0
+ARG HELMFILE_VERSION=0.165.0
 # https://github.com/open-policy-agent/opa/releases
 ARG OPA_VERSION=0.50.1
 # https://github.com/yannh/kubeconform/releases
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y \
     apt-transport-https \
     awscli \
     ca-certificates \
+    dnsutils \
     gettext \
     git \
     gnupg \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -161,6 +161,8 @@ COPY --from=builder /usr/lib /usr/lib
 # Copy over tools
 COPY --from=builder $APP_HOME $APP_HOME
 COPY --from=builder $HOME/.local/share/helm/plugins $HOME/.local/share/helm/plugins
+# Copy over trust store
+COPY --from=builder /etc/ssl /etc/ssl
 
 RUN chown -R app:app /home/app
 USER app

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
     apt-transport-https \
     awscli \
     ca-certificates \
-    dnsutils \
     gettext \
     git \
     gnupg \


### PR DESCRIPTION
This PR includes the following changes for making the installation process more robust against temporary connection issues with the Kubernetes API.
* `helm` has been upgraded to the latest release. Since v3.15.0, it has a retry-mechanism to reattempt Kubernetes API requests on certain HTTP status codes or connection timeouts. This is currently hard-coded to 30 retries.
* `helmfile` and the `helm-diff` plugin have been upgraded for ensuring compatibility, while `kubectl` has been upgraded for a closer match to the supported cluster version.
* On initial install, the total amount of queries is reduced by
  - skipping validation against the OpenAPI spec of the cluster's Kubernetes API
  - bypassing `helm diff` and proceeding to a Helm chart install directly
  - running one `helm` instance at a time.
* Also on the regular pipeline, Helm has a rate limiting of 20 queries per second applied. This is most likely only to affect read queries such as CRDs.