### PR TITLE
fix: do not use helmfile --reuse-values flag

### DIFF
--- a/src/common/hf.ts
+++ b/src/common/hf.ts
@@ -17,7 +17,6 @@ const replaceHFPaths = (output: string, envDir = env.ENV_DIR): string => output.
 export const HF_DEFAULT_SYNC_ARGS = [
   'sync',
   '--concurrency=1',
-  '--reuse-values', // Preserve values from existing releases on retry - makes install idempotent
   '--sync-args',
   // These two need to be in same string as is passed as single argument to --sync-args
   '--disable-openapi-validation --qps=20',


### PR DESCRIPTION
## 📌 Summary

Ensure to render and use only those values that are relevant to a given Helm chart version. Critical during the upgrade procedure.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
