### PR TITLE
feat: insert defaults into initial secret

### DIFF
--- a/src/common/git-config.ts
+++ b/src/common/git-config.ts
@@ -5,6 +5,7 @@ import { createUpdateGenericSecret, ensureNamespaceExists, getK8sSecret, k8s } f
 import { loadYaml } from './utils'
 import { generate as generatePassword } from 'generate-password'
 import { $ } from 'zx'
+import { get } from 'lodash'
 
 const d = terminal('common:git-config')
 
@@ -37,6 +38,7 @@ export interface GitRepoConfig {
 
 export interface GitConfigData {
   repoUrl: string
+  publicRepoUrl?: string
   branch: string
   email: string
   username?: string
@@ -164,10 +166,17 @@ export async function getInitialGitConfig(): Promise<{ config: Record<string, an
     symbols: '!@#$%&*',
     strict: true,
   })
+  const defaultConfig: GitConfigData = {
+    ...GIT_DEFAULT_CONFIG,
+    username: 'otomi-admin',
+    password: initialPassword,
+  }
+  const domainSuffix = get(inputValues, 'cluster.domainSuffix')
+  if (domainSuffix && typeof domainSuffix === 'string') {
+    defaultConfig.publicRepoUrl = `https://git.${domainSuffix}/otomi/values.git`
+  }
   return {
-    config: {
-      password: initialPassword,
-    },
+    config: defaultConfig,
     isInitial: true,
   }
 }

--- a/src/common/git-config.ts
+++ b/src/common/git-config.ts
@@ -200,7 +200,7 @@ export async function setGitConfig(config: Record<string, any>, coreV1Api?: Core
 
   const secretData: Partial<GitConfigData> = {}
   // Extract data in valid fields that has non-empty values input
-  for (const fieldName of ['repoUrl', 'branch', 'email', 'username', 'password']) {
+  for (const fieldName of ['repoUrl', 'publicRepoUrl', 'branch', 'email', 'username', 'password']) {
     if (config[fieldName]) {
       secretData[fieldName] = String(config[fieldName])
     }


### PR DESCRIPTION
## 📌 Summary

This PR adds the default repository information to the connection secret on initial clusters, providing more simplicity for platform administration to where to look it up.

Note that `publicRepoUrl` is only there for information purposes and intentionally not part of the schema. After migrating to another repository it is obsolete and removed.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
