### PR TITLE
fix: team-ns builds docker.yaml

### DIFF
--- a/charts/team-ns/templates/builds/docker.yaml
+++ b/charts/team-ns/templates/builds/docker.yaml
@@ -28,7 +28,7 @@ spec:
     - name: output
       workspace: shared-data
   {{- if or (not .externalRepo) .secretName }}
-    - name: basic-auth
+    - name: {{ if .externalRepo }}basic-auth{{ else }}ssh-directory{{ end }}
       workspace: git-credentials
   {{- end }}
     params:


### PR DESCRIPTION
## 📌 Summary

This PR fixes the team-ns builds docker.yaml for the internal private repos.

Related PR: https://github.com/linode/apl-core/pull/2606

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
