### PR TITLE
feat: set gitops targetrevision to gitops branch

### DIFF
--- a/charts/team-ns/templates/argocd/argocd-application-workload.yaml
+++ b/charts/team-ns/templates/argocd/argocd-application-workload.yaml
@@ -43,7 +43,7 @@ spec:
       - $values/env/teams/{{ $v.teamId }}/workloadValues/{{ $workload.name }}.managed.yaml
       {{- end }}
   - repoURL: {{ $v.gitOps.workloadValuesRepoUrl | quote }}
-    targetRevision: '{{ .revision }}'
+    targetRevision: {{ $v.gitOps.branch | quote }}
     ref: values
   syncPolicy:
     automated:


### PR DESCRIPTION
This PR fixes the issue when creating a workload it uses the workload revision for the gitops as well instead of the gitops branch, when creating the workload in argocd