### PR TITLE
feat: set user and group ids that are matching security context [TOOLS][MAJOR]

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -120,8 +120,9 @@ RUN set -uex && \
 FROM ubuntu:24.04 AS final
 
 RUN mkdir -p /home/app
-RUN groupadd -r app &&\
-  useradd -r -g app -d /home/app -s /sbin/nologin -c "Docker image user" app
+RUN groupadd -g 1001 app && \
+    groupadd -g 2000 appfsgroup && \
+    useradd -u 1001 -g app -G appfsgroup -d /home/app -s /sbin/nologin -c "Docker image user" app
 ENV HOME=/home/app
 ENV APP_HOME=/home/app/tools
 RUN mkdir $APP_HOME

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -57,9 +57,10 @@ RUN curl -LO "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/bin/yq
 
 RUN mkdir -p /home/app
-RUN groupadd -u 1001 app && \
-  useradd -u 1001 -g app -d /home/app -s /sbin/nologin -c "Docker image user" app && \
-  groupadd -u 2000 appfsgroup && \
+RUN groupadd -g 1001 app && \
+    groupadd -g 2000 appfsgroup && \
+    useradd -u 1001 -g app -G appfsgroup -d /home/app -s /sbin/nologin -c "Docker image user" app
+
 ENV HOME=/home/app
 ENV APP_HOME=/home/app/tools
 RUN mkdir $APP_HOME

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -57,8 +57,9 @@ RUN curl -LO "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/bin/yq
 
 RUN mkdir -p /home/app
-RUN groupadd -r app && \
-  useradd -r -g app -d /home/app -s /sbin/nologin -c "Docker image user" app
+RUN groupadd -u 1001 app && \
+  useradd -u 1001 -g app -d /home/app -s /sbin/nologin -c "Docker image user" app && \
+  groupadd -u 2000 appfsgroup && \
 ENV HOME=/home/app
 ENV APP_HOME=/home/app/tools
 RUN mkdir $APP_HOME


### PR DESCRIPTION
## 📌 Summary

Set correct user and group IDs that matches the securityContext.

#3356
## 🔍 Reviewer Notes

Mismatch between tools/Dockerfile and https://github.com/linode/apl-core/blob/APL-1958/charts/apl-operator/values.yaml#L25

```
# k exec -n apl-operator deploy/apl-operator -c apl-operator -it -- bash
groups: cannot find name for group ID 1001
groups: cannot find name for group ID 2000
```

```
I have no name!@apl-operator-7967cc47f9-mzllr:~/stack$ whoami
whoami: failed to get username: No such id: 1001
```

Expected output
```
# k exec -n apl-operator deploy/apl-operator -c apl-operator -it -- bash
app@apl-operator-5849895577-v5ch2:~/stack$ whoami
app
app@apl-operator-5849895577-v5ch2:~/stack$
```
## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
