### PR TITLE
fix: templating values for multi-tenant grafana

### DIFF
--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -244,13 +244,6 @@ kubeEtcd:
 kubelet:
   enabled: false
 
-{{- if eq $v.cluster.linode.tier "enterprise" }}
-coreDns:
-  service:
-    selector:
-      k8s-app: coredns
-{{- end }}
-
 extraManifests:
   - {{ tpl (readFile "../../helmfile.d/snippets/authpolicy-oauth2-ext.gotmpl") (dict "prefix" (print "monitoring-" $teamId) "gatewayName" $gatewayName "hosts" (list $alertmanagerHostname $grafanaHostname)) | nindent 12 }}
   - {{ tpl (readFile "../../helmfile.d/snippets/authpolicy-jwt.gotmpl") (dict "name" (print "monitoring-" $teamId) "allowGroups" (list "platform-admin" $teamGroupName) "excludeNamespace" $teamGroupName "excludeAccount" "monitoring/po-prometheus" "excludePaths" (list "/metrics")) | nindent 12 }}


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

```
Writing values file /tmp/otomi/values/team-api2-prometheus-api2.yaml
unexpected error: *fmt.wrapError: unmarshalling yaml /tmp/helmfile2729293225/team-api2-prometheus-api2-values-5546c7ffd9: yaml: unmarshal errors:
  line 276: mapping key "coreDns" already defined at line 270

    at AsyncLocalStorage.run (node:internal/async_local_storage/async_context_frame:63:14)
    exit code: 1
2026-06-29T14:50:23.999Z otomi:operator:apl-operator:error [poll] Apply process failed ApplyAsApps for teams failed
```

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
