### PR TITLE
ci: update log gathering command for APL operator

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -400,7 +400,7 @@ jobs:
       - name: Gather APL logs on failure
         if: failure()
         run: |
-          kubectl logs -l app.kubernetes.io/name=apl-operator -n apl-operator --tail=150
+          kubectl logs -l app.kubernetes.io/name=apl-operator -n apl-operator --tail 150
       - name: Remove the test cluster
         if: ${{ always() && inputs.domain_zone == 'DNS-Integration' }}
         run: |


### PR DESCRIPTION
## 📌 Summary

When an installation through GitHub fails it tries to get the logs from the installer job.
![image](https://github.com/user-attachments/assets/b1666b84-0c2e-4ac4-89b7-8b88f694f3cb)
