### PR TITLE
fix: target namespace of grafana secrets

### DIFF
--- a/values/prometheus-operator/prometheus-operator-raw.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-raw.gotmpl
@@ -13,7 +13,7 @@ resources:
     kind: ExternalSecret
     metadata:
       name: grafana-admin-secret
-      namespace: monitoring
+      namespace: grafana
     spec:
       refreshInterval: 1h
       secretStoreRef:
@@ -36,7 +36,7 @@ resources:
     kind: ExternalSecret
     metadata:
       name: grafana-oidc-secret
-      namespace: monitoring
+      namespace: grafana
     spec:
       refreshInterval: 1h
       secretStoreRef:
@@ -59,7 +59,7 @@ resources:
     kind: ExternalSecret
     metadata:
       name: grafana-loki-datasource-secret
-      namespace: monitoring
+      namespace: grafana
     spec:
       refreshInterval: 1h
       secretStoreRef:


### PR DESCRIPTION
## 📌 Summary

This is a followup of moving platform secrets from values to SealedSecret resources. These corrects the target namespace needed by the platform Grafana instance.

## 🔍 Reviewer Notes

Grafana currently fails to start in `main`. With this change, pods should be configured correctly.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
