### PR TITLE
feat: add deprecated labels for Jaeger, Falco, Httpbin and Kiali apps

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -68,7 +68,7 @@ appsInfo:
     deprecationInfo:
       message: Falco runtime security monitoring is being deprecated.
       reasons:
-        - Limited adoption of the platform and a high dependency on the cloud provider.
+        - This security tool requires is not cloud agnostic.
       options:
         - Click 'I understand' to continue using Falco dashboard
   gitea:
@@ -117,7 +117,7 @@ appsInfo:
     deprecationInfo:
       message: Httpbin testing service is being deprecated.
       reasons:
-        - Limited diagnostic value and not essential for platform operations.
+        - This diagnostic tool is not essential to deliver platform capabilities.
       options:
         - Click 'I understand' to continue using Httpbin service
   ingress-nginx:
@@ -156,7 +156,7 @@ appsInfo:
     deprecationInfo:
       message: Jaeger distributed tracing is being deprecated.
       reasons:
-        - Duplicated functionality provided by Tempo with better performance.
+        - This tracing tool duplicates functionality provided by Tempo.
       options:
         - Click 'I understand' to continue using Jaeger dashboard
   keycloak:
@@ -186,7 +186,7 @@ appsInfo:
     deprecationInfo:
       message: Kiali service mesh visualization is being deprecated.
       reasons:
-        - Limited diagnostic value and not essential for platform operations.
+        - This diagnostic tool is not essential to deliver platform capabilities.
       options:
         - Click 'I understand' to continue using Kiali dashboard
   knative:


### PR DESCRIPTION
## 📌 Summary

This PR adds `Deprecated` label for Jaeger, Falco, Httpbin and Kiali apps

Ticket: https://jira.linode.com/browse/APL-1022
PRs: [apl-api](https://github.com/linode/apl-api/pull/785) | [apl-console](https://github.com/linode/apl-console/pull/630)

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
