### PR TITLE
fix: change repo url for catalog charts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,4 +21,4 @@ AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''
 
 
-OTOMI_CHARTS_URL='https://github.com/redkubes/otomi-charts.git'
+OTOMI_CHARTS_URL='https://github.com/linode/apl-charts.git'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To install Otomi, make sure to have a K8s cluster running with at least:
 - A default storage class configured
 - When using the `custom` provider, make sure the K8s LoadBalancer Service created by `Otomi` can obtain an external IP (using a cloud load balancer or MetalLB)
 
-> **_NOTE:_**  Install Otomi with DNS to unlock it's full potential. Check [otomi.io](https://otomi.io) for more info.
+> **_NOTE:_** Install Otomi with DNS to unlock it's full potential. Check [otomi.io](https://otomi.io) for more info.
 
 Add the Helm repository:
 
@@ -135,7 +135,7 @@ Otomi open source consists out of the following projects:
 - Otomi Core (this project): The heart of Otomi
 - [Otomi Tasks](https://github.com/redkubes/otomi-tasks): Autonomous jobs orchestrated by Otomi Core
 - [Otomi Clients](https://github.com/redkubes/otomi-clients): Factory to build and publish openapi clients used in by otomi-tasks
-- [Otomi Charts](https://github.com/redkubes/otomi-charts): Quickstart Helm templates offered in the Catalog
+- [Otomi Charts](https://github.com/linode/apl-charts): Quickstart Helm templates offered in the Catalog
 
 ## Documentation
 

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -72,11 +72,11 @@ export const commit = async (): Promise<void> => {
 }
 
 export const cloneOtomiChartsInGitea = async (): Promise<void> => {
-  const d = terminal(`cmd:${cmdName}:gitea-otomi-charts`)
-  d.info('Cloning otomi-charts in Gitea')
+  const d = terminal(`cmd:${cmdName}:gitea-apl-charts`)
+  d.info('Cloning apl-charts in Gitea')
   const values = (await hfValues()) as Record<string, any>
   const { email, username, password } = getRepo(values)
-  const workDir = '/tmp/otomi-charts'
+  const workDir = '/tmp/apl-charts'
   const otomiChartsUrl = env.OTOMI_CHARTS_URL
   const giteaChartsUrl = `http://${username}:${password}@gitea-http.gitea.svc.cluster.local:3000/otomi/charts.git`
   try {
@@ -101,7 +101,7 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
   } catch (error) {
     d.info('CloneOtomiChartsInGitea Error:', error)
   }
-  d.info('Cloned otomi-charts in Gitea')
+  d.info('Cloned apl-charts in Gitea')
 }
 
 export const printWelcomeMessage = async (): Promise<void> => {

--- a/src/common/envalid.ts
+++ b/src/common/envalid.ts
@@ -29,8 +29,8 @@ export const cliEnvSpec = {
   NODE_TLS_REJECT_UNAUTHORIZED: bool({ default: true }),
   OTOMI_DEV: bool({ default: false }),
   OTOMI_CHARTS_URL: str({
-    default: 'https://github.com/redkubes/otomi-charts.git',
-    desc: 'The otomi-charts repository url to clone into Gitea',
+    default: 'https://github.com/linode/apl-charts.git',
+    desc: 'The apl-charts repository url to clone into Gitea',
   }),
   OTOMI_IN_TERMINAL: bool({ default: true }),
   STATIC_COLORS: bool({ default: false }),

--- a/tests/integration/minimal-with-team.yaml
+++ b/tests/integration/minimal-with-team.yaml
@@ -95,12 +95,12 @@ teamConfig:
         path: deployment
         revision: main
         selectedChart: deployment
-        url: https://github.com/redkubes/otomi-charts.git
+        url: https://github.com/linode/apl-charts.git
       - name: nginx-ksvc
         path: ksvc
         revision: main
         selectedChart: ksvc
-        url: https://github.com/redkubes/otomi-charts.git
+        url: https://github.com/linode/apl-charts.git
   admin:
     services: []
     workloads:

--- a/tests/integration/monitoring-with-team.yaml
+++ b/tests/integration/monitoring-with-team.yaml
@@ -70,7 +70,7 @@ teamConfig:
         path: otomi-deployment
         revision: b65583f614c800cb215b8418febbb42abbad5883
         selectedChart: custom
-        url: https://github.com/redkubes/otomi-charts
+        url: https://github.com/linode/apl-charts
   admin:
     services: []
     workloads: []

--- a/tests/integration/upgrade.yaml
+++ b/tests/integration/upgrade.yaml
@@ -128,12 +128,12 @@ teamConfig:
         path: deployment
         revision: main
         selectedChart: deployment
-        url: https://github.com/redkubes/otomi-charts.git
+        url: https://github.com/linode/apl-charts.git
       - name: nginx-ksvc
         path: ksvc
         revision: main
         selectedChart: ksvc
-        url: https://github.com/redkubes/otomi-charts.git
+        url: https://github.com/linode/apl-charts.git
   admin:
     services: []
     workloads:


### PR DESCRIPTION
The `otomi-charts` repo has been transferred to the Linode org and is renamed to `apl-charts`. This PR includes the changes needed to clone the apl-charts instead of the otomi-charts.
