### PR TITLE
feat: disable automatic sealing key renewal

### DIFF
--- a/values/sealed-secrets/sealed-secrets.gotmpl
+++ b/values/sealed-secrets/sealed-secrets.gotmpl
@@ -7,3 +7,6 @@ resources: {{- $app.resources.operator | toYaml | nindent 2 }}
 image:
   registry: "{{- $v.otomi.linodeLkeImageRepository }}/docker"
 {{- end }}
+
+# A value of 0 will deactivate automatic key renewal, so admins can backup keys during a maintenance window.
+keyrenewperiod: 0


### PR DESCRIPTION
## 📌 Summary

Admins must know when sealing key is rotated so they can create key backup. Otherwise they may end up in not having all sealing keys during the disaster recover.

## 🔍 Reviewer Notes

https://github.com/bitnami/sealed-secrets#sealing-key-renewal

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
