### PR TITLE
fix: replace team names for avoiding variable name issues

### DIFF
--- a/values/loki/loki-raw.gotmpl
+++ b/values/loki/loki-raw.gotmpl
@@ -3,6 +3,7 @@
 {{- $otomiAdmin := "otomi-admin" }}
 {{- $obj := $v.obj.provider }}
 {{- if $v.otomi.isMultitenant }}
+{{- $teamNames := sortAlpha (keys $v.teamConfig) }}
 resources:
   - apiVersion: external-secrets.io/v1
     kind: ExternalSecret
@@ -22,14 +23,14 @@ resources:
           type: Opaque
           data:
             authn.yaml: |
-              {{ "{{ " }}$adminPassword := .adminPassword | toString{{ " }}" }}
               users:
                 - username: otomi-admin
-                  password: {{ "\"{{ $adminPassword }}\"" }}
+                  password: '{{ "{{ .adminPassword }}" }}'
                   orgid: admins
-              {{- range $id, $team := $v.teamConfig }}
+              {{- range $id := $teamNames }}
+              {{- $passwordVar := printf "{{ .team_%s }}" (sha1sum $id) }}
                 - username: {{ $id }}
-                  password: {{ printf "\"{{ .team_%s_password | toString }}\"" $id }}
+                  password: {{ $passwordVar }}
                   orgid: {{ $id }}
               {{- end }}
       data:
@@ -37,8 +38,8 @@ resources:
           remoteRef:
             key: loki-secrets
             property: adminPassword
-        {{- range $id, $team := $v.teamConfig }}
-        - secretKey: team_{{ $id }}_password
+        {{- range $id := $teamNames }}
+        - secretKey: team_{{ sha1sum $id }}
           remoteRef:
             key: team-{{ $id }}-settings-secrets
             property: settings_password


### PR DESCRIPTION
## 📌 Summary

Team names may contain dashes. They are however used in variable names for creating ExternalSecrets, which is not valid. This PR replaces the team name with a checksum, which also rules out any other potentially invalid characters.
Also the team names are sorted to avoid unnecessary ArgoCD cycles.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
