### PR TITLE
fix: launch bash on tty startup

### DIFF
--- a/tools/Dockerfile-tty
+++ b/tools/Dockerfile-tty
@@ -88,4 +88,4 @@ RUN touch ~/.bashrc && \
 WORKDIR /home/user
 
 # Command to start a tmux session and expose it via ttyd.
-CMD ["ttyd", "-W", "-p", "8080", "tmux", "new", "-A"]
+CMD ["ttyd", "-W", "-p", "8080", "tmux", "new", "-A", "/bin/bash"]


### PR DESCRIPTION
## 📌 Summary

This PR adds the missing bash entry point to the tty Docker image.

## 🔍 Reviewer Notes

Requires update in API, referencing the new image tag a after merge.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
