### PR TITLE
ci: ensure exact match on helm chart name

### DIFF
--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -176,7 +176,9 @@ async function checkDependencyUpdates(dependency, allowedUpgradeType) {
     // Get all available versions for the dependency
     allVersions = await $`helm search repo ${dependency.name}/${dependency.name} -l -o json`
       .then((output) => JSON.parse(output.stdout))
-      .then((results) => results.map((entry) => entry.version).filter((version) => semver.valid(version)))
+      .then((results) => results
+        .filter((entry) => semver.valid(entry.version) && entry.name === `${dependency.name}/${dependency.name}`)
+        .map((entry) => entry.version))
   }
 
   if (!allVersions.length) {


### PR DESCRIPTION
## 📌 Summary

This PR fixes an issue in the chart autoupdater, where a listing of the Helm repo returns all charts with the same prefix. The script now removes these by adding an exact match filter.

(see https://github.com/linode/apl-core/actions/runs/21500328512/job/61945046816)

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
