### PR TITLE
fix: prometheus-operator storageclass

### DIFF
--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -130,7 +130,9 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: {{ $v.cluster.defaultStorageClass }}
+          {{- with $v.cluster.defaultStorageClass }}
+          storageClassName: {{ . }}
+          {{- end }}
           resources:
             requests:
               storage: {{ $p | get "storageSize" }}


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

This PR fixes the issue when trying to enable prometheus on an upgraded cluster.
Test: 
1. Deploy a cluster
2. Upgrade to main
3. Enabled Prometheus: Should work and not complain about the storageclass 

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
