### PR TITLE
fix: add excludePaths to authpolicy-jwt for monitoring team

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml.gotmpl
+++ b/helmfile.d/helmfile-60.teams.yaml.gotmpl
@@ -193,7 +193,7 @@ releases:
             otomi.io/auth-policy: monitoring-{{ $teamId }}
         extraManifests:
           - {{ tpl (readFile "../helmfile.d/snippets/authpolicy-oauth2-ext.gotmpl") (dict "prefix" (print "monitoring-" $teamId) "gatewayName" $gatewayName "hosts" (list $alertmanagerHostname $grafanaHostname)) | nindent 12 }}
-          - {{ tpl (readFile "../helmfile.d/snippets/authpolicy-jwt.gotmpl") (dict "name" (print "monitoring-" $teamId) "excludeNamespace" (print "team-" $teamId) "excludeAccount" "monitoring/po-prometheus") | nindent 12 }}
+          - {{ tpl (readFile "../helmfile.d/snippets/authpolicy-jwt.gotmpl") (dict "name" (print "monitoring-" $teamId) "excludeNamespace" (print "team-" $teamId) "excludeAccount" "monitoring/po-prometheus" "excludePaths" (list "/metrics")) | nindent 12 }}
           - {{ tpl (readFile "../helmfile.d/snippets/serviceentry.gotmpl") (dict "name" (print "monitoring-" $teamId) "hosts" (list $alertmanagerHostname $grafanaHostname)) | nindent 12 }}
     {{- if has "msteams" ($teamSettings | get "alerts.receivers" list) }}
   - name: prometheus-msteams-{{ $teamId }}


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
This PR fixes the grafana team monitoring by excluding the `metrics` endpoint.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
