### PR TITLE
feat: optimize argocd resource usage

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -26,16 +26,18 @@ environments:
             autoscaling:
               repoServer:
                 enabled: true
-                minReplicas: 2
+                minReplicas: 1
                 maxReplicas: 5
                 targetCPUUtilizationPercentage: 80
                 targetMemoryUtilizationPercentage: 80
+                targetCPUUtilizationPercentage: 100
               server:
                 enabled: true
                 minReplicas: 1
                 maxReplicas: 5
                 targetCPUUtilizationPercentage: 80
                 targetMemoryUtilizationPercentage: 80
+                targetCPUUtilizationPercentage: 100
             resources:
               controller:
                 requests:
@@ -53,8 +55,8 @@ environments:
                   memory: 1Gi
               repo:
                 requests:
-                  cpu: 100m
-                  memory: 640Mi
+                  cpu: 250m
+                  memory: 128Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -28,16 +28,14 @@ environments:
                 enabled: true
                 minReplicas: 1
                 maxReplicas: 5
-                targetCPUUtilizationPercentage: 80
-                targetMemoryUtilizationPercentage: 80
                 targetCPUUtilizationPercentage: 100
+                targetMemoryUtilizationPercentage: 80
               server:
                 enabled: true
                 minReplicas: 1
                 maxReplicas: 5
-                targetCPUUtilizationPercentage: 80
-                targetMemoryUtilizationPercentage: 80
                 targetCPUUtilizationPercentage: 100
+                targetMemoryUtilizationPercentage: 80
             resources:
               controller:
                 requests:


### PR DESCRIPTION
## 📌 Summary

Too low CPU request triggers autoscaling with even small spike in usage.
Since argocd does not carry any user specific traffic it is fine to set `repoServer` min replica to 1.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
