### PR TITLE
feat: support recursive paths for GitOps manifests

### DIFF
--- a/src/cmd/apply-as-apps.test.ts
+++ b/src/cmd/apply-as-apps.test.ts
@@ -98,6 +98,9 @@ describe('getArgocdGitopsManifest', () => {
             path: 'env/manifests/global',
             repoURL: 'https://git.example.com:443/otomi/values.git',
             targetRevision: 'HEAD',
+            directory: {
+              recurse: true,
+            },
           },
         ],
         destination: {
@@ -138,9 +141,12 @@ describe('getArgocdGitopsManifest', () => {
         },
         sources: [
           {
-            path: 'env/manifests/ns/my-namespace',
+            path: 'env/manifests/namespaces/my-namespace',
             repoURL: 'https://git.example.com:443/otomi/values.git',
             targetRevision: 'HEAD',
+            directory: {
+              recurse: true,
+            },
           },
         ],
         destination: {

--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -20,7 +20,7 @@ import { Argv, CommandModule } from 'yargs'
 import { ARGOCD_APP_DEFAULT_SYNC_POLICY, ARGOCD_APP_PARAMS } from '../common/constants'
 import { env } from '../common/envalid'
 
-export const GITOPS_MANIFESTS_NS_PATH = 'env/manifests/ns'
+export const GITOPS_MANIFESTS_NS_PATH = 'env/manifests/namespaces'
 export const GITOPS_MANIFESTS_GLOBAL_PATH = 'env/manifests/global'
 export const ARGOCD_APP_DEFAULT_LABEL = 'managed'
 export const ARGOCD_APP_GITOPS_LABEL = 'generic-gitops'
@@ -162,6 +162,9 @@ export const getArgocdGitopsManifest = (name: string, targetNamespace?: string) 
         path,
         repoURL,
         targetRevision: 'HEAD',
+        directory: {
+          recurse: true,
+        },
       },
     ],
     destination: {

--- a/src/cmd/migrate.ts
+++ b/src/cmd/migrate.ts
@@ -696,7 +696,7 @@ const createCatalogSealedSecret = async (
       },
     },
   }
-  const sealedSecretPath = `${env.ENV_DIR}/env/manifests/ns/argocd/${SEALED_SECRET_NAME}.yaml`
+  const sealedSecretPath = `${env.ENV_DIR}/env/manifests/namespaces/argocd/${SEALED_SECRET_NAME}.yaml`
   mkdirSync(dirname(sealedSecretPath), { recursive: true })
   d.info(`Writing sealed secret to ${sealedSecretPath}`)
   writeFileSync(sealedSecretPath, objectToYaml(sealedSecret))


### PR DESCRIPTION
## 📌 Summary

This PR updates the manifest path structure from `env/manifests/ns/` to `env/manifests/namespaces/` and enables `recursive` directory scanning on the argocd application source so subdirectories are picked up automatically.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
