### PR TITLE
ci: added repository_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
       - '**'
     tags-ignore:
       - '*'
+    repository_dispatch:
+      types:
+        - build_image
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: linode/apl-core
@@ -193,93 +196,6 @@ jobs:
           mark_as_latest: false
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
-  # test-otomi-release:
-  #   name: Test Helm Chart Installation
-  #   needs: [release, chart-release]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Use Scaleway CLI
-  #       uses: scaleway/action-scw@v0
-  #       with:
-  #         save-config: true
-  #         export-config: true
-  #         version: v2.26.0
-  #         access-key: ${{ secrets.SCW_ACCESS_KEY }}
-  #         secret-key: ${{ secrets.SCW_SECRET_KEY }}
-  #         default-project-id: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
-  #         default-organization-id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
-  #     - name: Pulling the helm chart
-  #       run: |
-  #         # Install and update helm repo
-  #         helm repo add apl https://linode.github.io/apl-core
-  #         helm repo update
-
-  #         # Get latest version of otomi
-  #         latest_version=$(helm search repo otomi -l | grep -m 1 otomi | awk '{print $2}')
-  #         echo The latest version to be tested is: $latest_version
-  #     - name: Creating the cluster
-  #       run: |
-  #         # Create cluster private network and get ID
-  #         SCALEWAY_PRIVATE_NETWORK_ID=$(scw vpc private-network create project-id=${{ secrets.SCW_DEFAULT_PROJECT_ID }} name='otomi-test-release' region=nl-ams -ojson | jq -r .id)
-
-  #         # Get k8s 1.27 patch version
-  #         K8s_VERSION=$(scw k8s version list -o json | jq -ce '.[] | .name' -r | grep 1.27)
-
-  #         # Create cluster
-  #         scw k8s cluster create \
-  #           name=otomi-test-release \
-  #           pools.0.node-type=PRO2-M \
-  #           private-network-id=$SCALEWAY_PRIVATE_NETWORK_ID \
-  #           auto-upgrade.enable=false \
-  #           cni=calico \
-  #           pools.0.name=otomi-test-release \
-  #           pools.0.size=3 \
-  #           pools.0.max-size=3 \
-  #           pools.0.autohealing=true \
-  #           pools.0.autoscaling=true \
-  #           pools.0.root-volume-size=50GB \
-  #           version=$K8s_VERSION \
-  #           region=nl-ams \
-  #           project-id=${{ secrets.SCW_DEFAULT_PROJECT_ID }} \
-  #           --wait
-  #         echo "Cluster deployed successfully"
-  #     - name: Installing new otomi release
-  #       run: |
-  #         # Get cluster ID and set env var
-  #         cluster_id=$(scw k8s cluster list region=nl-ams -o json | jq -r '.[] | select(.name == "otomi-test-release") | .id')
-  #         echo "Cluster ID: $cluster_id"
-  #         echo SCALEWAY_CLUSTER_ID=$cluster_id >> $GITHUB_ENV
-
-  #         # Get kubeconfig
-  #         scw k8s kubeconfig install $cluster_id region=nl-ams
-  #         echo "Kubeconfig installed successfully"
-
-  #         # Update values.yaml integration test file
-  #         SCALEWAY_CLUSTER_CONTEXT=`kubectl config current-context`
-
-  #         # Install otomi
-  #         helm install otomi otomi/otomi \
-  #         --wait --wait-for-jobs --timeout 30m0s \
-  #         --set cluster.provider=scaleway \
-  #         --set cluster.name=otomi-test-release \
-  #         --set cluster.k8sContext=$SCALEWAY_CLUSTER_CONTEXT
-  #     - name: Gather k8s events on failure
-  #       if: failure()
-  #       run: |
-  #         kubectl get events --sort-by='.lastTimestamp' -A
-  #     - name: Gather k8s pods on failure
-  #       if: failure()
-  #       run: |
-  #         kubectl get pods -A -o wide
-  #     - name: Gather otomi logs on failure
-  #       if: failure()
-  #       run: |
-  #         kubectl logs jobs/otomi --tail 150
-  #     - name: Delete k8s cluster at Scaleway
-  #       if: always()
-  #       run: |
-  #         scw k8s cluster delete ${{ env.SCALEWAY_CLUSTER_ID }} with-additional-resources=true region=nl-ams
 
   # notification:
   #   needs: [build-test-cache, push-to-docker, release, chart-release]


### PR DESCRIPTION
## 📌 Summary

Scheduled workflows that create PRs never trigger their dependent workflows. This is a known issue and currently only an issue for Helm chart upgrades. This adds a repository_dispatch trigger that allows for starting workflows manually, so images can be generated.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
