### PR TITLE
feat: remove tls passthrough

### DIFF
--- a/charts/team-ns/templates/routes.yaml
+++ b/charts/team-ns/templates/routes.yaml
@@ -11,7 +11,6 @@
 {{- $isCoreService := $s.isCore | default false }}
 {{- $isKnativeService := dig "ksvc" "predeployed" false $s }}
 {{- if not (or $isCoreService $isKnativeService) }}
-{{- $tlsPass := $s.tlsPass | default false }}
 {{- $cnameDomain := dig "cname" "domain" "" $s }}
 {{- $useCname := and ($s.useCname | default false) (ne $cnameDomain "") }}
 {{- $ingressClassName := $s.ingressClassName | default $defaultIngressClass }}
@@ -24,26 +23,15 @@
 {{- $headersResponseSet := dig "headers" "response" "set" nil $s }}
 {{- $headersRequestRemove := get $s "removeRequestHeaders" | default nil }}
 
-{{- /* Add specific listener configurations for each cname and/or TLS passthrough */}}
-{{- if or $tlsPass $useCname }}
-  {{- $hostname := ternary $cnameDomain $defaultHostname $useCname }}
-  {{- if $tlsPass }}
-    {{- $l := get $extraListeners $ingressClassName }}
-    {{- $l = append $l (dict "name" $serviceName "hostname" $hostname "tlsPass" true) }}
-    {{- $_ := set $extraListeners $ingressClassName $l }}
-  {{- else }}
-    {{- $l := get $extraListeners $ingressClassName }}
-    {{- $l = append $l (dict "name" $serviceName "hostname" $hostname "tlsPass" false "secretName" (dig "cname" "tlsSecretName" "" $s)) }}
-    {{- $_ := set $extraListeners $ingressClassName $l }}
-  {{- end }}
+{{- /* Add specific listener configurations for each cname */}}
+{{- if $useCname }}
+  {{- $l := get $extraListeners $ingressClassName }}
+  {{- $l = append $l (dict "name" $serviceName "hostname" $cnameDomain "secretName" (dig "cname" "tlsSecretName" "" $s)) }}
+  {{- $_ := set $extraListeners $ingressClassName $l }}
 {{- end }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
-{{- if $tlsPass }}
-kind: TLSRoute
-{{- else }}
 kind: HTTPRoute
-{{- end }}
 metadata:
   {{- with $v.httpRouteAnnotations }}
   annotations:
@@ -57,17 +45,15 @@ spec:
     - {{ $cnameDomain }}
     {{- end }}
   parentRefs:
-    {{- if or $tlsPass $useCname }}
+    {{- if $useCname }}
     - name: {{ $s.ingressClassName | default $defaultIngressClass }}-workloads
       kind: XListenerSet
       group: gateway.networking.x-k8s.io
     {{- end }}
-    {{- if not $tlsPass }}
     - name: {{ $s.ingressClassName | default $defaultIngressClass }}
       namespace: istio-system
       kind: Gateway
       group: gateway.networking.k8s.io
-    {{- end }}
   rules:
     - backendRefs:
       {{- if $useTrafficControl }}
@@ -160,17 +146,6 @@ spec:
     group: gateway.networking.k8s.io
   listeners:
   {{- range $listener := . }}
-    {{- if $listener.tlsPass }}
-    - name: tls-{{ $listener.name }}
-      hostname: {{ $listener.hostname }}
-      protocol: TLS
-      port: 443
-      tls:
-        mode: Passthrough
-      allowedRoutes:
-        namespaces:
-          from: Same
-    {{- else }}
     - name: http-cname-{{ $listener.name }}
       hostname: {{ $listener.hostname }}
       protocol: HTTP
@@ -189,7 +164,6 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
-    {{- end }}
   {{- end }}
 {{- range $httpRedirects }}
 ---

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1177,4 +1177,4 @@ environments:
           aiEnabled: false
         users: []
         versions:
-          specVersion: 62
+          specVersion: 64

--- a/tests/fixtures/env/settings/versions.yaml
+++ b/tests/fixtures/env/settings/versions.yaml
@@ -3,4 +3,4 @@ metadata:
     name: versions
     labels: {}
 spec:
-    specVersion: 62
+    specVersion: 64

--- a/tests/fixtures/env/teams/demo/services/hello.yaml
+++ b/tests/fixtures/env/teams/demo/services/hello.yaml
@@ -20,7 +20,6 @@ spec:
         predeployed: true
     ownHost: true
     port: 80
-    tlsPass: true
     trafficControl:
         enabled: true
         weightV1: 70

--- a/tests/fixtures/env/teams/demo/services/tlspass.yaml
+++ b/tests/fixtures/env/teams/demo/services/tlspass.yaml
@@ -1,8 +1,0 @@
-kind: AplTeamService
-metadata:
-    name: tlspass
-    labels:
-        apl.io/teamId: demo
-spec:
-    port: 443
-    tlsPass: true

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -473,3 +473,6 @@ changes:
       - 'apps.istio.tracing'
       - 'apps.otel.otlpCollector'
       - 'apps.otel.resources.otlpCollector'
+  - version: 64
+    deletions:
+      - 'teamConfig.{team}.services[].tlsPass'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1059,10 +1059,6 @@ definitions:
       svc:
         $ref: '#/definitions/idName'
         description: When given a backing k8s service is expected to be deployed with this name, which will be exposed through this team service.
-      tlsPass:
-        description: Will pass the request to the backing service without TLS termination.
-        type: boolean
-        default: false
       useCname:
         description: Will configure additional host(CNAME) for the service.
         type: boolean
@@ -1073,7 +1069,7 @@ definitions:
             description: CNAME of the service.
             type: string
           tlsSecretName:
-            description: Kubernetes secret name of type TLS (not required if the tlsPass flag is set to true).
+            description: Kubernetes secret name of type TLS.
             $ref: '#/definitions/idName'
       removeRequestHeaders:
         description: >-


### PR DESCRIPTION
## 📌 Summary

Our implementation of TLS passthrough is not functional in combination with the Gateway API. Therefore, it is removed but can be implemented with manifests by users as needed.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
