### PR TITLE
fix: PostgreSQL image upgrade considered for 4.12 release

### DIFF
--- a/src/common/runtime-upgrades/runtime-upgrades.ts
+++ b/src/common/runtime-upgrades/runtime-upgrades.ts
@@ -117,11 +117,6 @@ export const runtimeUpgrades: RuntimeUpgrades = [
           }
         },
       },
-    },
-  },
-  {
-    version: '4.13.0',
-    applications: {
       'gitea-gitea-otomi-db': {
         post: async (context: RuntimeUpgradeContext) => {
           await updateDbCollation('gitea', 'gitea-db', 'gitea', context.debug)


### PR DESCRIPTION
## 📌 Summary

The upgrade of PostgreSQL base images has already been merged into the 4.12 release. As the current runtime upgrades consider it being only in 4.13, currently post-upgrade runs on every operator run. This is not a huge issue, but unnecessary.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
