### PR TITLE
fix: removing .github dir from apl-charts

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -203,6 +203,7 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
 
     cd(workDir)
     await $`rm -rf .git`
+    await $`rm -rf .github`
     await $`rm -rf deployment`
     await $`rm -rf ksvc`
     await $`rm -rf icons`


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
Removes `.github` directory from apl-charts repo before pushing to gitea during installation.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
