### PR TITLE
fix: check for migration on every operator cycle

### DIFF
--- a/src/operator/apl-operator.test.ts
+++ b/src/operator/apl-operator.test.ts
@@ -212,13 +212,13 @@ describe('AplOperator', () => {
       expect(mockAplOps.applyAsAppsTeams).toHaveBeenCalled()
       expect(mockAplOps.apply).not.toHaveBeenCalled()
     })
-    test('should not run migrate and validate when run is reconcile', async () => {
+    test('should run migrate and but not validate when run is reconcile', async () => {
       Object.defineProperty(aplOperator, 'isApplying', { value: false, configurable: true })
 
       await aplOperator.runApplyIfNotBusy(ApplyTrigger.Reconcile, false)
 
       expect(mockAplOps.apply).toHaveBeenCalled()
-      expect(mockAplOps.migrate).not.toHaveBeenCalled()
+      expect(mockAplOps.migrate).toHaveBeenCalled()
       expect(mockAplOps.validateValues).not.toHaveBeenCalled()
     })
 

--- a/src/operator/apl-operator.ts
+++ b/src/operator/apl-operator.ts
@@ -75,9 +75,8 @@ export class AplOperator {
       this.d.info('Write default values to env repo')
       await writeValues(defaultValues)
 
+      await this.aplOps.migrate()
       if (trigger === ApplyTrigger.Poll) {
-        await this.aplOps.migrate()
-
         this.d.info(`[${trigger}] Starting validation process`)
         await this.aplOps.validateValues()
         this.d.info(`[${trigger}] Validation process completed`)


### PR DESCRIPTION
## 📌 Summary

This PR changes the apl-operator behavior to check for migrations on every cycle. This avoids errors on upgrades, where mutations are made before the values are validated.

Note that the extra validation step is still skipped on `reconcile`, as it is run later.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
