### PR TITLE
chore: upgrade base image of core to v2.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linode/apl-tools:v2.11.1 AS ci
+FROM linode/apl-tools:v2.11.2 AS ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -36,7 +36,7 @@ FROM ci AS clean
 # below command removes the packages specified in devDependencies and set NODE_ENV to production
 RUN npm prune --production
 
-FROM linode/apl-tools:v2.11.1 AS prod
+FROM linode/apl-tools:v2.11.2 AS prod
 ARG APPS_REVISION=''
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/values/gitea/gitea-raw.gotmpl
+++ b/values/gitea/gitea-raw.gotmpl
@@ -3,10 +3,10 @@
 {{- $otomiAdmin := "otomi-admin" }}
 {{- $obj := $v.obj.provider }}
 {{- $giteaBackupConfig := $v.platformBackups.gitea }}
-{{- $rcloneVersion := "1.70.3" }}
-{{- $rcloneZipSha512 := "472165c3989671f4163242c67cdb9da4c3d3e4548cd1222015f552d6d2fda1cbd616b133ec45e78d8efb088368e18cc314bfeea764e253b6a5d6a693d67a11ef" }}
-{{- $rcloneBinSha512 := "b98a32f87cc1d0ac292829d12de45d1e827fd0a3f480d4b5a5242f1af0ecbc48e6ef6901c98f22289c77571adb4ee79e09af28750f031e8b038f55eeea40f910" }}
-{{- $kubectlTag := "v1.33.3" }}
+{{- $rcloneVersion := "1.74.0" }}
+{{- $rcloneZipSha512 := "4f73acc20e38773cc9c56639f405c775b4e6fca87127dae498a3f1cb032a896c106512f5ca1f5c48e6a9ac6f3e94ebeb0f130fff69e9260050da5beabe1ab1f6" }}
+{{- $rcloneBinSha512 := "58e35e0324769c1cb3df37f22086eefe8fb025990232f00e4b8548f15b749096e8c241fb572a7d89861b4ce7534b63a0f58b71b3663a5ee3bda6db5fb9bf440d" }}
+{{- $kubectlTag := "v1.35.4" }}
 {{- $kubectlImage := print "registry.k8s.io/kubectl:" $kubectlTag }}
 {{- if $v.otomi.linodeLkeImageRepository }}
 {{- $kubectlImage = print $v.otomi.linodeLkeImageRepository "/k8s/kubectl:" $kubectlTag }}


### PR DESCRIPTION
## 📌 Summary

This PR upgrades the base image that is used to build Core, and some binary references used for Gitea application backup. The base image is created using Ubuntu 26 (upgrade from 24), and utility binaries (e.g. Git, Kubectl, Helm, Helmfile etc) were upgraded to more recent versions, either matching the versions used in other places of the charts (e.g. Tekton, ArgoCD) or to the latest minor version.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
