### PR TITLE
chore: use mirror for git-server images

### DIFF
--- a/values/git-server/git-server.gotmpl
+++ b/values/git-server/git-server.gotmpl
@@ -1,12 +1,11 @@
 {{- $v := .Values }}
 {{- $g := $v.apps | get "git-server" dict }}
-{{- if $v.otomi.linodeLkeImageRepository }}
-# image:
-#   repository: "{{ $v.otomi.linodeLkeImageRepository }}/docker/linode/apl-http-git-server"
-# Enable this once ORCS PR is merged: https://bits.linode.com/CNS/orcs/pull/123
-#initImage:
-#  git:
-#    repository: "{{ $v.otomi.linodeLkeImageRepository }}/docker/alpine/git"
+{{- with $v.otomi.linodeLkeImageRepository }}
+image:
+  repository: "{{ . }}/docker/linode/apl-http-git-server"
+initImage:
+  git:
+    repository: "{{ . }}/docker/alpine/git"
 {{- end }}
 repoName: otomi/values.git
 branchName: {{ $v.otomi.git.branch | quote }}


### PR DESCRIPTION
## 📌 Summary

This PR enables the ORCS mirror references for images used by the git-server.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
