### PR TITLE
fix: set correct loki url when no obj storage

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml.gotmpl
+++ b/helmfile.d/helmfile-60.teams.yaml.gotmpl
@@ -157,7 +157,7 @@ releases:
               uid: loki
               type: loki
               access: proxy
-              {{- if eq $v.obj.provider.type "minioLocal" "linode" }}
+              {{- if eq $v.obj.provider.type "linode" }}
               url: http://loki-query-frontend-headless.monitoring:3101
               {{- else }}
               url: http://loki-headless.monitoring:3101

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -300,7 +300,7 @@ grafana:
       uid: loki
       type: loki
       access: proxy
-      {{- if eq $v.obj.provider.type "minioLocal" "linode" }}
+      {{- if eq $v.obj.provider.type "linode" }}
       url: http://loki-query-frontend-headless.monitoring:3101
       {{- else }}
       url: http://loki-headless.monitoring:3101


### PR DESCRIPTION
## 📌 Summary

Same logic is used in the prometheus operator: https://github.com/linode/apl-core/blob/main/values/prometheus-operator/prometheus-operator.gotmpl#L275
## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
