### PR TITLE
ci: option to choose latest from all versions in chart upgrades

### DIFF
--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -8,6 +8,10 @@ import semver from 'semver'
 import { $ } from 'zx'
 
 export function isVersionApplicable(currentVersion, version, allowedUpgradeType) {
+  if (allowedUpgradeType === 'latest') {
+    // Consider all versions; the latest version is selected through sorting
+    return true
+  }
   if (semver.lte(version, currentVersion)) {
     return false // Ignore versions that are <= current version
   }
@@ -27,7 +31,7 @@ async function main() {
   const env = envalid.cleanEnv(process.env, {
     CI_UPDATE_TYPE: str({
       desc: 'Path to the YAML file to validate',
-      choices: ['patch', 'minor', 'major'],
+      choices: ['patch', 'minor', 'major', 'latest'],
       default: 'minor',
     }),
     CI_HELM_CHART_NAME_FILTER: json({ desc: 'A list of names in json format', default: [] }),


### PR DESCRIPTION
## 📌 Summary

The automated chart upgrade script compares the releases in this repo with the available versions. If the versioning scheme has been changed somehow, that can lead to missing upgrades. This PR adds an option to upgrade to the latest of all available (and valid semver) versions, not making any other comparisons.

## 🔍 Reviewer Notes

This is for manual use only. It is recommended with the environment variables
```
CI_UPDATE_TYPE=latest
CI_GIT_LOCAL_BRANCH_ONLY=true
# Example where this problem has occurred recently
CI_HELM_CHART_NAME_FILTER='["oauth2-proxy"]'
```

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
