### PR TITLE
fix: reattempt on first installation failure

### DIFF
--- a/chart/apl/templates/job.yaml
+++ b/chart/apl/templates/job.yaml
@@ -50,8 +50,8 @@ spec:
           command: [bash, -c]
           args:
             - |
-              set -e
               kubectl create ns otomi &> /dev/null
+              set -e
               binzx/otomi validate-cluster && binzx/otomi bootstrap && binzx/otomi apply
 
               {{- if .Values.cleanup.enabled }}


### PR DESCRIPTION
## 📌 Summary

This PR fixes an issue, where installation is not retried on failure. The reason is that a call to `kubectl` fails due to an existing namespace, which originally was ignored.

## 🔍 Reviewer Notes

In order to see the effect of this PR, terminate the installer pod. When testing Helm install from a local checkout, make sure to use the chart from this repo and not the published one.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
