### PR TITLE
ci: syntax and use workflow_dispatch instead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,7 @@ on:
       - '**'
     tags-ignore:
       - '*'
-    repository_dispatch:
-      types:
-        - build_image
+  workflow_dispatch: ~
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: linode/apl-core


### PR DESCRIPTION
## 📌 Summary

`repo_dispatch` only operates on the default branch, therefore `workflow_dispatch` needs to be used.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
