### PR TITLE
fix: errors in otomi-db chart

### DIFF
--- a/charts/otomi-db/templates/cluster.yaml
+++ b/charts/otomi-db/templates/cluster.yaml
@@ -70,16 +70,16 @@ spec:
   {{- if eq .Values.backup.type "s3" }}
   backup:
     retentionPolicy: {{ .Values.backup.retentionPolicy }}
-      barmanObjectStore:
-        destinationPath: s3://{{ .Values.backup.s3.bucket }}
-        endpointURL: {{ .Values.backup.endpointURL }}
-        s3Credentials:
-          accessKeyId:
-            name: s3-creds
-            key: S3_STORAGE_ACCOUNT
-          secretAccessKey:
-            name: s3-creds
-            key: S3_STORAGE_KEY
+    barmanObjectStore:
+      destinationPath: s3://{{ .Values.backup.s3.bucket }}
+      endpointURL: {{ .Values.backup.s3.endpointURL }}
+      s3Credentials:
+        accessKeyId:
+          name: s3-creds
+          key: S3_STORAGE_ACCOUNT
+        secretAccessKey:
+          name: s3-creds
+          key: S3_STORAGE_KEY
   {{- end }}
   {{- if eq .Values.backup.type "gcs" }}
   backup:

--- a/tests/fixtures/env/apps/cnpg.yaml
+++ b/tests/fixtures/env/apps/cnpg.yaml
@@ -3,12 +3,13 @@ apps:
         resources:
             limits:
                 cpu: 1000m
-                memory: 1000Mi
+                memory: 512Mi
             requests:
                 cpu: 100m
                 memory: 200Mi
         storage:
-            azure:
-                accountName: name
-                containerName: database
-            type: azure
+            s3:
+                accessKeyId: 2C2F1864-3ADB-4D06-8F77-C82CAB6F0415
+                bucket: databases/
+                s3Url: https://nl-ams-1.linodeobjects.com
+            type: s3

--- a/tests/fixtures/env/apps/secrets.cnpg.yaml
+++ b/tests/fixtures/env/apps/secrets.cnpg.yaml
@@ -1,5 +1,5 @@
 apps:
     cnpg:
         storage:
-            azure:
-                accountKey: anAccountKey
+            s3:
+                secretAccessKey: superdupersecretacceskey

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -76,7 +76,7 @@ otomi:
 platformBackups:
     database:
         harbor:
-            enabled: false
+            enabled: true
             retentionPolicy: 7d
             schedule: 0 0 0 * * *
     persistentVolumes:


### PR DESCRIPTION
Enabling backups with s3 configured resulted in the following errors:
```
in helmfile.d/helmfile-04.databases.yaml: command "/opt/homebrew/bin/helm" exited with non-zero status:

PATH:
  /opt/homebrew/bin/helm

ARGS:
  0: helm (4 bytes)
  1: --kube-context (14 bytes)
  2: otomi-eks-demo (14 bytes)
  3: template (8 bytes)
  4: harbor-otomi-db (15 bytes)
  5: ../charts/otomi-db (18 bytes)
  6: --namespace (11 bytes)
  7: harbor (6 bytes)
  8: --values (8 bytes)
  9: /var/folders/2m/5h7k3bvx20df649hd70d5j400000gq/T/helmfile3969984297/harbor-harbor-otomi-db-values-5594bdc98 (107 bytes)
  10: --skip-tests (12 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: YAML parse error on otomi-db/templates/cluster.yaml: error converting YAML to JSON: yaml: line 30: mapping values are not allowed in this context
  Use --debug flag to render out invalid YAML

COMBINED OUTPUT:
  Error: YAML parse error on otomi-db/templates/cluster.yaml: error converting YAML to JSON: yaml: line 30: mapping values are not allowed in this context
  Use --debug flag to render out invalid YAML
```

Running `otomi template -l name=harbor-otomi-db` now works with backups for s3 enabled