### PR TITLE
fix: include monitoring crds in chart for handling upgrades reliably

### DIFF
--- a/helmfile.d/helmfile-08.init.yaml.gotmpl
+++ b/helmfile.d/helmfile-08.init.yaml.gotmpl
@@ -31,6 +31,8 @@ releases:
       - {{- $a | get "prometheus._rawValues" dict | toYaml | nindent 8 }}
       - alertmanager: {{- $a | get "alertmanager._rawValues" dict | toYaml | nindent 10 }}
         grafana: {{- $a | get "grafana._rawValues" dict | toYaml | nindent 10 }}
+        crds:
+          enabled: true
         extraManifests:
           - {{ tpl (readFile "snippets/authpolicy-oauth2-ext.gotmpl") (dict "prefix" "monitoring" "gatewayName" $v.ingress.platformClass.className "hosts" $hosts) | nindent 12 }}
           - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "prometheus" "excludeNamespaces" (list "grafana" "monitoring" "team-*")) | nindent 12 }}


### PR DESCRIPTION
## 📌 Summary

This PR includes the CRDs required by Kube-Prometheus-Stack in the chart, considering them on both initial install and during upgrades.

They still must be applied during initial install, as other applications include ServiceMonitor resources.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
