### PR TITLE
fix: adjust exporter name

### DIFF
--- a/values/otel-operator/otel-operator-raw.gotmpl
+++ b/values/otel-operator/otel-operator-raw.gotmpl
@@ -225,13 +225,13 @@ resources:
               receivers:
                 - routing
               exporters:
-                - otlphttp/default
+                - otlp_http/default
             {{- range $id, $team := $v.teamConfig }}
             logs/otlphttp-team-{{ $id }}:
               receivers:
                 - routing
               exporters:
-                - otlphttp/team-{{ $id }}
+                - otlp_http/team-{{ $id }}
             {{- end }}
   {{- end }}
   - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## 📌 Summary

This PR fixes an issue introduced with the latest OpenTelemetry Operator upgrade, where exporter names were adjusted but not their reference.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
