### PR TITLE
fix: specify branch in git pull to ensure correct updates from origin

### DIFF
--- a/src/operator/git-repository.ts
+++ b/src/operator/git-repository.ts
@@ -52,7 +52,7 @@ export class GitRepository {
     await retry(
       async () => {
         try {
-          await this.git.pull()
+          await this.git.pull('origin', 'main')
           await this.setLastRevision()
         } catch (e) {
           d.warn(`The values repository has no commits yet. Retrying in ${interval} ms`)
@@ -98,7 +98,7 @@ export class GitRepository {
 
   private async pull(): Promise<string> {
     try {
-      await this.git.pull()
+      await this.git.pull('origin', 'main')
       return this.getCurrentRevision()
     } catch (error) {
       this.d.error('Failed to pull repository:', getErrorMessage(error))


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

During the installation, it may happen that the values repo has been created but nothing was uploaded yet. The apl-operator clones the empty repo and then perform consecutive git pull operations. The git pull operation on empty repo tries to fetch the `master` branch by default. This PR enforces fetching from main.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
