### PR TITLE
fix: restore team admin services

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml.gotmpl
+++ b/helmfile.d/helmfile-60.teams.yaml.gotmpl
@@ -29,7 +29,7 @@ releases:
       - name: admin
         teamId: admin
         otomi: {{- $v.otomi | toYaml | nindent 10 }}
-        services: []
+        services: {{- $tc.admin | get "services" list | toYaml | nindent 10 }}
         networkPolicy: null
         resourceQuota: null
 {{- range $teamId, $team := omit $tc "admin" }}


### PR DESCRIPTION
## 📌 Summary

This PR restores routes created by the team-admin, as they were not functional with recent removals of ingress-nginx.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
