### PR TITLE
fix: add excludePaths to authpolicy-jwt for monitoring namespace

### DIFF
--- a/helmfile.d/helmfile-08.init.yaml.gotmpl
+++ b/helmfile.d/helmfile-08.init.yaml.gotmpl
@@ -37,5 +37,5 @@ releases:
           - {{ tpl (readFile "snippets/authpolicy-oauth2-ext.gotmpl") (dict "prefix" "monitoring" "gatewayName" $v.ingress.platformClass.className "hosts" $hosts) | nindent 12 }}
           - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "prometheus" "excludeNamespaces" (list "grafana" "monitoring" "team-*")) | nindent 12 }}
           - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "excludeAccounts" (list "monitoring/po-prometheus" "grafana/po-grafana")) | nindent 12 }}
-          - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "namespace" "grafana" "excludeAccount" "monitoring/po-prometheus") | nindent 12 }}
+          - {{ tpl (readFile "snippets/authpolicy-jwt.gotmpl") (dict "name" "monitoring" "namespace" "grafana" "excludeAccount" "monitoring/po-prometheus" "excludePaths" (list "/metrics")) | nindent 12 }}
           - {{ tpl (readFile "snippets/serviceentry.gotmpl") (dict "name" "monitoring" "hosts" $hosts) | nindent 12 }}


### PR DESCRIPTION
## 📌 Summary

This PR fixes the 403 error on prometheus by adding excludePaths for metrics endpoint.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
