### PR TITLE
feat: ignoring metadata.generation for ValidatingWebhookConfiguration…

### DIFF
--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -165,6 +165,9 @@ configs:
     resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
         jqPathExpressions:
           - '.metadata.annotations'
+    resource.customizations.ignoreDifferences.admissionregistration.k8s.io_ValidatingWebhookConfiguration: |
+        jqPathExpressions:
+          - '.metadata.generation'
     oidc.config: |
       name: Otomi
       issuer: {{ $v._derived.oidcBaseUrl }}


### PR DESCRIPTION
## 📌 Summary

[APL-1020](https://jira.linode.com/browse/APL-1020)
<!-- What does this PR do? Why is it needed? -->

This PR configures argocd to ignore the metadata.generation field when syncing ValidatingWebhookConfiguration resources to address an issue with rabbitmq continuously staying out of sync.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
