### PR TITLE
fix: wrong indenting in otomi-db chart

### DIFF
--- a/charts/otomi-db/templates/cluster.yaml
+++ b/charts/otomi-db/templates/cluster.yaml
@@ -69,17 +69,17 @@ spec:
   {{- end }}
   {{- if eq .Values.backup.type "s3" }}
   backup:
-  retentionPolicy: {{ .Values.backup.retentionPolicy }}
-    barmanObjectStore:
-      destinationPath: s3://{{ .Values.backup.s3.bucket }}
-      endpointURL: {{ .Values.backup.endpointURL }}
-      s3Credentials:
-        accessKeyId:
-          name: s3-creds
-          key: S3_STORAGE_ACCOUNT
-        secretAccessKey:
-          name: s3-creds
-          key: S3_STORAGE_KEY
+    retentionPolicy: {{ .Values.backup.retentionPolicy }}
+      barmanObjectStore:
+        destinationPath: s3://{{ .Values.backup.s3.bucket }}
+        endpointURL: {{ .Values.backup.endpointURL }}
+        s3Credentials:
+          accessKeyId:
+            name: s3-creds
+            key: S3_STORAGE_ACCOUNT
+          secretAccessKey:
+            name: s3-creds
+            key: S3_STORAGE_KEY
   {{- end }}
   {{- if eq .Values.backup.type "gcs" }}
   backup:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
