### PR TITLE
fix: failed connection between grafana and alertmanager

### DIFF
--- a/helmfile.d/helmfile-08.init.yaml.gotmpl
+++ b/helmfile.d/helmfile-08.init.yaml.gotmpl
@@ -34,6 +34,6 @@ releases:
         extraManifests:
           - {{ tpl (readFile "snippets/authpolicy-oauth2-ext.gotmpl") (dict "prefix" "monitoring" "gatewayName" $v.ingress.platformClass.className "hosts" $hosts) | nindent 12 }}
           - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "prometheus" "excludeNamespaces" (list "grafana" "monitoring" "team-*")) | nindent 12 }}
-          - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "excludeAccount" "monitoring/po-prometheus") | nindent 12 }}
+          - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "excludeAccounts" (list "monitoring/po-prometheus" "grafana/po-grafana")) | nindent 12 }}
           - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "namespace" "grafana" "excludeAccount" "monitoring/po-prometheus") | nindent 12 }}
           - {{ tpl (readFile "snippets/serviceentry.gotmpl") (dict "name" "monitoring" "hosts" $hosts) | nindent 12 }}


### PR DESCRIPTION
## 📌 Summary

This PR fixes Grafana's Alertmanager datasource access by adding grafana/po-grafana to the monitoring AuthorizationPolicy. (Please check https://github.com/linode/apl-core/pull/3068)

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
