### PR TITLE
feat: increase resource limits for prometheus workloads

### DIFF
--- a/.values/env/policies.yaml
+++ b/.values/env/policies.yaml
@@ -6,7 +6,7 @@ policies:
     container-limits:
         cpu: '2'
         enabled: false
-        memory: 4G
+        memory: 4Gi
     psp-allowed-repos:
         enabled: false
         repos: []

--- a/.values/env/policies.yaml
+++ b/.values/env/policies.yaml
@@ -6,7 +6,7 @@ policies:
     container-limits:
         cpu: '2'
         enabled: false
-        memory: 2000Mi
+        memory: 4G
     psp-allowed-repos:
         enabled: false
         repos: []

--- a/tests/fixtures/env/policies.yaml
+++ b/tests/fixtures/env/policies.yaml
@@ -6,7 +6,7 @@ policies:
     container-limits:
         cpu: '2'
         enabled: true
-        memory: 2Gi
+        memory: 4G
     psp-allowed-repos:
         enabled: false
         repos:

--- a/tests/fixtures/env/policies.yaml
+++ b/tests/fixtures/env/policies.yaml
@@ -6,7 +6,7 @@ policies:
     container-limits:
         cpu: '2'
         enabled: true
-        memory: 4G
+        memory: 4Gi
     psp-allowed-repos:
         enabled: false
         repos:

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -95,7 +95,7 @@ alertmanager:
     resources:
       limits:
         cpu: 500m
-        memory: '2G'
+        memory: 2G
       requests:
         cpu: 100m
         memory: 64Mi

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -59,8 +59,8 @@ prometheus:
     remoteWrite: null
     resources:
       limits:
-        cpu: 200m
-        memory: 512Mi
+        cpu: '1'
+        memory: 4G
       requests:
         cpu: 100m
         memory: 128Mi
@@ -72,8 +72,8 @@ grafana:
   plugins: []
   resources:
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: '1'
+      memory: 4G
     requests:
       cpu: 100m
       memory: 128Mi
@@ -94,8 +94,8 @@ alertmanager:
       type: OnNamespace
     resources:
       limits:
-        cpu: 200m
-        memory: 128Mi
+        cpu: 500m
+        memory: '2G'
       requests:
         cpu: 100m
         memory: 64Mi

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -60,7 +60,7 @@ prometheus:
     resources:
       limits:
         cpu: '1'
-        memory: 4G
+        memory: 4Gi
       requests:
         cpu: 100m
         memory: 128Mi
@@ -73,7 +73,7 @@ grafana:
   resources:
     limits:
       cpu: '1'
-      memory: 4G
+      memory: 4Gi
     requests:
       cpu: 100m
       memory: 128Mi
@@ -95,7 +95,7 @@ alertmanager:
     resources:
       limits:
         cpu: 500m
-        memory: 2G
+        memory: 2Gi
       requests:
         cpu: 100m
         memory: 64Mi


### PR DESCRIPTION
This PR increases the resource limits of some team resources, as this has frequently caused issues in existing setups (pods OOM killed) with larger amounts of workloads. This should be considered a workaround until we have ways to either inject reasonable estimates or team-specific configuration implemented.