### PR TITLE
fix: push on initial install and encode credentials

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -81,9 +81,12 @@ const commitAndPush = async (gitConfig: GitRepoConfig, initialInstall = false): 
     const filesChangedCount = statusOutput.split('\n').length - 1
     if (filesChangedCount === 0) {
       d.log('Nothing to commit')
-      return
+      if (!initialInstall) {
+        return
+      }
+    } else {
+      await $git`git commit -m ${message} --no-verify`.quiet()
     }
-    await $git`git commit -m ${message} --no-verify`.quiet()
   } catch (e) {
     const errorMsg = `commitAndPush error: ${e?.message?.replace(password, '****')}`
     d.error(errorMsg)

--- a/src/common/git-config.ts
+++ b/src/common/git-config.ts
@@ -86,10 +86,10 @@ export function getAuthUrlFromGitConfig(credentials: Partial<GitConfigData>): st
   }
   const url = new URL(repoUrl)
   if (username) {
-    url.username = username
-    url.password = password
+    url.username = encodeURIComponent(username)
+    url.password = encodeURIComponent(password)
   } else {
-    url.username = password
+    url.username = encodeURIComponent(password)
     url.password = ''
   }
   return url.toString()


### PR DESCRIPTION
## 📌 Summary

This PR fixes two issues that were discovered in the course of an installation:
* When the first push attempt to the initial repository fails, it is not reattempted if there are no new commits. This PR changes that behavior for the initial installation.
* The login credentials must be URL-encoded separately for the Git client.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
