### PR TITLE
fix: remove obsolete configuration from team values

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml.gotmpl
+++ b/helmfile.d/helmfile-60.teams.yaml.gotmpl
@@ -28,8 +28,6 @@ releases:
       - ../values/team-ns/team-ns.gotmpl
       - name: admin
         teamId: admin
-        otomi: {{- $v.otomi | toYaml | nindent 10 }}
-        services: {{- $tc.admin | get "services" list | toYaml | nindent 10 }}
         networkPolicy: null
         resourceQuota: null
 {{- range $teamId, $team := omit $tc "admin" }}


### PR DESCRIPTION
## 📌 Summary

This PR removes two value lookups from the template. `otomi` is no longer used directly in any templates of the `team-ns` chart. `services` is handled in the `team-ns.gotmpl` and does not need special treatment for team `admin`. This fixes an error in apl-operator, when the team `admin` is not explicitly configured with any services (e.g. during initial minimal setup).

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
