### PR TITLE
fix: upgrades prior to 5.x

### DIFF
--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -298,35 +298,38 @@ const getAplOperatorValues = async (): Promise<string> => {
   return await readFile(`${valuesDir}/apl-operator-apl-operator.yaml`, 'utf-8')
 }
 
-export const applyAsApps = async (argv: HelmArguments): Promise<boolean> => {
-  const helmfileSource = argv.file?.toString() || 'helmfile.d/'
-  d.info(`Parsing helm releases defined in ${helmfileSource}`)
-  setup()
-  const otomiVersion = await getImageTagFromValues()
+export const updateOperatorApplication = async (expectedRevision: string): Promise<boolean> => {
+  d.info('Checking running revision of apl-operator...')
   try {
-    const expectedRevision = env.APPS_REVISION || otomiVersion
-    d.info('Checking running revision of apl-operator...')
     const operatorRevisionMatches = await appRevisionMatches(
       'apl-operator-apl-operator',
-      env.APPS_REVISION || otomiVersion,
+      expectedRevision,
       k8s.custom(),
     )
     if (operatorRevisionMatches) {
       d.info(`Expected revision ${expectedRevision} found for apl-operator.`)
+      return false
     } else {
       const values = await getAplOperatorValues()
       d.info(`Updating apl-operator application to revision ${expectedRevision}.`)
       await patchArgoCdApp('apl-operator-apl-operator', expectedRevision, values, k8s.custom())
-      d.info('Skipping further updates until apl-operator has restarted.')
-      return false
+      return true
     }
   } catch (error) {
     if (error instanceof ApiException && error.code === 404) {
       d.info('apl-operator application not found, continuing')
+      return false
     } else {
       throw error
     }
   }
+}
+
+export const applyAsApps = async (argv: HelmArguments): Promise<void> => {
+  const helmfileSource = argv.file?.toString() || 'helmfile.d/'
+  d.info(`Parsing helm releases defined in ${helmfileSource}`)
+  setup()
+  const otomiVersion = await getImageTagFromValues()
   const res = await hf({
     fileOpts: argv.file,
     labelOpts: argv.label,
@@ -397,7 +400,6 @@ export const applyAsApps = async (argv: HelmArguments): Promise<boolean> => {
     errors.map((e) => d.error(e))
     d.error(`Not all applications have been deployed successfully`)
   }
-  return true
 }
 
 export const addGitOpsApps = async (

--- a/src/cmd/apply.test.ts
+++ b/src/cmd/apply.test.ts
@@ -32,6 +32,7 @@ jest.mock('zx', () => ({
 jest.mock('./apply-as-apps', () => ({
   applyAsApps: jest.fn(),
   applyGitOpsApps: jest.fn(),
+  updateOperatorApplication: jest.fn(),
 }))
 
 jest.mock('./apply-teams', () => ({
@@ -94,6 +95,7 @@ describe('Apply command', () => {
       getPackageVersion: require('src/common/values').getPackageVersion,
       applyAsApps: require('./apply-as-apps').applyAsApps,
       applyGitOpsApps: require('./apply-as-apps').applyGitOpsApps,
+      updateOperatorApplication: require('./apply-as-apps').updateOperatorApplication,
       commit: require('./commit').commit,
       runtimeUpgrade: require('src/common/runtime-upgrade').runtimeUpgrade,
       deletePendingHelmReleases: require('src/common/k8s').deletePendingHelmReleases,
@@ -107,6 +109,7 @@ describe('Apply command', () => {
     mockDeps.getPackageVersion.mockReturnValue('1.0.0')
     mockDeps.applyAsApps.mockResolvedValue(true)
     mockDeps.applyGitOpsApps.mockResolvedValue(undefined)
+    mockDeps.updateOperatorApplication.mockResolvedValue(false)
     mockDeps.commit.mockResolvedValue(undefined)
     mockDeps.runtimeUpgrade.mockResolvedValue(undefined)
     mockDeps.deletePendingHelmReleases.mockResolvedValue(undefined)
@@ -376,6 +379,38 @@ describe('Apply command', () => {
 
       process.env.DISABLE_SYNC = originalEnv
       process.env.NODE_ENV = originalIsDev
+    })
+  })
+
+  describe('updateOperatorApplication return value', () => {
+    test('should return early when updateOperatorApplication returns true', async () => {
+      mockDeps.updateOperatorApplication.mockResolvedValue(true)
+
+      await applyAll()
+
+      expect(mockDeps.setDeploymentState).not.toHaveBeenCalled()
+      expect(mockDeps.getDeploymentState).not.toHaveBeenCalled()
+      expect(mockDeps.runtimeUpgrade).not.toHaveBeenCalled()
+      expect(mockDeps.applyAsApps).not.toHaveBeenCalled()
+      expect(mockDeps.applyGitOpsApps).not.toHaveBeenCalled()
+      expect(mockDeps.commit).not.toHaveBeenCalled()
+    })
+
+    test('should continue full deployment when updateOperatorApplication returns false', async () => {
+      mockDeps.updateOperatorApplication.mockResolvedValue(false)
+
+      const originalEnv = process.env.DISABLE_SYNC
+      process.env.DISABLE_SYNC = 'true'
+
+      await applyAll()
+
+      expect(mockDeps.setDeploymentState).toHaveBeenCalled()
+      expect(mockDeps.getDeploymentState).toHaveBeenCalled()
+      expect(mockDeps.runtimeUpgrade).toHaveBeenCalled()
+      expect(mockDeps.applyAsApps).toHaveBeenCalled()
+      expect(mockDeps.applyGitOpsApps).toHaveBeenCalled()
+
+      process.env.DISABLE_SYNC = originalEnv
     })
   })
 

--- a/src/cmd/apply.test.ts
+++ b/src/cmd/apply.test.ts
@@ -102,7 +102,7 @@ describe('Apply command', () => {
     }
 
     // Set up default mock return values
-    mockDeps.getDeploymentState.mockResolvedValue({ status: 'deployed' })
+    mockDeps.getDeploymentState.mockResolvedValue({ status: 'deployed', deployingVersion: '1.0.0' })
     mockDeps.getImageTagFromValues.mockResolvedValue('v1.0.0')
     mockDeps.getPackageVersion.mockReturnValue('1.0.0')
     mockDeps.applyAsApps.mockResolvedValue(true)
@@ -150,23 +150,30 @@ describe('Apply command', () => {
 
       await applyAll()
 
-      // Verify pre-upgrade steps
-      expect(mockDeps.runtimeUpgrade).toHaveBeenCalledWith({ when: 'pre' })
-
-      // Verify deployment state management
-      expect(mockDeps.getDeploymentState).toHaveBeenCalled()
-      expect(mockDeps.getImageTagFromValues).toHaveBeenCalled()
       expect(mockDeps.setDeploymentState).toHaveBeenCalledWith({
         status: 'deploying',
         deployingTag: 'v1.0.0',
         deployingVersion: '1.0.0',
       })
 
+      expect(mockDeps.getDeploymentState).toHaveBeenCalled()
+      // Verify pre-upgrade steps
+      expect(mockDeps.runtimeUpgrade).toHaveBeenCalledWith({
+        when: 'pre',
+        deploymentState: { status: 'deployed', deployingVersion: '1.0.0' },
+      })
+
+      // Verify deployment state management
+      expect(mockDeps.getImageTagFromValues).toHaveBeenCalled()
+
       // Verify core apply process
       expect(mockDeps.applyAsApps).toHaveBeenCalled()
 
       // Verify post-upgrade steps
-      expect(mockDeps.runtimeUpgrade).toHaveBeenCalledWith({ when: 'post' })
+      expect(mockDeps.runtimeUpgrade).toHaveBeenCalledWith({
+        when: 'post',
+        deploymentState: { status: 'deployed', deployingVersion: '1.0.0' },
+      })
 
       // Verify GitOps apps setup
       expect(mockDeps.applyGitOpsApps).toHaveBeenCalled()

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -11,7 +11,7 @@ import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from 'src/co
 import { Argv, CommandModule } from 'yargs'
 import { cd } from 'zx'
 import { runtimeUpgrade } from '../common/runtime-upgrade'
-import { applyAsApps, applyGitOpsApps } from './apply-as-apps'
+import { applyAsApps, applyGitOpsApps, updateOperatorApplication } from './apply-as-apps'
 import { applyTeams } from './apply-teams'
 import { commit } from './commit'
 
@@ -29,11 +29,16 @@ const setup = (): void => {
   mkdirSync(dir, { recursive: true })
 }
 
-export const applyAll = async () => {
+export const applyAll = async (): Promise<void> => {
   const d = terminal(`cmd:${cmdName}:applyAll`)
   const argv: HelmArguments = getParsedArgs()
 
   const tag = await getImageTagFromValues()
+  const revisionUpdated = await updateOperatorApplication(env.APPS_REVISION || tag)
+  if (revisionUpdated) {
+    d.info('Operator has pending update to a different revision. Pausing until restart.')
+    return
+  }
   const deployingVersion = getPackageVersion()
   await setDeploymentState({ status: 'deploying', deployingTag: tag, deployingVersion })
   const deploymentState = await getDeploymentState()
@@ -50,24 +55,16 @@ export const applyAll = async () => {
   }
   // Note that team-ns-admin contains ingress for platform apps.
   const params = cloneDeep(argv)
-  const appsApplyCompleted = await applyAsApps(params)
+  await applyAsApps(params)
 
-  if (appsApplyCompleted) {
-    await runtimeUpgrade({ when: 'post', deploymentState })
-  } else {
-    d.info('Apps apply step not completed, skipping upgrade checks')
-  }
+  await runtimeUpgrade({ when: 'post', deploymentState })
 
   if (!(env.isDev && env.DISABLE_SYNC)) {
     await commit(false)
   }
   await applyGitOpsApps()
-  if (appsApplyCompleted) {
-    await setDeploymentState({ status: 'deployed', version: deployingVersion })
-    d.info('Deployment completed')
-  } else {
-    d.info('Deployment finished with actions pending')
-  }
+  await setDeploymentState({ status: 'deployed', version: deployingVersion })
+  d.info('Deployment completed')
 }
 
 export const apply = async (): Promise<void> => {

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -31,16 +31,17 @@ const setup = (): void => {
 
 export const applyAll = async () => {
   const d = terminal(`cmd:${cmdName}:applyAll`)
-  const prevState = await getDeploymentState()
   const argv: HelmArguments = getParsedArgs()
 
-  await runtimeUpgrade({ when: 'pre' })
-
-  d.info('Start apply all')
-  d.info(`Deployment state: ${JSON.stringify(prevState)}`)
   const tag = await getImageTagFromValues()
   const deployingVersion = getPackageVersion()
   await setDeploymentState({ status: 'deploying', deployingTag: tag, deployingVersion })
+  const deploymentState = await getDeploymentState()
+
+  await runtimeUpgrade({ when: 'pre', deploymentState })
+
+  d.info('Start apply all')
+  d.info(`Deployment state: ${JSON.stringify(deploymentState)}`)
 
   // We still need to deploy all teams because some settings depend on platform apps.
   const teamsApplyCompleted = await applyTeams()
@@ -52,7 +53,7 @@ export const applyAll = async () => {
   const appsApplyCompleted = await applyAsApps(params)
 
   if (appsApplyCompleted) {
-    await runtimeUpgrade({ when: 'post' })
+    await runtimeUpgrade({ when: 'post', deploymentState })
   } else {
     d.info('Apps apply step not completed, skipping upgrade checks')
   }

--- a/src/common/k8s.test.ts
+++ b/src/common/k8s.test.ts
@@ -733,8 +733,8 @@ describe('helm operations in progress check', () => {
 
     await k8s.deletePendingHelmReleases()
     expect(mockGetPendingHelmReleases).toHaveBeenCalled()
-    expect(mockDeleteSecretForHelmRelease).toHaveBeenNthCalledWith(1, 'release-1', 'ns-1')
-    expect(mockDeleteSecretForHelmRelease).toHaveBeenNthCalledWith(3, 'release-2', 'ns-2')
+    expect(mockDeleteSecretForHelmRelease).toHaveBeenNthCalledWith(2, 'release-1', 'ns-1', 2)
+    expect(mockDeleteSecretForHelmRelease).toHaveBeenNthCalledWith(3, 'release-2', 'ns-2', 1)
   })
 })
 

--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -149,14 +149,14 @@ export const getK8sSecret = async (name: string, namespace: string): Promise<Rec
   }
 }
 
-export const deleteSecretForHelmRelease = async (releaseName: string, namespace: string) => {
+export const deleteSecretForHelmRelease = async (releaseName: string, namespace: string, revision = 1) => {
   const d = terminal('common:k8s:deleteSecretForHelmRelease')
-  d.info(`Deleting secret for Helm release ${releaseName} in namespace ${namespace}`)
+  d.info(`Deleting secret for Helm release ${releaseName} revision ${revision} in namespace ${namespace}`)
   try {
-    await coreClient.deleteNamespacedSecret({ name: `sh.helm.release.v1.${releaseName}.v1`, namespace })
-    d.debug(`Deleted secret for Helm release ${releaseName} in namespace ${namespace}`)
+    await coreClient.deleteNamespacedSecret({ name: `sh.helm.release.v1.${releaseName}.v${revision}`, namespace })
+    d.debug(`Deleted secret for Helm release ${releaseName} revision ${revision} in namespace ${namespace}`)
   } catch (error) {
-    if (error?.response?.statusCode !== 404) {
+    if (!(error instanceof ApiException && error.code === 404)) {
       throw error
     }
   }
@@ -194,9 +194,11 @@ export const deletePendingHelmReleases = async (): Promise<void> => {
   const d = terminal(`common:k8s:deletePendingHelmReleases`)
   const pendingHelmReleases = await getPendingHelmReleases()
   if (pendingHelmReleases.length > 0) {
-    d.info(`Pending Helm operations detected for releases: ${pendingHelmReleases.join(', ')}. removing secrets...`)
+    d.info(
+      `Pending Helm operations detected for releases: ${pendingHelmReleases.map((r) => `${r.namespace}/${r.name}:v${r.revision}`).join(', ')}. removing secrets...`,
+    )
     for (const release of pendingHelmReleases) {
-      await deleteSecretForHelmRelease(release.name, release.namespace)
+      await deleteSecretForHelmRelease(release.name, release.namespace, release.revision)
     }
   }
 }

--- a/src/common/runtime-upgrade.test.ts
+++ b/src/common/runtime-upgrade.test.ts
@@ -19,7 +19,6 @@ jest.mock('./runtime-upgrades/runtime-upgrades', () => ({
   },
 }))
 
-const mockGetDeploymentState = getDeploymentState as jest.MockedFunction<typeof getDeploymentState>
 const mockWaitForArgoCDAppSync = waitForArgoCDAppSync as jest.MockedFunction<typeof waitForArgoCDAppSync>
 const mockWaitForArgoCDAppHealthy = waitForArgoCDAppHealthy as jest.MockedFunction<typeof waitForArgoCDAppHealthy>
 const mockGetApplications = getApplications as jest.MockedFunction<typeof getApplications>
@@ -47,9 +46,7 @@ describe('runtimeUpgrade', () => {
 
   describe('first installation scenarios', () => {
     it('should skip runtime upgrade for first installation (empty deployment state)', async () => {
-      mockGetDeploymentState.mockResolvedValue({})
-
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: {} })
 
       expect(mockDebugger.info).toHaveBeenCalledWith(
         'Skipping the runtime upgrade procedure because this is initial installation',
@@ -57,8 +54,6 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should skip runtime upgrade for null deployment state', async () => {
-      mockGetDeploymentState.mockResolvedValue(null as any)
-
       await runtimeUpgrade({ when: 'pre' })
 
       expect(mockDebugger.info).toHaveBeenCalledWith(
@@ -69,9 +64,7 @@ describe('runtimeUpgrade', () => {
 
   describe('version handling and filtering', () => {
     it('should skip when no applicable upgrades found', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '2.0.0', deployingVersion: '2.0.1' })
-
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: { version: '2.0.0', deployingVersion: '2.0.1' } })
 
       expect(mockDebugger.info).toHaveBeenCalledWith('The current version of the App Platform: 2.0.0')
       expect(mockDebugger.info).toHaveBeenCalledWith('Deploying essential manifests')
@@ -79,9 +72,7 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should use current version when deployment state has no version', async () => {
-      mockGetDeploymentState.mockResolvedValue({ status: 'deployed', deployingVersion: '1.0.1' })
-
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: { status: 'deployed', deployingVersion: '1.0.1' } })
 
       expect(mockDebugger.info).toHaveBeenCalledWith(
         'Skipping the runtime upgrade procedure because this is initial installation',
@@ -103,9 +94,7 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should execute global pre operations', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0', deployingVersion: '1.0.1' })
-
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: { version: '1.0.0', deployingVersion: '1.0.1' } })
 
       expect(mockPreOperation).toHaveBeenCalledWith({
         debug: mockDebugger,
@@ -114,9 +103,7 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should execute global post operations', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0', deployingVersion: '1.0.1' })
-
-      await runtimeUpgrade({ when: 'post' })
+      await runtimeUpgrade({ when: 'post', deploymentState: { version: '1.0.0', deployingVersion: '1.0.1' } })
 
       expect(mockPostOperation).toHaveBeenCalledWith({
         debug: mockDebugger,
@@ -131,9 +118,7 @@ describe('runtimeUpgrade', () => {
         pre: mockPreOperation,
       })
 
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0' })
-
-      await runtimeUpgrade({ when: 'post' })
+      await runtimeUpgrade({ when: 'post', deploymentState: { version: '1.0.0' } })
 
       expect(mockPreOperation).not.toHaveBeenCalled()
     })
@@ -161,9 +146,8 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should execute application-specific operations with ArgoCD waits', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0', deployingVersion: '1.0.1' })
       mockGetApplications.mockResolvedValue(['istio-operator'])
-      await runtimeUpgrade({ when: 'post' })
+      await runtimeUpgrade({ when: 'post', deploymentState: { version: '1.0.0', deployingVersion: '1.0.1' } })
 
       expect(mockWaitForArgoCDAppSync).toHaveBeenCalledWith('istio-operator', mockCustomApi, mockDebugger)
       expect(mockWaitForArgoCDAppHealthy).toHaveBeenCalledWith('istio-operator', mockCustomApi, mockDebugger)
@@ -176,10 +160,9 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should not execute application operations for wrong phase', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0', deployingVersion: '1.0.1' })
       mockGetApplications.mockResolvedValue(['argocd'])
 
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: { version: '1.0.0', deployingVersion: '1.0.1' } })
 
       expect(mockWaitForArgoCDAppSync).toHaveBeenCalledWith('argocd', mockCustomApi, mockDebugger)
       expect(mockWaitForArgoCDAppHealthy).toHaveBeenCalledWith('argocd', mockCustomApi, mockDebugger)
@@ -207,9 +190,7 @@ describe('runtimeUpgrade', () => {
     })
 
     it('should execute both global and application operations in correct order', async () => {
-      mockGetDeploymentState.mockResolvedValue({ version: '1.0.0', deployingVersion: '1.0.1' })
-
-      await runtimeUpgrade({ when: 'pre' })
+      await runtimeUpgrade({ when: 'pre', deploymentState: { version: '1.0.0', deployingVersion: '1.0.1' } })
 
       expect(mockGlobalPre).toHaveBeenCalledWith({
         debug: mockDebugger,

--- a/src/common/runtime-upgrade.ts
+++ b/src/common/runtime-upgrade.ts
@@ -2,16 +2,16 @@ import semver from 'semver'
 import { getApplications } from 'src/cmd/apply-as-apps'
 import { terminal } from './debug'
 import { deployEssential } from './hf'
-import { getDeploymentState, k8s, waitForArgoCDAppHealthy, waitForArgoCDAppSync } from './k8s'
+import { DeploymentState, k8s, waitForArgoCDAppHealthy, waitForArgoCDAppSync } from './k8s'
 import { RuntimeUpgradeContext, RuntimeUpgrades, runtimeUpgrades } from './runtime-upgrades/runtime-upgrades'
 
 interface RuntimeUpgradeArgs {
   when: string
+  deploymentState?: DeploymentState
 }
 
-export async function runtimeUpgrade({ when }: RuntimeUpgradeArgs): Promise<void> {
+export async function runtimeUpgrade({ when, deploymentState }: RuntimeUpgradeArgs): Promise<void> {
   const d = terminal('cmd:upgrade:runtimeUpgrade')
-  const deploymentState = await getDeploymentState()
 
   if (!deploymentState?.version || !deploymentState?.deployingVersion) {
     d.info('Skipping the runtime upgrade procedure because this is initial installation')
@@ -69,9 +69,12 @@ export async function runtimeUpgrade({ when }: RuntimeUpgradeArgs): Promise<void
             d.info(
               `Runtime upgrade operations detected for version ${upgrade.version}, application: ${applicationName}`,
             )
-            // Wait for the ArgoCD app to be synced and healthy before running the operation
-            await waitForArgoCDAppSync(applicationName, k8s.custom(), d)
-            await waitForArgoCDAppHealthy(applicationName, k8s.custom(), d)
+            // In dev-mode, the app is likely not syncing in the cluster
+            if (process.env.NODE_ENV !== 'development' || applicationName !== 'apl-operator-apl-operator') {
+              // Wait for the ArgoCD app to be synced and healthy before running the operation
+              await waitForArgoCDAppSync(applicationName, k8s.custom(), d)
+              await waitForArgoCDAppHealthy(applicationName, k8s.custom(), d)
+            }
             //execute the application-specific operation
             await applicationOperation(context)
           }


### PR DESCRIPTION
## 📌 Summary

This PR backports two fixes regarding upgrades to the release branch 4.15.x. These fixes have apl-operator process a self-upgrade before running other upgrade scripts, and also set the revision of dependencies correctly.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
