### PR TITLE
fix: error handling in helm cleanup

### DIFF
--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -158,7 +158,7 @@ export const deleteSecretForHelmRelease = async (releaseName: string, namespace:
     await coreClient.deleteNamespacedSecret({ name: `sh.helm.release.v1.${releaseName}.v${revision}`, namespace })
     d.debug(`Deleted secret for Helm release ${releaseName} revision ${revision} in namespace ${namespace}`)
   } catch (error) {
-    if (error?.response?.statusCode !== 404) {
+    if (!(error instanceof ApiException && error.code === 404)) {
       throw error
     }
   }


### PR DESCRIPTION
## 📌 Summary

This is a followup PR to fix error handling during removal of stuck Helm installs. As the error itself should only occur on race conditions it likely has little practical impact.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
