### PR TITLE
fix: missing admin team deployment

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml.gotmpl
+++ b/helmfile.d/helmfile-60.teams.yaml.gotmpl
@@ -17,6 +17,21 @@ bases:
 {{- $gatewayName := $v.ingress.platformClass.className }}
 {{- $httpRoute := tpl (readFile "../helmfile.d/snippets/routes.gotmpl") $v | fromYaml }}
 releases:
+  - name: team-ns-admin
+    installed: true
+    namespace: team-admin
+    chart: ../charts/team-ns
+    labels:
+      team: admin
+      pipeline: otomi-task-teams
+    values:
+      - ../values/team-ns/team-ns.gotmpl
+      - name: admin
+        teamId: admin
+        otomi: {{- $v.otomi | toYaml | nindent 10 }}
+        services: []
+        networkPolicy: null
+        resourceQuota: null
 {{- range $teamId, $team := omit $tc "admin" }}
   {{- $teamServices := ($team | get "services" list) }}
   {{- $teamSettings := $team.settings }}
@@ -223,7 +238,6 @@ releases:
     chart: ../charts/team-ns
     labels:
       tag: teams
-      ingress: 'true'
       team: {{ $teamId }}
       pipeline: otomi-task-teams
     values:


### PR DESCRIPTION
## 📌 Summary

This is a fix for a regression on linode/apl-core#3246, where the admin team application is no longer updated in the cluster.
The ingress label has been removed, as it no longer has any usage.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
