### PR TITLE
fix: prefer internal repo url on gitops applications in dev mode

### DIFF
--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -437,7 +437,7 @@ export const addGitOpsApps = async (
   deps = { getArgocdGitopsManifest, applyArgocdApp, getStoredGitRepoConfig },
 ): Promise<void> => {
   d.info(`Adding GitOps apps: ${Array.from(appNames).join(', ')}`)
-  const { repoUrl, branch } = await deps.getStoredGitRepoConfig()
+  const { repoUrl, branch } = await deps.getStoredGitRepoConfig(true)
   if (appNames.has(ARGOCD_APP_GITOPS_GLOBAL_NAME)) {
     d.debug('Creating GitOps apps for cluster resources')
     const appManifest = deps.getArgocdGitopsManifest(ARGOCD_APP_GITOPS_GLOBAL_NAME, repoUrl, branch)

--- a/src/common/git-config.ts
+++ b/src/common/git-config.ts
@@ -89,7 +89,7 @@ export async function getGitConfigData(): Promise<GitConfigData | undefined> {
  * Reconstructs GitRepoConfig from stored ConfigMap + Secret.
  * This avoids calling hfValues() in operator startup path.
  */
-export async function getStoredGitRepoConfig(): Promise<GitRepoConfig> {
+export async function getStoredGitRepoConfig(preferInternal = false): Promise<GitRepoConfig> {
   let [configData, credentials] = await Promise.all([getGitConfigData(), getGitCredentials()])
 
   // Try the canonical secret populated by SealedSecrets/ESO (same source as getRepo())
@@ -133,7 +133,7 @@ export async function getStoredGitRepoConfig(): Promise<GitRepoConfig> {
       email: 'pipeline@cluster.local',
     }
   }
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'development' && !preferInternal) {
     configData.repoUrl = process.env.GIT_REPO_URL
   }
   const { username, password } = credentials


### PR DESCRIPTION
## 📌 Summary

In development mode, the Git repo URL invariably replaced with the value from the environment variable `GIT_REPO_URL`. This breaks ArgoCD applications which need an internal repo reference (i.e. GitOps) when the internal Git server is used. SealedSecrets cannot be tested that way.

This PR conditionally skips this replacement.

## 🔍 Reviewer Notes

GIVEN apl installation with internal git server
WHEN I connect local apl-operator to the public URL
THEN Argocd Apps to not change their source URLs 

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
