### PR TITLE
chore: remove outdated line from adr

### DIFF
--- a/adr/2026-05-20-gateway-api.md
+++ b/adr/2026-05-20-gateway-api.md
@@ -44,7 +44,6 @@ Chosen option: **Kubernetes Gateway API with Istio**, because it eliminates the 
 - Good, because it removes the unstable two-controller chain.
 - Good, because `HTTPRoute` is a first-class Kubernetes API resource with rich, extensible semantics.
 - Good, because Istio is the `GatewayClass` implementation, so the mesh and the ingress layer are the same system.
-- Bad, because CNAME listener support relies on the experimental `XListenerSet` resource (see Negative Consequences above).
 
 ## Links
 


### PR DESCRIPTION
## 📌 Summary

This PR just removed one line from the ADR on the Gateway API implementation, which does not apply.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
