### PR TITLE
ci: apl chart image repository overwrite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -309,7 +309,6 @@ jobs:
           LKE_APL_FIREWALL_INBOUND_RULES: ${{ secrets.LKE_APL_FIREWALL_INBOUND_RULES }}
         run: |
           touch values.yaml
-
           adminPassword="$(head /dev/urandom | tr -dc 'A-Za-z0-9' | head -c 24)"
 
           install_args=(otomi chart/apl --wait --wait-for-jobs --timeout 90m0s \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -328,7 +328,7 @@ jobs:
             --set otomi.adminPassword=$adminPassword \
             --set otomi.version=${GITHUB_REF##*/} \
             --set apps.linode-cfw.enabled=true \
-            --set operator.image.repository=docker.io/linode/apl-operator
+            --set operator.image.repository=docker.io/linode/apl-core
           )
 
           [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -327,8 +327,9 @@ jobs:
             --set otomi.hasExternalDNS=true \
             --set otomi.adminPassword=$adminPassword \
             --set otomi.version=${GITHUB_REF##*/} \
-            --set apps.linode-cfw.enabled=true) \
+            --set apps.linode-cfw.enabled=true \
             --set operator.image.repository=docker.io/linode/apl-operator
+          )
 
           [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
           [[ '${{ inputs.certificate }}' == 'letsencrypt_production' ]] && echo "$LETSENCRYPT_PRODUCTION" >> values.yaml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,10 +22,6 @@ on:
         description: 'Select Domain Zone'
         type: string
         default: DNS-Integration
-      kms:
-        description: 'Should APL encrypt secrets in values repo (DNS or KMS is turned on)?'
-        type: string
-        default: age
       certificate:
         description: 'Select certificate issuer'
         type: string
@@ -88,13 +84,7 @@ on:
           - Zone-2
           - Random
           - DNS-Integration
-      kms:
-        type: choice
-        description: Should APL encrypt secrets in values repo (DNS or KMS is turned on)?
-        options:
-          - age
-          - no_kms
-        default: no_kms
+        default: Random
       certificate:
         type: choice
         description: Select certificate issuer
@@ -144,7 +134,6 @@ jobs:
           echo 'install_profile: ${{ inputs.install_profile }}'
           echo 'lke_tier: ${{ inputs.lke_tier }}'
           echo 'kubernetes_version: ${{ inputs.kubernetes_version }}'
-          echo 'kms: ${{ inputs.kms }}'
           echo 'domain_zone: ${{ inputs.domain_zone }}'
           echo 'certificate: ${{ inputs.certificate }}'
           echo 'is_pre_installed: ${{ inputs.is_pre_installed }}'
@@ -339,11 +328,11 @@ jobs:
             --set otomi.hasExternalDNS=true \
             --set otomi.adminPassword=$adminPassword \
             --set otomi.version=${GITHUB_REF##*/} \
-            --set apps.linode-cfw.enabled=true)
+            --set apps.linode-cfw.enabled=true) \
+            --set operator.image.repository=docker.io/linode/apl-operator
 
           [[ '${{ inputs.certificate }}' == 'letsencrypt_staging' ]] && echo "$LETSENCRYPT_STAGING" >> values.yaml
           [[ '${{ inputs.certificate }}' == 'letsencrypt_production' ]] && echo "$LETSENCRYPT_PRODUCTION" >> values.yaml
-          [[ '${{ inputs.kms }}' == 'age' ]] && install_args+=(--set kms.sops.provider=age)
           [[ '${{ inputs.is_pre_installed }}' == 'true' ]] && install_args+=(--set otomi.isPreInstalled=true)
           if [[ '${{ inputs.disableORCS }}' == 'true' ]]; then
             install_args+=(--set otomi.useORCS=false)

--- a/chart/apl/templates/deployment.yaml
+++ b/chart/apl/templates/deployment.yaml
@@ -1,7 +1,5 @@
 {{- $kms := .Values.kms | default dict }}
-{{- $imageName := .Values.imageName | default "linode/apl-core" }}
 {{- $version := .Values.otomi.version | default .Chart.AppVersion }}
-{{- $useORCS := .Values.otomi.useORCS }}
 {{- $skipDeployment := .Values.installation.skipOperatorDeployment }}
 {{- if not $skipDeployment }}
 apiVersion: apps/v1
@@ -38,11 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: apl-operator
-          {{- if $useORCS }}
-          image: "mirror.registry.linodelke.net/docker/{{ $imageName }}:{{ $version }}"
-          {{- else }}
-          image: "docker.io/{{ $imageName }}:{{ $version }}"
-          {{- end }}
+          image: "{{ .Values.operator.image.repository }}:{{ $version }}"
           imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/chart/apl/templates/post-job.yaml
+++ b/chart/apl/templates/post-job.yaml
@@ -1,7 +1,5 @@
-{{- $kms := .Values.kms | default dict }}
-{{- $imageName := .Values.imageName | default "linode/apl-core" }}
 {{- $version := .Values.otomi.version | default .Chart.AppVersion }}
-{{- $useORCS := .Values.otomi.useORCS }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,11 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: destroy
-          {{- if $useORCS }}
-          image: "mirror.registry.linodelke.net/docker/{{ $imageName }}:{{ $version }}"
-          {{- else }}
-          image: "{{ $imageName }}:{{ $version }}"
-          {{- end }}
+          image: "{{ .Values.operator.image.repository }}:{{ $version }}"
           imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -62,11 +56,6 @@ spec:
               value: /home/app/stack/env
             - name: VALUES_INPUT
               value: /secret/values.yaml
-          {{- if hasKey $kms "sops" }}
-          envFrom:
-            - secretRef:
-                name: {{ include "apl-operator.fullname" . }}-sops-secrets
-          {{- end }}
           volumeMounts:
             - name: otomi-values
               mountPath: /home/app/stack/env

--- a/chart/apl/values.yaml
+++ b/chart/apl/values.yaml
@@ -96,25 +96,6 @@ otomi:
 #       apiSecret: ''
 #       email: ''
 #       proxied: # true|false (default is true)
-# KMS for encrypting values
-# kms:
-#   sops:
-#   # provider can be one of aws|azure|google
-#     provider: ''
-#     aws:
-#       keys: ''
-#       accessKey: ''
-#       secretKey: ''
-#       region: ''
-#     azure:
-#       keys: ''
-#       tenantID: ''
-#       clientID: ''
-#       clientSecret: ''
-#     google:
-#       keys: ''
-#       accountJson: ''
-#       project: ''
 # Bring your own IDP, or leave commented out to use keycloak as IDP
 # oidc:
 #   clientID: ''
@@ -148,6 +129,8 @@ operator:
   pollIntervalMs: 1000
   # Reconcile interval for applying changes (milliseconds)
   reconcileIntervalMs: 300000
+  image:
+    repository: "mirror.registry.linodelke.net/docker/linode/apl-operator"
 
 installation:
   mode: standard

--- a/chart/apl/values.yaml
+++ b/chart/apl/values.yaml
@@ -130,7 +130,7 @@ operator:
   # Reconcile interval for applying changes (milliseconds)
   reconcileIntervalMs: 300000
   image:
-    repository: "mirror.registry.linodelke.net/docker/linode/apl-operator"
+    repository: "mirror.registry.linodelke.net/docker/linode/apl-core"
 
 installation:
   mode: standard


### PR DESCRIPTION
## 📌 Summary

This pull request simplifies and standardizes how the APL operator image is configured and removes legacy KMS (Key Management Service) handling from both the CI workflow and Helm chart templates. The image repository is now set via a single value, and all logic for toggling KMS providers and related environment variables has been removed.

**Helm chart improvements:**

* The operator image is now set using `operator.image.repository` in both `deployment.yaml` and `post-job.yaml`, removing the need for conditional logic and the `imageName`/`useORCS` variables. [[1]](diffhunk://#diff-f1b46d25b2473a8488d00d39b9a9d843f10c1ca91c147dfe635355749de4a00eL2-L4) [[2]](diffhunk://#diff-f1b46d25b2473a8488d00d39b9a9d843f10c1ca91c147dfe635355749de4a00eL41-R39) [[3]](diffhunk://#diff-b262a1fc7c6233f41e03a189869ae5578f8c25e0067bcf6e23b86d75dc967a7eL1-R2) [[4]](diffhunk://#diff-b262a1fc7c6233f41e03a189869ae5578f8c25e0067bcf6e23b86d75dc967a7eL35-R33) [[5]](diffhunk://#diff-e6faca3f71344efcd99d239dc755f3a70e03eccb31eb4842c644419e3a16ef76R132-R133)

**KMS and SOPS removal:**

* All KMS-related values and SOPS secret handling have been removed from the Helm chart templates and `values.yaml`, including the conditional mounting of SOPS secrets in jobs. [[1]](diffhunk://#diff-b262a1fc7c6233f41e03a189869ae5578f8c25e0067bcf6e23b86d75dc967a7eL65-L69) [[2]](diffhunk://#diff-e6faca3f71344efcd99d239dc755f3a70e03eccb31eb4842c644419e3a16ef76L99-L117)

**CI workflow simplification:**

* The `kms` input and related logic have been removed from `.github/workflows/integration.yml`, streamlining the workflow and eliminating unused options. [[1]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL25-L28) [[2]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL91-R87) [[3]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL147) [[4]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL342-L346)

**Minor fixes:**

* The default value for the `domain_zone` input in the workflow has been corrected to `Random`.
* The operator image repository is explicitly set in the workflow install arguments for clarity.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
