### PR TITLE
ci: fix dev cluster update after merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ env:
   REPO: linode/apl-core
   DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
   DOCKER_USERNAME: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
-  DEV_KUBECONFIG_64: ${{ secrets.DEV_KUBECONFIG }}
   BOT_EMAIL: ${{ vars.BOT_EMAIL }}
   BOT_USERNAME: ${{ vars.BOT_USERNAME }}
   COMMIT_SHA: ${{ github.sha }}
@@ -82,7 +81,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Install the Linode CLI
+        uses: linode/action-linode-cli@v1
+        with:
+          token: ${{ secrets.LINODE_TOKEN }}
       - name: Deploy to dev
+        env:
+          DEV_CLUSTER_ID: ${{ secrets.DEV_CLUSTER_ID }}
+          LKE_CP_ACL_IPV4: ${{ secrets.LKE_CP_ACL_IPV4 }}
         run: ci/scripts/trigger_dev.sh
 
   release:

--- a/ci/scripts/trigger_dev.sh
+++ b/ci/scripts/trigger_dev.sh
@@ -23,6 +23,7 @@ echo "Updating ACL"
 linode-cli lke cluster-update "${update_args[@]}"
 
 echo "Restart platform deployments"
+set +e
 kubectl -n otomi rollout restart deployment/otomi-api
 kubectl -n otomi rollout restart deployment/otomi-console
 kubectl rollout restart deployment -n apl-harbor-operator apl-harbor-operator

--- a/ci/scripts/trigger_dev.sh
+++ b/ci/scripts/trigger_dev.sh
@@ -3,11 +3,24 @@
 
 set -e
 
-echo "Decode and set the Kubernetes configuration for the dev environment"
-if [ -z "$KUBECONFIG" ]; then
-  echo $DEV_KUBECONFIG_64 | base64 -d >.kubeconfig
-  export KUBECONFIG=$(pwd)/.kubeconfig
+echo "Fetch the Kubernetes configuration for the dev environment"
+export KUBECONFIG=$(mktemp -d)/.kubeconfig
+linode-cli get-kubeconfig --id "$DEV_CLUSTER_ID" --kubeconfig "$KUBECONFIG"
+
+CURRENT_IP=$(curl -sS https://ipv4.whatismyip.akamai.com/)
+echo "Current IP: $CURRENT_IP"
+update_args=("$DEV_CLUSTER_ID" --control_plane.acl.enabled true)
+if [[ -n "${LKE_CP_ACL_IPV4}" ]]; then
+  IFS=',' read -ra acl_ips <<< "${LKE_CP_ACL_IPV4}"
+  for acl_ip in "${acl_ips[@]}"; do
+    update_args+=(--control_plane.acl.addresses.ipv4 "$acl_ip")
+  done
 fi
+reset_args=("${update_args[@]}")
+update_args+=(--control_plane.acl.addresses.ipv4 "$CURRENT_IP")
+
+echo "Updating ACL"
+linode-cli lke cluster-update "${update_args[@]}"
 
 echo "Restart platform deployments"
 kubectl -n otomi rollout restart deployment/otomi-api
@@ -17,3 +30,6 @@ kubectl rollout restart deployment -n apl-keycloak-operator apl-keycloak-operato
 kubectl rollout restart deployment -n apl-gitea-operator apl-gitea-operator
 kubectl rollout restart deployment -n otomi-operator otomi-operator
 kubectl rollout restart deployment -n apl-operator apl-operator
+
+echo "Resetting ACL"
+linode-cli lke cluster-update "${reset_args[@]}"

--- a/ci/scripts/trigger_dev.sh
+++ b/ci/scripts/trigger_dev.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # This script is used to deploy the latest changes merged on main to the dev environment.
 
-set -e
+set -euo pipefail
 
 echo "Fetch the Kubernetes configuration for the dev environment"
 export KUBECONFIG=$(mktemp -d)/.kubeconfig
@@ -21,6 +21,17 @@ update_args+=(--control_plane.acl.addresses.ipv4 "$CURRENT_IP")
 
 echo "Updating ACL"
 linode-cli lke cluster-update "${update_args[@]}"
+
+echo "Waiting for ACL to apply..."
+while true; do
+    if kubectl get pods 2> /dev/null; then
+       echo "Ok."
+       break
+    else
+       echo "Retrying in 5 seconds"
+       sleep 5
+    fi
+done
 
 echo "Restart platform deployments"
 set +e


### PR DESCRIPTION
## 📌 Summary

This PR updates the dev cluster's ACL temporarily, for triggering a restart of updated services after merge to main. The ACL is reset back to its default afterwards.

## 🔍 Reviewer Notes

The script `ci/scripts/trigger_dev.sh` can be tested locally by setting the following variables (assumes authenticated linode-cli):
* `DEV_CLUSTER_ID`: can be any valid cluster ID, but the cluster must run Harbor since the script assumes the operator is deployed.
* `LKE_CP_ACL_IPV4`: comma-separated list of valid IP ranges. Check dev cluster for the actual values.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
