### PR TITLE
ci: check availability of Kubernetes API before attempting Helm install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -346,6 +346,19 @@ jobs:
             install_args+=(--set-json apps.linode-cfw._rawValues.firewall.inbound='${{ env.LKE_APL_FIREWALL_INBOUND_RULES }}')
           fi
 
+          # Wait for KubeAPI to respond before attempting install
+          echo "Checking Kubernetes API availability..."
+          while true; do
+              kubectl get pods 2> /dev/null
+              if [[ "$?" = 0 ]]; then
+                 echo "Ok."
+                 break
+              else
+                 echo "Retrying in 5 seconds"
+                 sleep 5
+              fi
+          done
+
           helm install "${install_args[@]}" &
           HELM_PID=$!
           sleep 120


### PR DESCRIPTION
## 📌 Summary

This PR posts a single query to a new LKE cluster before attempting to post a Helm install. This is to avoid failures when the Kubeconfig is provided, but the cluster does not accept requests yet.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
