### PR TITLE
ci: add BYO_GIT checkbox to the Deploy APL action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -110,7 +110,7 @@ on:
         type: boolean
         default: true
       BYO_GIT:
-        description: 'Check the box to use a custom git repository (requires BYO_GIT_PAT and BYO_GIT_URL secrets)'
+        description: 'Use external values repo instead of the default'
         type: boolean
         default: false
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -109,6 +109,10 @@ on:
         description: 'Check the box to enable Wiz integration'
         type: boolean
         default: true
+      BYO_GIT:
+        description: 'Check the box to use a custom git repository (requires BYO_GIT_PAT and BYO_GIT_URL secrets)'
+        type: boolean
+        default: false
 
 env:
   CACHE_REGISTRY: ghcr.io
@@ -139,6 +143,18 @@ jobs:
           echo 'certificate: ${{ inputs.certificate }}'
           echo 'is_pre_installed: ${{ inputs.is_pre_installed }}'
           echo 'disableORCS: ${{ inputs.disableORCS }}'
+          echo 'BYO_GIT: ${{ inputs.BYO_GIT }}'
+
+      - name: Validate BYO_GIT secrets
+        if: ${{ inputs.BYO_GIT }}
+        env:
+          BYO_GIT_PAT: ${{ secrets.BYO_GIT_PAT }}
+          BYO_GIT_URL: ${{ secrets.BYO_GIT_URL }}
+        run: |
+          if [[ -z "$BYO_GIT_PAT" ]] || [[ -z "$BYO_GIT_URL" ]]; then
+            echo "BYO_GIT is enabled but BYO_GIT_PAT or BYO_GIT_URL secrets are not set."
+            exit 1
+          fi
 
   preprocess-linode-input:
     needs: preprocess-input
@@ -308,6 +324,8 @@ jobs:
           EDGEDNS_HOST: ${{ secrets.EDGEDNS_HOST }}
           LKE_CP_ACL_IPV4: ${{ secrets.LKE_CP_ACL_IPV4 }}
           LKE_APL_FIREWALL_INBOUND_RULES: ${{ secrets.LKE_APL_FIREWALL_INBOUND_RULES }}
+          BYO_GIT_PAT: ${{ secrets.BYO_GIT_PAT }}
+          BYO_GIT_URL: ${{ secrets.BYO_GIT_URL }}
         run: |
           touch values.yaml
           adminPassword="$(head /dev/urandom | tr -dc 'A-Za-z0-9' | head -c 24)"
@@ -346,6 +364,12 @@ jobs:
                 --docker-password='${{ secrets.BOT_PULL_TOKEN }}'
               install_args+=(--set imageName=${{ env.CACHE_REGISTRY }}/${{ env.CACHE_REPO }} --set imagePullSecretNames[0]=reg-otomi-github)
             fi
+          fi
+
+          if [[ '${{ inputs.BYO_GIT }}' == 'true' ]]; then
+            install_args+=(--set otomi.git.repoUrl="$BYO_GIT_URL")
+            install_args+=(--set otomi.git.password="$BYO_GIT_PAT")
+            install_args+=(--set otomi.git.branch="$DOMAIN")
           fi
 
           if [[ -n '${{ env.LKE_APL_FIREWALL_INBOUND_RULES }}' ]]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -110,7 +110,7 @@ on:
         type: boolean
         default: true
       BYO_GIT:
-        description: 'Use external values repo instead of the default'
+        description: 'BYO git. Use predefined external values repo with branch named after the cluster.domainSuffix'
         type: boolean
         default: false
 


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
This pull request adds support for a "Bring Your Own Git" (BYO_GIT) integration to the `integration.yml` GitHub Actions workflow. The main changes introduce a new input flag, validate required secrets, and pass these secrets to relevant jobs for use during installation.

Key changes:

**BYO_GIT input and validation:**
* Added a new boolean input `BYO_GIT` to the workflow, allowing users to enable the BYO Git integration option.
* Added a step to validate that required secrets (`BYO_GIT_PAT` and `BYO_GIT_URL`) are set if `BYO_GIT` is enabled, failing early if they are missing.

**Secrets management and usage:**
* Passed `BYO_GIT_PAT` and `BYO_GIT_URL` secrets to the relevant job environments to make them available during workflow execution.
* Updated the installation command to use the BYO Git repository URL, password, and branch (based on the domain) when the `BYO_GIT` option is enabled.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
