### PR TITLE
fix: setting namespace in team-admin services

### DIFF
--- a/charts/team-ns/templates/routes.yaml
+++ b/charts/team-ns/templates/routes.yaml
@@ -18,6 +18,8 @@
 {{- $useTrafficControl := dig "trafficControl" "enabled" false $s }}
 {{- $serviceName := $s.name }}
 {{- $serviceLabel := $s.name }}
+{{- /* Setting the namespace is only valid for the admin team */}}
+{{- $serviceNamespace := ternary (get $s "namespace") nil (eq $v.teamId "admin") }}
 {{- $defaultHostname := print $serviceName "-" $v.teamId "." $v.domain }}
 {{- $headersRequestSet := dig "headers" "request" "set" nil $s }}
 {{- $headersResponseSet := dig "headers" "response" "set" nil $s }}
@@ -26,7 +28,7 @@
 {{- /* Add specific listener configurations for each cname */}}
 {{- if $useCname }}
   {{- $l := get $extraListeners $ingressClassName }}
-  {{- $l = append $l (dict "name" $serviceName "hostname" $cnameDomain "secretName" (dig "cname" "tlsSecretName" "" $s)) }}
+  {{- $l = append $l (dict "name" $serviceName "namespace" $serviceNamespace "hostname" $cnameDomain "secretName" (dig "cname" "tlsSecretName" "" $s)) }}
   {{- $_ := set $extraListeners $ingressClassName $l }}
 {{- end }}
 ---
@@ -38,6 +40,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
   name: {{ $serviceName }}
+  {{- with $serviceNamespace }}
+  namespace: {{ . }}
+  {{- end }}
   labels:
     otomi.io/app: {{ $serviceLabel }}
 spec:
@@ -113,6 +118,9 @@ apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: {{ $serviceName }}-internal
+  {{- with $serviceNamespace }}
+  namespace: {{ . }}
+  {{- end }}
 spec:
   hosts:
     - {{ $defaultHostname }}
@@ -165,7 +173,11 @@ spec:
           - name: {{ $listener.secretName | quote }}
       allowedRoutes:
         namespaces:
+          {{- if $listener.namespace }}
+          from: All
+          {{- else }}
           from: Same
+          {{- end }}
   {{- end }}
 {{- range $httpRedirects }}
 ---

--- a/tests/fixtures/env/teams/admin/services/misc-admin.yaml
+++ b/tests/fixtures/env/teams/admin/services/misc-admin.yaml
@@ -1,0 +1,12 @@
+kind: AplTeamService
+metadata:
+    name: misc
+    labels:
+        apl.io/teamId: admin
+spec:
+    port: 80
+    namespace: misc
+    cname:
+      domain: misc-admin.cname.com
+      tlsSecretName: 'hello-cert'
+    useCname: true

--- a/tests/fixtures/env/teams/demo/services/hello.yaml
+++ b/tests/fixtures/env/teams/demo/services/hello.yaml
@@ -25,3 +25,4 @@ spec:
         weightV1: 70
         weightV2: 30
     useCname: true
+    namespace: should-be-ignored


### PR DESCRIPTION
## 📌 Summary

Since the Gateway API implementation, setting the namespace field in the team-admin's Services has no effect. This PR fixes that issue.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
